### PR TITLE
feat(converge): deterministic orientation packet for convergence loops

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,22 @@ caller — spawn a fresh review each round feeding the growing `already_raised`
 list — until findings converge or drop to noise. (Never paste prior reviewers'
 prose; just the deduplicated claim + citation.)
 
+### Convergence packet mode (`converge: true`)
+
+Each cold round otherwise re-gathers the same orientation — re-reading the touched
+files and re-running `git`, which measurements show dominates the per-round cost.
+Pass `converge: true` to `critique_branch` and the server instead **pre-gathers a
+deterministic evidence packet** (the contents of every touched file in the reviewed
+snapshot — binary/large files are marked rather than embedded — plus the diff) and
+hands it to the reviewer with a packet-aware prompt, so it verifies rather than
+re-collects. The review runs against a **materialized worktree** of the snapshot
+captured at request time, so evidence is a consistent point-in-time view that later
+live edits can't perturb, and `already_raised` is always preserved under the packet
+budget (`max_packet_chars`, default 400k). Deterministic and per-request — no
+persistent session or handle; independent of the reviewer engine. (The end-to-end
+saving is the subject of the plan's acceptance benchmark; the mechanism removes the
+gather step, but treat the magnitude as pending that measurement.)
+
 ## Install
 
 ### Prerequisites
@@ -203,9 +219,16 @@ All tools accept:
   target ref, so they never collide with your working tree and can review a
   branch that isn't checked out. (Dirty-working-tree reviews necessarily run in
   the live repo, read-only.)
-- **No API keys, no telemetry, no state.** The server shells out to a CLI you're
-  already signed into. It writes a local audit record per review to
-  `~/.paranoia/logs/` (provenance + the session ref for `rebut`) and nothing else.
+- **No API keys, no telemetry, minimal state.** The server shells out to a CLI
+  you're already signed into. It writes a local audit record per review to
+  `~/.paranoia/logs/` (provenance + the session ref for `rebut`). In `converge`
+  mode (below) it additionally creates a short-lived git worktree and a few
+  **unreferenced** git objects (the reviewed snapshot) in the target repo. On a
+  clean exit both are cleaned up (best-effort) and no ref is ever created. A hard
+  crash mid-review — or a rare teardown failure —
+  can leave the worktree registration (and, while it exists, the snapshot objects
+  it checks out) until the next `git worktree prune`/`git gc` — run either to
+  reclaim them. Your working tree and index are never touched.
 
 ## Rate limits
 

--- a/docs/orientation_reuse_plan.md
+++ b/docs/orientation_reuse_plan.md
@@ -1,0 +1,131 @@
+# Plan: deterministic orientation packet (Phase 1 — the shipped scope)
+
+Status: FINAL — scope decided by the owner after 5 adversarial-review rounds.
+**The Claude fork (former Phase 2) is dropped.** The review established that a fork's
+review effectiveness cannot be guaranteed by construction (a deterministic manifest
+cannot be a true superset — rename-only deps, beyond-cap callers), only measured, and its
+correct implementation (registry, PID/heartbeat lease, stable-path rematerialization,
+change-sets, cross-worktree session resume) carried every FATAL found. Phase 1 captures
+the bulk of the measured saving with none of that surface. This doc is now Phase 1 only.
+
+## 1. Problem (measured)
+
+Convergence loops spawn a cold reviewer every round (`handlers.py:113-119`; only `rebut`
+resumes). The dominant waste is the reviewer's **multi-turn re-gathering**: on stereogram,
+one file was re-read **18×** in a 3-round loop, one doc **41×** in a 20-round loop, with
+**23–38 git/grep calls per round** — repeated every round. The reasoning is not
+duplicated. Most of the saving comes from eliminating those gather *turns*, which a
+server-prebuilt evidence packet + a packet-aware prompt can do **statelessly, per
+request, for both engines**.
+
+## 2. Design — stateless, per request
+
+No handles, sessions, registry, leases, or cross-round state. Each `converge:true` call:
+
+1. **Resolve once, snapshot immutably.** `H = git rev-parse HEAD`. Dirty tree: build the
+   snapshot **from `H`** (not the symbol `HEAD`, so a concurrent HEAD move can't corrupt
+   it) — `GIT_INDEX_FILE=<tmp> git read-tree H → git add -A → git write-tree` → `<tree>`
+   (captures tracked incl. tracked-but-ignored + untracked; verified) — then wrap it:
+   `git commit-tree <tree> -p H -m paranoia-snapshot` with **`-m` (never bare — `commit-tree`
+   reads its message from stdin, which is the MCP transport)** and identity+dates pinned
+   via `GIT_*_NAME/EMAIL/DATE` env. Committed ranges use the resolved commits directly.
+2. **Unreferenced objects (as built — repo ODB, not a temp ODB).** The snapshot tree and
+   wrapper commit are written to the repo's own object store but **no ref is created**, so
+   they are unreferenced objects that `git gc` reclaims. This was chosen over a temporary
+   ODB after verifying that a temp ODB requires threading `GIT_ALTERNATE_OBJECT_DIRECTORIES`
+   into the *reviewer* subprocess (else its git sees `bad object HEAD` in the worktree) —
+   an unverifiable dependency on the CLI propagating env to its git children. Trade-off:
+   a clean exit leaves nothing; a hard crash can leave the worktree registration + its
+   objects until `git worktree prune`/`gc`. The author's working tree and index are never
+   touched.
+3. **Materialize a separate checkout.** `git worktree add --detach <path> <wrapper-commit>`
+   (reused `worktree.py::worktree_at`). No `chmod` — the reviewer is already read-only
+   (Write/Edit denied by the allowlist; Codex OS-sandboxed), and the worktree is a *separate*
+   checkout, so live-repo edits during the review can't perturb it. Consistent point-in-time
+   evidence without the `chmod` teardown hazards.
+4. **Revision-stable git.** Every git command the server renders **and every command shown
+   to the reviewer** uses resolved ids / `<base_id>..<head_id>` (two-dot endpoint comparison,
+   used consistently for the file list, diffstat, diff, and labels) — never `main...HEAD` or
+   `git diff HEAD`. Inside the worktree that range reproduces exactly the dirty patch.
+5. **Deterministic file evidence (as built).** Phase 1 embeds the touched files themselves:
+   `changed_files` (`--name-status -z -M`, so deletions/renames are typed) + each file's
+   current content in the snapshot. Binary / non-UTF-8 / submodule-gitlink / unreadable
+   entries are represented by a marker, never raw bytes. This is the high-value, fully
+   deterministic core; a symbol/call-site *manifest* (the weaker, non-superset part) is
+   **deferred** — the reviewer retains full repo read access to grep call-sites itself.
+6. **Budgeted packet** (`build_packet`): file evidence under a `MAX_PACKET_CHARS` evidence
+   budget (separators + truncation marker accounted for). The header + `already_raised` are
+   **mandatory and always included** (the firewall list is never dropped); only file evidence
+   is trimmed, with an `=== EVIDENCE TRUNCATED ===` marker.
+7. **Packet-aware review prompt.** Inert unless the instructions change:
+   `CODE_REVIEW_INSTRUCTIONS` currently orders "read every touched file… follow the blast
+   radius… read history" (`prompts.py:43-47`). Add a variant — *"the files, call-sites,
+   and history below were gathered for you; verify and go deeper only where warranted; do
+   not re-gather what is already provided"* — so the reviewer skips the routine gather
+   turns. This is the mechanism that produces the saving.
+8. **Instrumentation + fallback.** `Review` gains `returncode`, `error`,
+   `usage`/`duration` from engine JSON; `_execute` stops discarding non-zero
+   (`engines.py:113-122`); `parse_output` reads Claude `is_error`/`subtype` + Codex error.
+   Logs get a **unique filename suffix** (`logs.py:27` collides at second precision).
+9. **Opt-in & compat.** Activates on `converge:true` (requires `repo_path`; else error);
+   omitted ⇒ byte-for-byte today's single `engine.run`. `converge:true` **overrides
+   `isolate=false`** (`handlers.py:98,113`) — materialization is mandatory.
+
+The packet is facts only (no findings); `already_raised` remains the caller-driven
+convergence channel exactly as today.
+
+**Known Phase-1 limitations (accepted, documented):** a touched **symlink** is embedded
+as its target string without being flagged as a symlink; `ChangeEntry` carries no git
+object mode, so a reviewer could follow a link to live/external bytes rather than the
+snapshot. Low risk (the reviewer is read-only and the worktree is a private checkout) —
+marking symlink modes is deferred. Worktree teardown is **best-effort** (return codes
+not checked); a teardown failure can leave a registration until `git worktree prune`.
+
+## 3. Implementation (TDD; pure core, injected impure edge)
+
+RED→GREEN→refactor, then a mutation pass on the new pure logic per repo convention.
+
+- `orientation.py`: `resolve_head`, `snapshot_tree` (dirty via temp-ODB read-tree/add/
+  write-tree; committed via rev-parse), `wrap_commit` (`-m`, pinned identity/dates, temp
+  ODB), `build_manifest` (pure, deterministic), `build_packet` (reserve `already_raised`,
+  `MAX_PACKET_CHARS`), and resolved-id rendering for every git command. Pure functions
+  over an injected `_run`.
+- `worktree.py`: read-only materialization of a wrapper commit (`chmod -R a-w` after
+  checkout), temp-ODB env plumbing, always-clean teardown.
+- `engines.py`: `Review.returncode/error/usage/duration`; error+usage parsing for both
+  engines; `_execute` preserves status.
+- `prompts.py`: packet-aware `CODE_REVIEW_INSTRUCTIONS` variant.
+- `handlers.py`: `converge` branch (snapshot → materialize → packet → packet-aware
+  review in the worktree → teardown), `converge`-requires-`repo_path`,
+  `converge`-overrides-`isolate`, instrumentation into the log record.
+- `logs.py`: unique filename suffix.
+- `config.py`: `MAX_PACKET_CHARS`, manifest call-site cap.
+- `server.py`: `converge` input on `critique_branch`; doc the packet behaviour.
+- README: correct the "audit logs and nothing else" line if the temp-ODB/worktree
+  lifecycle warrants a note (it leaves nothing persistent, so likely a one-line clarify).
+
+## 4. Tests
+
+Snapshot: tracked / untracked / tracked-but-ignored / deleted / renamed / empty; **git
+identity unset** (recipe needs none); a HEAD move between `rev-parse` and `read-tree` does
+not corrupt the wrapper range. `commit-tree` never blocks on or consumes MCP stdin (uses
+`-m`). Materialization: review reads current snapshot bytes; live-repo edits during a
+review don't change what the reviewer sees; worktree is read-only; **never leaks a
+worktree** (`git worktree list` clean); temp ODB leaves no objects in the reviewed repo,
+even on simulated crash. Manifest: deterministic (same tree ⇒ byte-identical manifest);
+symbol/call-site/doc enumeration + cap. Packet: `MAX_PACKET_CHARS` truncates evidence but
+**never `already_raised`**. Reviewer-shown git commands use resolved ids, not `HEAD`.
+Compat: omitted `converge` ⇒ identical argv, single `engine.run`; `converge` without
+`repo_path` ⇒ error; `converge` overrides `isolate=false`. Failure: non-zero + `is_error`
+surface as errors; usage/duration persisted; sub-second same-tool logs don't collide.
+Packet is facts only (no severity/evaluation vocabulary).
+
+## 5. Acceptance
+
+Full suite green; §4 tests; mutation pass on `snapshot_tree`, `build_manifest`,
+`build_packet`, resolved-id rendering. **Performance gate (the reason to ship):** a paired
+before/after benchmark — packet-aware prompt vs today's — on a real convergence loop must
+show the reviewer's gather turns (file reads + git/grep calls) actually drop and
+wall-clock/tokens fall, with review quality not worse (`already_raised` still respected,
+no new false negatives on a spot-check). Until that benchmark passes, the saving is a
+hypothesis, not a shipped win.

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 import json
 from abc import ABC, abstractmethod
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from pathlib import Path
 from typing import Callable
 
@@ -27,11 +27,16 @@ _PROGRESS_MSG_MAX = 100
 
 @dataclass(frozen=True)
 class Review:
-    """The reviewer's final message plus a token to resume the same session."""
+    """The reviewer's final message plus a token to resume the same session, and enough
+    process/usage metadata to detect real failures and reproduce a cost decision."""
 
     text: str
     session_ref: str | None
     raw: str
+    returncode: int = 0
+    error: bool = False
+    usage: dict | None = None
+    duration_ms: int | None = None
 
 
 class Engine(ABC):
@@ -110,16 +115,24 @@ class Engine(ABC):
             )
         else:
             result = (runner or run_capture)(argv, prompt, cwd, timeout or DEFAULT_TIMEOUT_SEC)
-        if result.returncode != 0 and not result.stdout.strip():
+        review = self.parse_output(result.stdout)
+        # A review is failed if the process exited non-zero OR the engine reported an
+        # in-band error (e.g. Claude's is_error) — the latter can occur with rc 0 and
+        # non-empty stdout, which the old "rc != 0 AND empty stdout" gate silently
+        # swallowed, defeating any downstream fallback.
+        failed = result.returncode != 0 or review.error
+        if failed and not (review.text or "").strip():
             return Review(
                 text=(
                     f"[paranoia-local error] {self.name} exited {result.returncode}: "
                     f"{result.stderr.strip()[:2000]}"
                 ),
-                session_ref=None,
-                raw=result.stderr,
+                session_ref=review.session_ref,
+                raw=result.stderr or result.stdout,
+                returncode=result.returncode,
+                error=True,
             )
-        return self.parse_output(result.stdout)
+        return replace(review, returncode=result.returncode, error=failed)
 
 
 class CodexEngine(Engine):
@@ -190,6 +203,8 @@ class CodexEngine(Engine):
     def parse_output(self, stdout: str) -> Review:
         thread_id: str | None = None
         last_message: str | None = None
+        usage: dict | None = None
+        error = False
         for line in stdout.splitlines():
             line = line.strip()
             if not line:
@@ -200,14 +215,26 @@ class CodexEngine(Engine):
                 continue
             if not isinstance(event, dict):
                 continue
-            if event.get("type") == "thread.started":
+            etype = event.get("type")
+            if etype == "thread.started":
                 thread_id = event.get("thread_id") or thread_id
+            if etype == "error":
+                error = True
+            if etype == "turn.completed":
+                u = event.get("usage")
+                if isinstance(u, dict):
+                    usage = u
             item = event.get("item")
-            if isinstance(item, dict) and item.get("type") == "agent_message":
-                text = item.get("text")
-                if isinstance(text, str):
-                    last_message = text
-        return Review(text=last_message or "", session_ref=thread_id, raw=stdout)
+            if isinstance(item, dict):
+                if item.get("type") == "agent_message":
+                    text = item.get("text")
+                    if isinstance(text, str):
+                        last_message = text
+                elif item.get("type") == "error":
+                    error = True
+        return Review(
+            text=last_message or "", session_ref=thread_id, raw=stdout, error=error, usage=usage
+        )
 
 
 # Read-only tool allowlist for the Claude engine. In `-p` mode a tool that
@@ -271,10 +298,17 @@ class ClaudeEngine(Engine):
             return Review(text=stdout.strip(), session_ref=None, raw=stdout)
         if not isinstance(data, dict):
             return Review(text=stdout.strip(), session_ref=None, raw=stdout)
+        usage: dict | None = None
+        tokens, cost = data.get("usage"), data.get("total_cost_usd")
+        if tokens is not None or cost is not None:
+            usage = {"tokens": tokens, "cost_usd": cost}
         return Review(
             text=str(data.get("result", "")),
             session_ref=data.get("session_id"),
             raw=stdout,
+            error=bool(data.get("is_error", False)),
+            usage=usage,
+            duration_ms=data.get("duration_ms"),
         )
 
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -52,7 +52,15 @@ def _footer(review: Review, engine: Engine) -> str:
         )
     else:
         note = f"\n\n---\n_paranoia-local · engine={engine.name}_"
-    return (review.text or "[empty review]") + note
+    # Surface a failed run explicitly — a non-zero exit or an in-band engine error means
+    # the text below may be an error message or a truncated/aborted review, not a verdict.
+    prefix = ""
+    if review.error:
+        prefix = (
+            f"⚠️ REVIEW FAILED (engine={engine.name}, exit={review.returncode}) — treat the "
+            f"output below as an error, not a completed review.\n\n"
+        )
+    return prefix + (review.text or "[empty review]") + note
 
 
 def _progress_kwargs(on_progress: Callable[[str], None] | None) -> dict[str, Any]:
@@ -74,6 +82,8 @@ def _log(
         record={
             "engine": engine.name,
             "session_ref": review.session_ref,
+            "returncode": review.returncode,
+            "error": review.error,
             "text": review.text,
             **extra,
         },
@@ -103,8 +113,21 @@ def critique_branch(
     model = resolve("model", arguments.get("model"), cfg, engine.default_model)
     effort = resolve("effort", arguments.get("effort"), cfg, "high")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
+    converge = bool(resolve("converge", arguments.get("converge"), cfg, False))
+    max_packet_chars = int(
+        resolve("max_packet_chars", arguments.get("max_packet_chars"), cfg, orientation.MAX_PACKET_CHARS)
+    )
 
     target = orientation.resolve_target(repo, base_ref, head_ref, include_unc)
+
+    if converge:
+        return _converge_branch_review(
+            repo, engine, target=target, base_ref=base_ref, head_ref=head_ref,
+            project_summary=project_summary, diff_intent=diff_intent, focus=focus,
+            already=already, model=model, effort=effort, web_search=web_search,
+            max_packet_chars=max_packet_chars, log_dir=log_dir, now=now, on_progress=on_progress,
+        )
+
     packet = orientation.build_orientation(
         repo, target, project_summary, diff_intent, focus, already
     )
@@ -120,6 +143,59 @@ def critique_branch(
 
     _log(log_dir, "critique_branch", engine, review, now,
          {"target": target.description, "model": model})
+    return _footer(review, engine)
+
+
+def _converge_branch_review(
+    repo: Path,
+    engine: Engine,
+    *,
+    target: orientation.Target,
+    base_ref: str,
+    head_ref: str | None,
+    project_summary: str | None,
+    diff_intent: str | None,
+    focus: str | None,
+    already: list[str],
+    model: str,
+    effort: str,
+    web_search: bool,
+    max_packet_chars: int,
+    log_dir: Path,
+    now: Clock,
+    on_progress: Callable[[str], None] | None,
+) -> str:
+    """Opt-in convergence path: pre-gather a deterministic packet so the reviewer skips
+    the re-read/re-grep turns, and review it against an IMMUTABLE materialized worktree
+    (which always applies here, overriding isolate=false — mixed-revision evidence off a
+    live mutable tree is exactly what this prevents)."""
+    if target.is_dirty:
+        if orientation.has_head(repo):
+            base_id = orientation.resolve_head(repo)
+            parent: str | None = base_id
+        else:
+            # Unborn repo (files, no commit yet): base off git's empty tree, parentless wrapper.
+            base_id = orientation.empty_tree(repo)
+            parent = None
+        head_id = orientation.wrap_commit(repo, orientation.snapshot_tree(repo, base_id), parent)
+    else:
+        base_id = orientation.resolve_ref(repo, base_ref)
+        head_id = orientation.resolve_ref(repo, head_ref or "HEAD")
+
+    packet = orientation.build_packet(
+        repo, base_id, head_id,
+        project_summary=project_summary, diff_intent=diff_intent, focus=focus,
+        already_raised=already, max_chars=max_packet_chars,
+    )
+    prompt = prompts.compose(prompts.CODE_REVIEW_INSTRUCTIONS_PACKET, packet)
+
+    with worktree_at(repo, head_id) as wt:
+        review = engine.run(prompt, wt, model, effort, web_search,
+                            **_progress_kwargs(on_progress))
+
+    _log(log_dir, "critique_branch", engine, review, now,
+         {"target": target.description, "model": model, "mode": "converge-packet",
+          "usage": review.usage, "duration_ms": review.duration_ms})
     return _footer(review, engine)
 
 

--- a/src/paranoia_local/logs.py
+++ b/src/paranoia_local/logs.py
@@ -7,6 +7,7 @@ so all failures are swallowed and reported as a `None` return.
 from __future__ import annotations
 
 import json
+import uuid
 from pathlib import Path
 from typing import Any
 
@@ -24,7 +25,9 @@ def write_log(
     try:
         log_dir = Path(log_dir)
         log_dir.mkdir(parents=True, exist_ok=True)
-        path = log_dir / f"{timestamp}-{tool}.json"
+        # A short random suffix keeps two same-tool reviews that finish within the
+        # same clock second (the timestamp's resolution) from overwriting each other.
+        path = log_dir / f"{timestamp}-{tool}-{uuid.uuid4().hex[:8]}.json"
         payload = {"timestamp": timestamp, "tool": tool, **record}
         path.write_text(json.dumps(payload, indent=2, default=str), encoding="utf-8")
         return path

--- a/src/paranoia_local/orientation.py
+++ b/src/paranoia_local/orientation.py
@@ -9,7 +9,10 @@ embed of the diff, and the author-stated context/intent framed as claims.
 
 from __future__ import annotations
 
+import os
+import shutil
 import subprocess
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -19,11 +22,156 @@ from pathlib import Path
 MAX_EMBED_CHARS = 200_000
 
 
-def _run(cmd: list[str], cwd: Path) -> str:
-    r = subprocess.run(cmd, cwd=cwd, capture_output=True, text=True)
+def _run(cmd: list[str], cwd: Path, env: dict[str, str] | None = None) -> str:
+    # env, when given, is layered over the ambient environment — callers pass
+    # only the git overrides they need (GIT_INDEX_FILE, GIT_OBJECT_DIRECTORY,
+    # snapshot identity) without having to reconstruct PATH etc.
+    r = subprocess.run(
+        cmd, cwd=cwd, capture_output=True, text=True,
+        env={**os.environ, **env} if env else None,
+    )
     if r.returncode != 0:
         raise RuntimeError(f"{' '.join(cmd)} failed: {r.stderr.strip()}")
     return r.stdout
+
+
+# Snapshot git commands are hermetic (ignore the user's global/system config, so a
+# stray commit.gpgsign or diff setting can't perturb them) and carry a fixed identity
+# and dates, so a given working state always wraps to the same commit sha.
+_HERMETIC_ENV = {"GIT_CONFIG_GLOBAL": "/dev/null", "GIT_CONFIG_SYSTEM": "/dev/null"}
+_SNAPSHOT_IDENTITY = {
+    "GIT_AUTHOR_NAME": "paranoia",
+    "GIT_AUTHOR_EMAIL": "paranoia@localhost",
+    "GIT_COMMITTER_NAME": "paranoia",
+    "GIT_COMMITTER_EMAIL": "paranoia@localhost",
+    "GIT_AUTHOR_DATE": "2000-01-01T00:00:00 +0000",
+    "GIT_COMMITTER_DATE": "2000-01-01T00:00:00 +0000",
+}
+
+
+def resolve_head(repo: Path) -> str:
+    """The current commit id — resolved ONCE so a concurrent HEAD move can't make
+    later snapshot/diff commands describe a different revision."""
+    return _run(["git", "rev-parse", "HEAD"], repo).strip()
+
+
+def resolve_ref(repo: Path, ref: str) -> str:
+    """Resolve a ref/rev to its object id, so packet + review commands are pinned."""
+    return _run(["git", "rev-parse", ref], repo).strip()
+
+
+def snapshot_tree(repo: Path, head_id: str) -> str:
+    """Write a tree of the current working state and return its sha.
+
+    Captures tracked (including tracked-but-ignored) AND untracked files: a private
+    alternate index is seeded from `head_id` (`read-tree`) so tracked-but-ignored paths
+    survive, then `add -A` stages everything. The author's real index is never touched.
+    Objects land in the repo's own store, loose and unreferenced (see `wrap_commit`).
+    """
+    idx_dir = Path(tempfile.mkdtemp(prefix="paranoia-idx-"))
+    env = {**_HERMETIC_ENV, "GIT_INDEX_FILE": str(idx_dir / "index")}
+    try:
+        _run(["git", "read-tree", head_id], repo, env=env)
+        _run(["git", "add", "-A"], repo, env=env)
+        return _run(["git", "write-tree"], repo, env=env).strip()
+    finally:
+        shutil.rmtree(idx_dir, ignore_errors=True)
+
+
+def has_head(repo: Path) -> bool:
+    """Whether the repo has a resolvable HEAD (False for an unborn repo with no commit)."""
+    r = subprocess.run(
+        ["git", "rev-parse", "--verify", "--quiet", "HEAD"], cwd=repo, capture_output=True, text=True
+    )
+    return r.returncode == 0
+
+
+def empty_tree(repo: Path) -> str:
+    """The empty-tree object id in THIS repo's object format — the base for an unborn repo.
+    Computed (not a hard-coded SHA-1 constant) so SHA-256 repositories also work."""
+    return _run(["git", "hash-object", "-t", "tree", "/dev/null"], repo).strip()
+
+
+def wrap_commit(
+    repo: Path, tree: str, parent: str | None, message: str = "paranoia-snapshot"
+) -> str:
+    """Wrap `tree` as a commit parented on `parent` (or parentless, for an unborn repo);
+    `<parent-or-empty-tree>..<wrapper>` then reproduces the captured dirty patch. NO ref is
+    created, so the wrapper is an unreferenced object that git GC reclaims once no worktree
+    checks it out — nothing is pinned in the reviewed repo, and a materialized worktree can
+    read it with no special object-store env. The message is passed explicitly (`-m`): bare
+    `git commit-tree` reads it from stdin, which for the MCP server is the live transport.
+    """
+    env = {**_HERMETIC_ENV, **_SNAPSHOT_IDENTITY}
+    args = ["git", "commit-tree", tree]
+    if parent:
+        args += ["-p", parent]
+    args += ["-m", message]
+    return _run(args, repo, env=env).strip()
+
+
+@dataclass(frozen=True)
+class ChangeEntry:
+    """One entry of a structured change-set. `status` is a single letter (M/A/D/T/R/C).
+    `path`/`old_path` are decoded with `surrogateescape`, so the exact bytes round-trip back
+    to git (for `git show`) even for a non-UTF-8 filename — never render them into the packet
+    directly; use `_display()` for a JSON/UTF-8-safe label."""
+
+    status: str
+    path: str
+    old_path: str | None = None
+
+
+def _display(name: str) -> str:
+    """A display-safe, INJECTIVE rendering of a possibly `surrogateescape`-decoded path.
+    Valid Unicode (e.g. `café.py`) is kept; a literal backslash is doubled first so it can't
+    be confused with an escape introducer, then non-UTF-8 bytes carried as surrogates become
+    `\\u….` escapes. The result therefore can't (a) collide two distinct paths onto one label
+    (a real `a\\udcff` vs a `0xff`-byte path stay distinct), or (b) inject lone surrogates that
+    crash JSON/UTF-8 encoding of the packet or the reviewer prompt stdin."""
+    return name.replace("\\", "\\\\").encode("utf-8", "backslashreplace").decode("utf-8")
+
+
+def changed_files(repo: Path, from_ref: str, to_ref: str) -> list[ChangeEntry]:
+    """Structured file delta from `from_ref` to `to_ref` via `--name-status -z` (so
+    deletions and renames are typed, not just listed). `-M` enables rename detection.
+
+    `-z` emits pathnames verbatim, so this reads bytes and decodes with replacement — a
+    non-UTF-8 filename must not crash the review. A path mangled by replacement won't
+    round-trip to `git show`, so `file_evidence` will mark it `[not embeddable]` rather
+    than embed it, which is the correct graceful degradation."""
+    r = subprocess.run(
+        ["git", "diff", "--name-status", "-M", "-z", from_ref, to_ref],
+        cwd=repo, capture_output=True,
+    )
+    if r.returncode != 0:
+        raise RuntimeError(
+            "git diff --name-status failed: " + r.stderr.decode("utf-8", errors="replace").strip()
+        )
+    # surrogateescape keeps the exact bytes so a non-UTF-8 path round-trips back to `git show`
+    # (no lossy collision onto another real file); `_display()` sanitizes it for the packet.
+    return _parse_name_status(r.stdout.decode("utf-8", errors="surrogateescape"))
+
+
+def _parse_name_status(out: str) -> list[ChangeEntry]:
+    tokens = out.split("\0")
+    entries: list[ChangeEntry] = []
+    i, n = 0, len(tokens)
+    while i < n:
+        status = tokens[i]
+        if not status:  # trailing NUL / blank
+            i += 1
+            continue
+        code = status[0]
+        if code in ("R", "C") and i + 2 < n:
+            entries.append(ChangeEntry(status=code, path=tokens[i + 2], old_path=tokens[i + 1]))
+            i += 3
+        elif i + 1 < n:
+            entries.append(ChangeEntry(status=code, path=tokens[i + 1]))
+            i += 2
+        else:
+            break
+    return entries
 
 
 def diffstat(repo: Path, base: str, head: str) -> str:
@@ -168,3 +316,164 @@ def build_orientation(
         )
 
     return "\n\n".join(parts)
+
+
+# ── Phase-1 deterministic packet ──────────────────────────────────────────────
+# The packet pre-gathers the evidence a cold reviewer would otherwise spend turns
+# re-reading every round: the full contents of every touched file in the exact
+# snapshot under review, plus the diff. Paired with the packet-aware review prompt
+# (prompts.CODE_REVIEW_INSTRUCTIONS_PACKET) so the reviewer skips the gather step.
+
+MAX_PACKET_CHARS = 400_000  # evidence budget; header + `already_raised` are always included
+MAX_FILE_CHARS = 50_000     # per-file evidence cap
+_TRUNCATION_MARKER = (
+    "=== EVIDENCE TRUNCATED ===\nPacket budget reached — open the remaining touched files "
+    "in your worktree."
+)
+
+
+def _show_bytes(repo: Path, spec: str) -> bytes | None:
+    """Raw bytes of a blob, or None if git can't produce one (e.g. a submodule gitlink)."""
+    r = subprocess.run(["git", "show", spec], cwd=repo, capture_output=True)
+    return r.stdout if r.returncode == 0 else None
+
+
+def _safe_diff(repo: Path, base: str, head: str) -> str:
+    """`git diff base head` decoded defensively. Git's own text/binary heuristic sniffs
+    only the first ~8000 bytes, so it can embed raw content (incl. NUL or non-UTF-8 bytes)
+    for a file whose binary marker appears later. Read bytes and decode with replacement,
+    and neutralize NUL, so the packet can never carry control bytes or crash on decode."""
+    r = subprocess.run(["git", "diff", base, head], cwd=repo, capture_output=True)
+    return r.stdout.decode("utf-8", errors="replace").replace("\x00", "�")
+
+
+def file_evidence(
+    repo: Path, head_id: str, entries: list[ChangeEntry], max_file_chars: int = MAX_FILE_CHARS
+) -> list[tuple[ChangeEntry, str | None]]:
+    """Current content of each touched file *in the snapshot* (`head_id`), capped. Deletions
+    carry `None`. Binary blobs, unreadable paths, and submodule gitlinks are represented by a
+    short marker instead of their raw bytes — embedding raw bytes would corrupt the packet and
+    (with text decoding) crash the review."""
+    out: list[tuple[ChangeEntry, str | None]] = []
+    for e in entries:
+        if e.status == "D":
+            out.append((e, None))
+            continue
+        shown = _display(e.path)
+        data = _show_bytes(repo, f"{head_id}:{e.path}")  # e.path (surrogateescape) → exact bytes
+        if data is None:
+            out.append((e, f"[not embeddable ({shown}) — submodule gitlink or unreadable; open it in your worktree]"))
+            continue
+        if b"\x00" in data:  # full scan — a NUL anywhere means binary (a late NUL is still binary)
+            out.append((e, f"[binary file, {len(data)} bytes — not embedded; open {shown} in your worktree]"))
+            continue
+        try:
+            content = data.decode("utf-8")
+        except UnicodeDecodeError:
+            out.append((e, f"[non-UTF-8 file, {len(data)} bytes — not embedded; open {shown} in your worktree]"))
+            continue
+        if len(content) > max_file_chars:
+            content = (
+                content[:max_file_chars]
+                + f"\n… [TRUNCATED at {max_file_chars} chars — open {shown} to read the rest]\n"
+            )
+        out.append((e, content))
+    return out
+
+
+def build_packet(
+    repo: Path,
+    base_id: str,
+    head_id: str,
+    *,
+    project_summary: str | None = None,
+    diff_intent: str | None = None,
+    focus: str | None = None,
+    already_raised: list[str] | None = None,
+    max_chars: int = MAX_PACKET_CHARS,
+    max_file_chars: int = MAX_FILE_CHARS,
+) -> str:
+    """Assemble the deterministic evidence packet for `base_id..head_id` (resolved ids, two-dot
+    endpoint comparison used consistently for diffstat, diff, file list, and labels).
+
+    Layout: mandatory header (context/intent/focus/diffstat) + budgeted evidence (diff, then
+    each touched file's content) + mandatory `already_raised` block. `max_chars` bounds the
+    packet whenever it exceeds the mandatory header + `already_raised`; those two are ALWAYS
+    included (the firewall list is never dropped) even if they alone exceed `max_chars`. When
+    evidence is trimmed a marker is emitted, and the marker's own size is reserved so the
+    final packet stays within `max_chars` in the normal case."""
+    already_raised = already_raised or []
+    entries = changed_files(repo, base_id, head_id)
+
+    head_parts = [
+        f"=== UNDER REVIEW ===\nworking-tree snapshot {base_id[:12]}..{head_id[:12]} in {_display(repo.name)}"
+    ]
+    if project_summary:
+        head_parts.append(
+            "=== AUTHOR-STATED PROJECT CONTEXT (description, not advocacy) ===\n" + project_summary
+        )
+    if diff_intent:
+        head_parts.append(
+            "=== AUTHOR-STATED DIFF INTENT (a CLAIM to test, not a fact to accept) ===\n"
+            + diff_intent
+        )
+    if focus:
+        head_parts.append(f"=== REVIEWER FOCUS ===\n{focus}")
+    stat_proc = subprocess.run(["git", "diff", "--stat", base_id, head_id], cwd=repo, capture_output=True)
+    stat = stat_proc.stdout.decode("utf-8", errors="replace").strip()  # byte-safe: a non-UTF-8 path in --stat must not crash
+    if stat:
+        head_parts.append(f"=== DIFFSTAT ===\n{stat}")
+    header = "\n\n".join(head_parts)
+
+    reserved = ""
+    if already_raised:
+        reserved = "=== Already-raised — do NOT restate these; hunt for what they missed ===\n" + "\n".join(
+            f"- {c}" for c in already_raised
+        )
+
+    evidence: list[str] = [
+        f"=== DIFF (git diff {base_id[:12]}..{head_id[:12]}) ===\n{_safe_diff(repo, base_id, head_id)}"
+    ]
+    for e, content in file_evidence(repo, head_id, entries, max_file_chars):
+        if content is None:
+            evidence.append(f"=== FILE {_display(e.path)} [DELETED] ===\n(this file no longer exists in the snapshot)")
+        else:
+            label = (
+                f"{_display(e.old_path or '')} → {_display(e.path)}"
+                if e.status.startswith("R")
+                else _display(e.path)
+            )
+            evidence.append(f"=== FILE {label} [{e.status}] ===\n{content}")
+
+    sep = "\n\n"
+    mandatory = len(header) + (len(sep) + len(reserved) if reserved else 0)
+    marker_cost = len(sep) + len(_TRUNCATION_MARKER)
+    available = max_chars - mandatory
+    # First fit evidence WITHOUT reserving marker space, so evidence that fits on its own is
+    # never dropped just to hold a marker that won't be needed.
+    included: list[str] = []
+    used = 0
+    truncated = False
+    for part in evidence:
+        cost = len(part) + len(sep)
+        if used + cost <= available:
+            included.append(part)
+            used += cost
+        else:
+            truncated = True
+            break
+    # If anything was omitted, an EVIDENCE TRUNCATED notice is MANDATORY (a silent omission
+    # would make the reviewer treat the packet as complete). Backtrack evidence to make room;
+    # if the budget can't even hold the notice alone, emit it anyway — that (max_chars <
+    # mandatory + marker) is the documented too-small-budget case where the packet may exceed
+    # max_chars rather than drop the omission signal.
+    if truncated:
+        while included and used + marker_cost > available:
+            used -= len(included.pop()) + len(sep)
+
+    sections = [header, *included]
+    if truncated:
+        sections.append(_TRUNCATION_MARKER)
+    if reserved:
+        sections.append(reserved)
+    return sep.join(sections)

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -65,6 +65,15 @@ You are read-only. Do not write, edit, or run the whole test suite — it is slo
 - Tag every item in "What doesn't work", "Risks", "Gaps", and "Improvements" with exactly one of: [BLOCKER] (ships a bug / data loss / money loss / live-trading miswiring / security hole), [MAJOR] (fix before merge — breaks a documented invariant, test, or workflow), [MINOR] (fix opportunistically), [OUT-OF-SCOPE] (real, but beyond this change's stated intent — file separately, don't fold in). The author treats untagged advice as mandatory; miscalibrated tags cause either shipped bugs or wasted churn.
 - Compare the change to the AUTHOR-STATED INTENT: does the code actually do what the author claims? Mismatches go in "What doesn't work" with the intent quoted."""
 
+
+_PACKET_PREAMBLE = """## The evidence was gathered for you — do not re-gather it
+The task input contains, under `=== FILE … ===` sections, the current contents of every touched file in the exact snapshot under review, plus the diff and diffstat. Treat these as authoritative. DO NOT re-open, re-read, or `git diff`/`git show` a file whose contents are fully provided — that is the routine gather step this packet exists to eliminate. EXCEPTIONS you MUST open yourself: any file section marked `[TRUNCATED …]`, `[binary …]`, `[non-UTF-8 …]`, or `[not embeddable …]`, and an `=== EVIDENCE TRUNCATED ===` notice means further touched files were omitted — open those in your worktree. Investigate FURTHER — call-sites, related modules, git history, configs — only where a specific finding needs evidence not already in front of you. Spend your effort on judgment, not on re-collecting what is already provided."""
+
+# Packet-aware code review: same rubric, but the evidence is pre-supplied, so the
+# "read every touched file / re-run git" gather step is replaced by a verify-and-go-deeper
+# instruction. Used by the Phase-1 `converge` path (handlers.critique_branch).
+CODE_REVIEW_INSTRUCTIONS_PACKET = CODE_REVIEW_INSTRUCTIONS + "\n\n" + _PACKET_PREAMBLE
+
 PLAN_REVIEW_INSTRUCTIONS = f"""You are Paranoia, an adversarial reviewer of plans and design documents. Assume the plan will fail in ways the author has not considered.
 
 When a repository is available to you, you are running as an autonomous agent inside it with READ access to the entire codebase and git history. The CODE IS GROUND TRUTH for how the system behaves today. Your single most valuable job: test every premise the plan makes about current behaviour against the actual code. A plan that asserts "X currently does Y" when the code shows otherwise is the most dangerous kind of plan — that is a top-severity finding, and you must quote the contradicting file:line. If a premise depends on code you cannot find, say so explicitly rather than guessing.

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -77,6 +77,14 @@ TOOLS: list[Tool] = [
                     "type": "boolean",
                     "description": "Review inside a throwaway worktree of head_ref so it can't collide with ongoing work (default true; ignored for uncommitted).",
                 },
+                "converge": {
+                    "type": "boolean",
+                    "description": "Convergence mode (default false): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate).",
+                },
+                "max_packet_chars": {
+                    "type": "integer",
+                    "description": "Total character budget for the converge packet (default 400000). The already_raised list is always preserved; only file evidence is trimmed.",
+                },
                 "project_summary": {"type": "string", "description": "Neutral factual description of the project (not advocacy). The reviewer tests the diff against it."},
                 "diff_intent": {"type": "string", "description": "What the diff is SUPPOSED to achieve — treated as a claim to verify."},
                 "focus": {"type": "string", "description": "Narrow the review to a specific concern."},

--- a/src/paranoia_local/worktree.py
+++ b/src/paranoia_local/worktree.py
@@ -18,9 +18,14 @@ from pathlib import Path
 
 
 def _git(args: list[str], cwd: Path) -> None:
-    r = subprocess.run(["git", *args], cwd=cwd, capture_output=True, text=True)
+    # Capture bytes, not text: `git worktree add` runs a non-quiet `reset --hard` that echoes
+    # the checked-out commit's subject, which for a committed review is author-controlled and
+    # may not be valid UTF-8 — a strict text decode there would crash the review.
+    r = subprocess.run(["git", *args], cwd=cwd, capture_output=True)
     if r.returncode != 0:
-        raise RuntimeError(f"git {' '.join(args)} failed: {r.stderr.strip()}")
+        raise RuntimeError(
+            f"git {' '.join(args)} failed: {r.stderr.decode('utf-8', errors='replace').strip()}"
+        )
 
 
 @contextmanager

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -1,0 +1,100 @@
+"""The opt-in `converge` path on critique_branch: pre-gather a deterministic packet and
+review it against an immutable materialized worktree (never the live mutable tree). See
+docs/orientation_reuse_plan.md.
+"""
+
+import json
+from pathlib import Path
+
+from paranoia_local import handlers
+from paranoia_local.engines import Review
+from tests.conftest import git
+
+
+class FakeEngine:
+    name = "fake"
+    default_model = "fake-model"
+
+    def __init__(self) -> None:
+        self.calls: list[dict] = []
+
+    def run(self, prompt, cwd, model, effort, web_search, **kw):
+        self.calls.append({"prompt": prompt, "cwd": Path(cwd)})
+        return Review(
+            text="## What works\nok", session_ref="sess", raw="{}",
+            usage={"cost_usd": 0.01}, duration_ms=42,
+        )
+
+
+def _dirty(repo: Path) -> None:
+    (repo / "app.py").write_text("# dirty edit MARKER\n")
+
+
+def _args(repo: Path, **extra) -> dict:
+    return {"repo_path": str(repo), "include_uncommitted": True, **extra}
+
+
+class TestConvergeBranch:
+    def test_runs_in_materialized_worktree_not_live_repo(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo, converge=True), engine=fake, log_dir=tmp_path)
+        cwd = fake.calls[0]["cwd"]
+        assert cwd != repo
+        assert "paranoia-wt" in str(cwd)
+        assert not cwd.exists()  # throwaway worktree cleaned up after the review
+
+    def test_packet_prompt_embeds_evidence(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo, converge=True), engine=fake, log_dir=tmp_path)
+        prompt = fake.calls[0]["prompt"]
+        assert "gathered for you" in prompt.lower()  # packet-aware instructions
+        assert "# dirty edit MARKER" in prompt        # full file evidence embedded
+
+    def test_overrides_isolate_false(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo, converge=True, isolate=False), engine=fake, log_dir=tmp_path)
+        assert "paranoia-wt" in str(fake.calls[0]["cwd"])  # still materialized
+
+    def test_logs_mode_and_usage(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo, converge=True), engine=fake, log_dir=tmp_path)
+        rec = json.loads(next(tmp_path.glob("*.json")).read_text())
+        assert rec["mode"] == "converge-packet"
+        assert rec["usage"] == {"cost_usd": 0.01}
+
+    def test_default_off_runs_in_live_repo_for_dirty(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo), engine=fake, log_dir=tmp_path)  # no converge
+        assert fake.calls[0]["cwd"] == repo  # unchanged behaviour: live repo for dirty
+
+    def test_converge_on_unborn_repo(self, tmp_path: Path) -> None:
+        # A repo with files but no first commit must not crash on resolve_head.
+        repo = tmp_path / "unborn"
+        repo.mkdir()
+        git(["init", "-q", "-b", "main"], repo)
+        (repo / "a.py").write_text("UNBORN_MARKER = 1\n")
+        fake = FakeEngine()
+        handlers.critique_branch(
+            {"repo_path": str(repo), "include_uncommitted": True, "converge": True},
+            engine=fake, log_dir=tmp_path / "logs",
+        )
+        assert "UNBORN_MARKER = 1" in fake.calls[0]["prompt"]  # new file's content packaged
+
+    def test_failed_review_is_surfaced_and_logged(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+
+        class FailEngine(FakeEngine):
+            def run(self, prompt, cwd, model, effort, web_search, **kw):
+                self.calls.append({"prompt": prompt, "cwd": Path(cwd)})
+                return Review(text="boom", session_ref=None, raw="", returncode=1, error=True)
+
+        fe = FailEngine()
+        out = handlers.critique_branch(_args(repo, converge=True), engine=fe, log_dir=tmp_path)
+        assert "REVIEW FAILED" in out
+        rec = json.loads(next(tmp_path.glob("*.json")).read_text())
+        assert rec["error"] is True and rec["returncode"] == 1

--- a/tests/test_instrumentation.py
+++ b/tests/test_instrumentation.py
@@ -1,0 +1,73 @@
+"""Engine instrumentation: capture usage/duration and detect real failures — including
+Claude's in-band is_error with a zero exit code, which the old gate swallowed. This is
+what lets the caller reproduce a cost decision and lets a fallback fire. See
+docs/orientation_reuse_plan.md.
+"""
+
+from pathlib import Path
+
+from paranoia_local import engines
+from paranoia_local.runner import RunResult
+
+CLAUDE_OK = (
+    '{"type":"result","subtype":"success","is_error":false,'
+    '"result":"## What works\\nok","session_id":"s2","total_cost_usd":0.02,'
+    '"duration_ms":1234,"usage":{"input_tokens":10}}'
+)
+CLAUDE_ERR = (
+    '{"type":"result","subtype":"error_during_execution","is_error":true,'
+    '"result":"boom","session_id":"s1"}'
+)
+CODEX_OK = (
+    '{"type":"thread.started","thread_id":"t1"}\n'
+    '{"type":"item.completed","item":{"type":"agent_message","text":"done"}}\n'
+    '{"type":"turn.completed","usage":{"input_tokens":5,"output_tokens":7}}\n'
+)
+
+
+def _fake(rc: int, stdout: str, stderr: str = ""):
+    def runner(argv, stdin, cwd, timeout):
+        return RunResult(returncode=rc, stdout=stdout, stderr=stderr)
+    return runner
+
+
+class TestClaudeInstrumentation:
+    def test_success_captures_usage_and_duration(self) -> None:
+        r = engines.get_engine("claude").parse_output(CLAUDE_OK)
+        assert r.error is False
+        assert r.usage == {"tokens": {"input_tokens": 10}, "cost_usd": 0.02}
+        assert r.duration_ms == 1234
+
+    def test_in_band_error_flagged_even_with_text_and_rc0(self) -> None:
+        r = engines.get_engine("claude").run(
+            prompt="x", cwd=Path("/repo"), model="m", effort="high",
+            web_search=False, runner=_fake(0, CLAUDE_ERR),
+        )
+        assert r.error is True       # rc 0 + is_error:true ⇒ failed (old gate missed this)
+        assert r.returncode == 0
+        assert "boom" in r.text      # text preserved so a fallback can inspect it
+
+
+class TestCodexInstrumentation:
+    def test_captures_usage_and_no_error(self) -> None:
+        r = engines.get_engine("codex").parse_output(CODEX_OK)
+        assert r.session_ref == "t1"
+        assert r.usage == {"input_tokens": 5, "output_tokens": 7}
+        assert r.error is False
+
+
+class TestExecuteReturncode:
+    def test_success_sets_returncode_zero_and_no_error(self) -> None:
+        r = engines.get_engine("claude").run(
+            prompt="x", cwd=Path("/repo"), model="m", effort="high",
+            web_search=False, runner=_fake(0, CLAUDE_OK),
+        )
+        assert r.returncode == 0 and r.error is False
+
+    def test_hard_failure_with_no_text_synthesizes_error(self) -> None:
+        r = engines.get_engine("claude").run(
+            prompt="x", cwd=Path("/repo"), model="m", effort="high",
+            web_search=False, runner=_fake(1, "", "auth failed: not logged in"),
+        )
+        assert r.error is True and r.returncode == 1
+        assert "auth failed" in r.text

--- a/tests/test_packet.py
+++ b/tests/test_packet.py
@@ -1,0 +1,168 @@
+"""Phase-1 deterministic packet: pre-gather the touched files' full contents + diff so
+the reviewer skips the routine re-read/re-grep turns, under a total budget that always
+preserves the `already_raised` convergence list. See docs/orientation_reuse_plan.md.
+"""
+
+import os
+from pathlib import Path
+
+import pytest
+
+from paranoia_local import orientation as o
+from paranoia_local import prompts
+
+
+def _snapshot(repo: Path) -> tuple[str, str]:
+    head = o.resolve_head(repo)
+    return head, o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+
+
+class TestFileEvidence:
+    def test_content_for_modified_none_for_deleted(self, repo: Path) -> None:
+        (repo / "app.py").write_text("# edited\n")
+        (repo / "README.md").unlink()
+        head, wrap = _snapshot(repo)
+        entries = o.changed_files(repo, head, wrap)
+        ev = {e.path: c for e, c in o.file_evidence(repo, wrap, entries)}
+        assert "# edited" in ev["app.py"]
+        assert ev["README.md"] is None
+
+    def test_truncates_large_file(self, repo: Path) -> None:
+        (repo / "big.py").write_text("x\n" * 100_000)
+        head, wrap = _snapshot(repo)
+        entries = o.changed_files(repo, head, wrap)
+        ev = {e.path: c for e, c in o.file_evidence(repo, wrap, entries, max_file_chars=1000)}
+        assert "TRUNCATED at 1000" in ev["big.py"]
+        assert len(ev["big.py"]) < 2000
+
+
+class TestBuildPacket:
+    def test_embeds_diff_and_full_file_contents(self, repo: Path) -> None:
+        (repo / "app.py").write_text('"""App."""\n\n\ndef greet(n):\n    return f"yo {n}"\n')
+        (repo / "new.py").write_text("ADDED_MARKER = 1\n")
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(repo, head, wrap, diff_intent="make it friendlier")
+        assert "=== DIFF" in packet
+        assert "ADDED_MARKER = 1" in packet                 # full content of the added file
+        assert "=== FILE new.py [A] ===" in packet
+        assert "AUTHOR-STATED DIFF INTENT" in packet
+
+    def test_marks_deletions(self, repo: Path) -> None:
+        (repo / "README.md").unlink()
+        head, wrap = _snapshot(repo)
+        assert "FILE README.md [DELETED]" in o.build_packet(repo, head, wrap)
+
+    def test_reserves_already_raised_even_when_budget_tiny(self, repo: Path) -> None:
+        (repo / "app.py").write_text("x\n" * 5000)  # large evidence that will be truncated
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(
+            repo, head, wrap, already_raised=["engine.py:1 — foo is wrong"], max_chars=800
+        )
+        assert "engine.py:1 — foo is wrong" in packet  # firewall list survives truncation
+        assert "EVIDENCE TRUNCATED" in packet
+
+    def test_within_budget_includes_evidence_untruncated(self, repo: Path) -> None:
+        (repo / "app.py").write_text("MARK=1\n")
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(repo, head, wrap, max_chars=400_000)
+        assert "MARK=1" in packet
+        assert "EVIDENCE TRUNCATED" not in packet
+
+
+class TestPacketRobustness:
+    def test_binary_file_is_marked_not_embedded(self, repo: Path) -> None:
+        (repo / "blob.bin").write_bytes(b"\x00\x01\x02BINARY\x00\xff\xfe")
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(repo, head, wrap)
+        assert "binary file" in packet.lower()
+        assert "blob.bin" in packet
+        assert "\x00" not in packet  # raw NUL never embedded (would crash text handling)
+
+    def test_binary_with_late_nul_is_marked(self, repo: Path) -> None:
+        # NUL past byte 8000 (an early-window sniff would miss it; NUL is valid UTF-8 so
+        # decoding would succeed and embed the raw byte).
+        (repo / "late.bin").write_bytes(b"A" * 9000 + b"\x00" + b"B" * 100)
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(repo, head, wrap)
+        assert "binary file" in packet.lower()
+        assert "\x00" not in packet
+
+    def test_respects_max_chars_ceiling_and_keeps_already_raised(self, repo: Path) -> None:
+        for i in range(5):
+            (repo / f"f{i}.py").write_text("y = 1\n" * 500)  # several large touched files
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(
+            repo, head, wrap, already_raised=["a.py:1 — x is wrong"], max_chars=3000
+        )
+        assert len(packet) <= 3000                # true ceiling in the normal case
+        assert "a.py:1 — x is wrong" in packet    # firewall list preserved
+        assert "EVIDENCE TRUNCATED" in packet
+
+    def test_budget_never_overflows_at_or_above_floor(self, repo: Path) -> None:
+        # `floor` = smallest packet (mandatory header + the mandatory omission notice). At or
+        # above it, the packet must never exceed max_chars.
+        (repo / "app.py").write_text("y = 1\n" * 400)
+        head, wrap = _snapshot(repo)
+        floor = len(o.build_packet(repo, head, wrap, max_chars=1))
+        for mc in (floor, floor + 10, floor + 60, floor + 200, 5000):
+            assert len(o.build_packet(repo, head, wrap, max_chars=mc)) <= mc
+
+    def test_omission_is_always_signalled(self, repo: Path) -> None:
+        for i in range(4):
+            (repo / f"f{i}.py").write_text("z = 1\n" * 300)
+        head, wrap = _snapshot(repo)
+        full = o.build_packet(repo, head, wrap, max_chars=10_000_000)
+        half = o.build_packet(repo, head, wrap, max_chars=len(full) // 2)
+        assert "EVIDENCE TRUNCATED" in half        # omission never silent
+        assert len(half) <= len(full) // 2
+
+    def test_no_needless_truncation_when_evidence_fits(self, repo: Path) -> None:
+        (repo / "app.py").write_text("y = 1\n" * 50)
+        head, wrap = _snapshot(repo)
+        full = o.build_packet(repo, head, wrap, max_chars=10_000_000)
+        assert "EVIDENCE TRUNCATED" not in full
+        exact = o.build_packet(repo, head, wrap, max_chars=len(full))  # exactly enough
+        assert "EVIDENCE TRUNCATED" not in exact   # marker not reserved when unneeded
+
+    def test_non_utf8_filename_does_not_crash(self, repo: Path) -> None:
+        try:
+            path = os.path.join(os.fsencode(str(repo)), b"weird-\xff-name.txt")
+            with open(path, "wb") as f:
+                f.write(b"content\n")
+        except (OSError, ValueError):
+            pytest.skip("filesystem rejects non-UTF-8 filenames")
+        head, wrap = _snapshot(repo)
+        packet = o.build_packet(repo, head, wrap)
+        packet.encode("utf-8")             # packet is UTF-8/JSON-safe (no lone surrogates)
+        assert "name.txt" in packet        # file represented (exact escape form varies)
+
+
+class TestDisplaySanitizer:
+    def test_escapes_surrogate_bytes_and_stays_encodable(self) -> None:
+        p = b"a\xff.txt".decode("utf-8", "surrogateescape")  # as changed_files would yield
+        assert "\udcff" in p               # raw lone surrogate present before sanitizing
+        d = o._display(p)
+        d.encode("utf-8")                  # no lone surrogate now — would raise otherwise
+        assert "\udcff" not in d           # the raw surrogate was escaped away
+        assert "udcff" in d                # ...into a readable \udcff escape
+
+    def test_preserves_valid_unicode(self) -> None:
+        assert o._display("café.py") == "café.py"
+
+    def test_is_injective_across_tricky_paths(self) -> None:
+        invalid = b"a\xff".decode("utf-8", "surrogateescape")       # a 0xFF byte
+        real_fffd = b"a\xef\xbf\xbd".decode("utf-8", "surrogateescape")  # a real U+FFFD
+        literal_escape = "a\\udcff"                                  # a file literally named a\udcff
+        labels = {o._display(invalid), o._display(real_fffd), o._display(literal_escape)}
+        assert len(labels) == 3  # three distinct inputs → three distinct labels (injective)
+        for label in labels:
+            label.encode("utf-8")  # every label is UTF-8/JSON-safe
+
+
+class TestPacketPrompt:
+    def test_has_five_sections_and_forbids_regather(self) -> None:
+        p = prompts.CODE_REVIEW_INSTRUCTIONS_PACKET
+        for h in ("## What works", "## What doesn't work", "## Risks", "## Gaps", "## Improvements"):
+            assert h in p
+        assert "gathered for you" in p.lower()
+        assert "do not re-open" in p.lower()

--- a/tests/test_snapshot.py
+++ b/tests/test_snapshot.py
@@ -1,0 +1,148 @@
+"""Phase-1 snapshot/plumbing core: capture the reviewed working state as an immutable
+git commit whose `<parent>..<wrapper>` range reproduces the dirty patch, and enumerate
+structured change-sets. Objects land in the repo's own store but NO ref is created, so
+git GC reclaims them and a worktree can read the wrapper with no special env. See
+docs/orientation_reuse_plan.md.
+"""
+
+import subprocess
+from pathlib import Path
+
+from paranoia_local import orientation as o
+from paranoia_local.worktree import worktree_at
+from tests.conftest import commit_all, git
+
+
+def _dirty(repo: Path) -> None:
+    """Dirty the working tree: edit a tracked file, add an untracked one."""
+    (repo / "app.py").write_text('"""App."""\n\n\ndef greet(name):\n    return f"yo {name}"\n')
+    (repo / "brand_new.py").write_text("x = 1\n")
+
+
+def _read_git(args: list[str], cwd: Path) -> str:
+    env = {
+        "GIT_CONFIG_GLOBAL": "/dev/null",
+        "GIT_CONFIG_SYSTEM": "/dev/null",
+        "PATH": "/usr/bin:/bin:/usr/local/bin:/opt/homebrew/bin",
+        "HOME": str(cwd),
+    }
+    r = subprocess.run(["git", *args], cwd=cwd, env=env, capture_output=True, text=True)
+    assert r.returncode == 0, r.stderr
+    return r.stdout
+
+
+class TestResolveHead:
+    def test_matches_rev_parse(self, repo: Path) -> None:
+        assert o.resolve_head(repo) == _read_git(["rev-parse", "HEAD"], repo).strip()
+
+
+class TestStateless:
+    def test_snapshot_and_wrap_create_no_ref(self, repo: Path) -> None:
+        # Round-5's concern was refs pinning content indefinitely. We create NONE:
+        # the wrapper is an unreferenced (GC-able) object, not anchored by any ref.
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        refs_before = _read_git(["for-each-ref"], repo)
+        wrap = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        assert _read_git(["for-each-ref"], repo) == refs_before  # no ref created
+        assert wrap in _read_git(["fsck", "--unreachable", "--no-reflogs"], repo)
+
+
+class TestSnapshotTree:
+    def test_captures_dirty_tracked_and_untracked(self, repo: Path) -> None:
+        _dirty(repo)
+        tree = o.snapshot_tree(repo, o.resolve_head(repo))
+        listing = _read_git(["ls-tree", "-r", "--name-only", tree], repo)
+        assert "app.py" in listing and "brand_new.py" in listing
+        assert "yo {name}" in _read_git(["show", f"{tree}:app.py"], repo)
+
+    def test_captures_tracked_but_ignored_dirty(self, repo: Path) -> None:
+        # A tracked file that also matches .gitignore, with a dirty change, must still be
+        # snapshotted — this is why the recipe does `read-tree HEAD` before `add -A`.
+        (repo / ".gitignore").write_text("secret.txt\n")
+        (repo / "secret.txt").write_text("v1\n")
+        git(["add", "-f", "secret.txt", ".gitignore"], repo)
+        commit_all(repo, "track ignored file")
+        (repo / "secret.txt").write_text("v2-dirty\n")
+        tree = o.snapshot_tree(repo, o.resolve_head(repo))
+        assert "v2-dirty" in _read_git(["show", f"{tree}:secret.txt"], repo)
+
+    def test_does_not_touch_author_index(self, repo: Path) -> None:
+        _dirty(repo)
+        before = _read_git(["status", "--porcelain"], repo)
+        o.snapshot_tree(repo, o.resolve_head(repo))
+        assert _read_git(["status", "--porcelain"], repo) == before
+
+
+class TestWrapCommit:
+    def test_wraps_on_head_with_message(self, repo: Path) -> None:
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        wrap = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        parents = _read_git(["rev-list", "--parents", "-n", "1", wrap], repo).split()
+        assert parents[1] == head  # wrapper's sole parent is the resolved HEAD
+        assert _read_git(["log", "-1", "--format=%s", wrap], repo).strip() == "paranoia-snapshot"
+
+    def test_range_reproduces_dirty_patch(self, repo: Path) -> None:
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        wrap = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        names = _read_git(["diff", "--name-status", f"{head}..{wrap}"], repo)
+        assert "M\tapp.py" in names
+        assert "A\tbrand_new.py" in names
+
+    def test_deterministic_same_state_same_sha(self, repo: Path) -> None:
+        # Pinned identity + dates ⇒ a given working state always wraps to the same sha.
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        a = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        b = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        assert a == b
+
+
+class TestMaterialize:
+    """The review runs against a throwaway worktree of the wrapper commit, so evidence is
+    a consistent snapshot — the reviewer reads current bytes, git works with no special
+    env, and edits to the live repo during a review can't perturb it."""
+
+    def test_worktree_of_wrapper_has_dirty_snapshot(self, repo: Path) -> None:
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        wrap = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        with worktree_at(repo, wrap) as wt:
+            assert (wt / "brand_new.py").exists()               # untracked captured
+            assert "yo {name}" in (wt / "app.py").read_text()   # dirty edit present
+            # git works inside the worktree with ZERO special object-store env
+            assert _read_git(["log", "-1", "--format=%s"], wt).strip() == "paranoia-snapshot"
+            assert "M\tapp.py" in _read_git(["diff", "--name-status", f"{head}..HEAD"], wt)
+        assert "paranoia-wt" not in _read_git(["worktree", "list"], repo)  # cleaned up
+
+    def test_live_edit_during_review_does_not_change_the_worktree(self, repo: Path) -> None:
+        _dirty(repo)
+        head = o.resolve_head(repo)
+        wrap = o.wrap_commit(repo, o.snapshot_tree(repo, head), head)
+        with worktree_at(repo, wrap) as wt:
+            (repo / "app.py").write_text("# the author kept editing the LIVE repo\n")
+            assert "yo {name}" in (wt / "app.py").read_text()  # worktree is unaffected
+
+
+class TestChangedFiles:
+    def test_modified_added_deleted(self, repo: Path) -> None:
+        base = o.resolve_head(repo)
+        (repo / "app.py").write_text("# changed\n")
+        (repo / "newf.py").write_text("y = 2\n")
+        (repo / "README.md").unlink()
+        commit_all(repo, "modify+add+delete")
+        entries = {e.path: e for e in o.changed_files(repo, base, o.resolve_head(repo))}
+        assert entries["app.py"].status == "M"
+        assert entries["newf.py"].status == "A"
+        assert entries["README.md"].status == "D"
+
+    def test_rename_carries_old_and_new_path(self, repo: Path) -> None:
+        base = o.resolve_head(repo)
+        git(["mv", "app.py", "renamed.py"], repo)
+        commit_all(repo, "rename app.py")
+        renames = [e for e in o.changed_files(repo, base, o.resolve_head(repo)) if e.status == "R"]
+        assert renames, "rename not detected"
+        assert renames[0].old_path == "app.py"
+        assert renames[0].path == "renamed.py"


### PR DESCRIPTION
Phase 1 of the orientation-reuse plan (docs/orientation_reuse_plan.md). Adds an opt-in `converge` mode to critique_branch that pre-gathers a deterministic evidence packet — the full contents of every touched file in an immutable snapshot, plus the diff — and reviews it with a packet-aware prompt, so the reviewer skips the per-round re-read/re-grep that dominates convergence-loop cost. Stateless and per-request, both engines.

The Claude-fork design (former Phase 2) was dropped after review: a deterministic manifest can't be a guaranteed superset, so fork effectiveness is unprovable by construction, and its correct implementation carried disproportionate lifecycle risk.

- orientation.py: snapshot_tree/wrap_commit capture the working state as an unreferenced git commit (repo ODB, no ref -> GC-reclaimable, worktree-readable with no special env); build_packet with a real char budget that always preserves already_raised and always signals omission; changed_files (--name-status -z -M); comprehensive byte-safety for binary/non-UTF-8 content and filenames (surrogateescape lookup + injective _display); unborn-repo + SHA-256 support.
- prompts.py: CODE_REVIEW_INSTRUCTIONS_PACKET (verify, don't re-gather).
- engines.py: Review gains returncode/error/usage/duration; _execute flags in-band engine errors (not just non-zero AND empty stdout).
- handlers.py: converge branch (snapshot -> materialized worktree -> packet review), requires repo_path, overrides isolate; surfaces + logs failures.
- worktree.py/logs.py/server.py: byte-safe worktree teardown; unique log filenames; converge/max_packet_chars tool inputs.

Reviewed to convergence over 6 rounds of cross-agent (Codex) adversarial review. 154 tests (+1 platform-skipped). Documented Phase-1 limitations: symlink object-mode, best-effort teardown.