### PR TITLE
feat(converge): make convergence packet mode the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,11 +58,13 @@ caller — spawn a fresh review each round feeding the growing `already_raised`
 list — until findings converge or drop to noise. (Never paste prior reviewers'
 prose; just the deduplicated claim + citation.)
 
-### Convergence packet mode (`converge: true`)
+### Convergence packet mode (`converge`, **on by default**)
 
 Each cold round otherwise re-gathers the same orientation — re-reading the touched
 files and re-running `git`, which measurements show dominates the per-round cost.
-Pass `converge: true` to `critique_branch` and the server instead **pre-gathers a
+`critique_branch` therefore runs in **convergence mode by default** (pass
+`converge: false`, or set it in `.paranoia.toml`, to fall back to the legacy in-place
+review). In convergence mode the server **pre-gathers a
 deterministic evidence packet** (the contents of every touched file in the reviewed
 snapshot — binary/large files are marked rather than embedded — plus the diff) and
 hands it to the reviewer with a packet-aware prompt, so it verifies rather than

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -113,7 +113,10 @@ def critique_branch(
     model = resolve("model", arguments.get("model"), cfg, engine.default_model)
     effort = resolve("effort", arguments.get("effort"), cfg, "high")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
-    converge = bool(resolve("converge", arguments.get("converge"), cfg, False))
+    # Converge (packet) mode is ON by default: pre-gather a deterministic evidence packet
+    # and review it against an immutable materialized snapshot. Pass converge=false (call
+    # arg or .paranoia.toml) to fall back to the legacy in-place review.
+    converge = bool(resolve("converge", arguments.get("converge"), cfg, True))
     max_packet_chars = int(
         resolve("max_packet_chars", arguments.get("max_packet_chars"), cfg, orientation.MAX_PACKET_CHARS)
     )

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -79,7 +79,7 @@ TOOLS: list[Tool] = [
                 },
                 "converge": {
                     "type": "boolean",
-                    "description": "Convergence mode (default false): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate).",
+                    "description": "Convergence mode (default TRUE): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate). Pass false to fall back to the legacy in-place review.",
                 },
                 "max_packet_chars": {
                     "type": "integer",

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -66,11 +66,17 @@ class TestConvergeBranch:
         assert rec["mode"] == "converge-packet"
         assert rec["usage"] == {"cost_usd": 0.01}
 
-    def test_default_off_runs_in_live_repo_for_dirty(self, repo: Path, tmp_path: Path) -> None:
+    def test_default_on_materializes_for_dirty(self, repo: Path, tmp_path: Path) -> None:
         _dirty(repo)
         fake = FakeEngine()
-        handlers.critique_branch(_args(repo), engine=fake, log_dir=tmp_path)  # no converge
-        assert fake.calls[0]["cwd"] == repo  # unchanged behaviour: live repo for dirty
+        handlers.critique_branch(_args(repo), engine=fake, log_dir=tmp_path)  # converge is default
+        assert "paranoia-wt" in str(fake.calls[0]["cwd"])  # materialized snapshot, not live repo
+
+    def test_explicit_converge_false_restores_live_repo(self, repo: Path, tmp_path: Path) -> None:
+        _dirty(repo)
+        fake = FakeEngine()
+        handlers.critique_branch(_args(repo, converge=False), engine=fake, log_dir=tmp_path)
+        assert fake.calls[0]["cwd"] == repo  # escape hatch: legacy in-place review
 
     def test_converge_on_unborn_repo(self, tmp_path: Path) -> None:
         # A repo with files but no first commit must not crash on resolve_head.

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -59,19 +59,23 @@ class TestCritiqueBranch:
         assert "abc-999" in out
 
     def test_dirty_tree_runs_in_repo_not_worktree(self, repo: Path, tmp_path: Path) -> None:
+        # Legacy (non-converge) path: a dirty review runs in place. converge=False pins it,
+        # since converge (materialized snapshot) is now the default.
         (repo / "app.py").write_text("# uncommitted edit\n")
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo), "include_uncommitted": True},
+            {"repo_path": str(repo), "include_uncommitted": True, "converge": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo
 
     def test_isolate_false_runs_in_repo(self, repo_with_branch: Path, tmp_path: Path) -> None:
+        # Legacy path: isolate=false reviews in place. converge=False required now that
+        # converge is the default (and converge always materializes, overriding isolate).
         eng = FakeEngine()
         handlers.critique_branch(
             {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "isolate": False},
+             "isolate": False, "converge": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo_with_branch


### PR DESCRIPTION
critique_branch now defaults converge=true, so every branch review pre-gathers the deterministic evidence packet and reviews against an immutable materialized snapshot. Pass converge=false (call arg or .paranoia.toml) to fall back to the legacy in-place review. Legacy-path handler tests pinned with converge=false; the converge default test flipped to assert materialization; escape-hatch test added.