### PR TITLE
docs: round docstring should say MAJOR-or-higher, not FATAL/BLOCKER-only

### DIFF
--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -71,8 +71,9 @@ def _progress_kwargs(on_progress: Callable[[str], None] | None) -> dict[str, Any
 def _calibration(stakes: str | None, review_round: int | None) -> str | None:
     """Render the reviewer-calibration block. STAKES bounds legitimate concern
     (findings beyond it are out of scope); ROUND sets the severity floor across a
-    convergence loop (high rounds report only blocking findings). Both optional;
-    absent → the reviewer assumes a modest internal tool and reports everything."""
+    convergence loop (round >=3 reports MAJOR-or-higher only, withholding MINOR
+    and OUT-OF-SCOPE). Both optional; absent → the reviewer assumes a modest
+    internal tool and reports everything."""
     lines: list[str] = []
     if stakes:
         lines.append(f"STAKES: {stakes}")

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -74,10 +74,12 @@ _ROUND = {
     "minimum": 1,
     "description": (
         "Convergence-loop round number (1-based). Increment it on each cold review round you run. "
-        "At round >=3 the reviewer restricts itself to blocking ([FATAL]/[BLOCKER]) in-scope "
-        "findings and declares 'CONVERGED' when none remain — this is the lever to STOP a loop "
-        "instead of chasing marginal/hardening findings across many rounds. Start at 1 and raise "
-        "as the design stabilises; omit to report at all severities (round-1 behaviour)."
+        "At round >=3 the reviewer restricts itself to merge-blocking in-scope findings — MAJOR "
+        "or higher ([BLOCKER]/[MAJOR] for code review, [FATAL]/[MAJOR] for plan review) — and "
+        "withholds [MINOR] and [OUT-OF-SCOPE], declaring 'CONVERGED' when none remain. This is "
+        "the lever to STOP a loop instead of chasing marginal/hardening findings across many "
+        "rounds. Start at 1 and raise as the design stabilises; omit to report at all severities "
+        "(round-1 behaviour)."
     ),
 }
 


### PR DESCRIPTION
## Summary
- The `round` parameter docstring (used by both `critique_plan` and `critique_branch`) said round >=3 restricts the reviewer to "blocking ([FATAL]/[BLOCKER])" findings — read literally, that excludes MAJOR.
- The actual behavior, per the `_CALIBRATION` block in `prompts.py`, sets the floor at "[MAJOR] or higher for this review mode": only `[MINOR]` and `[OUT-OF-SCOPE]` get withheld at round >=3.
- Updated `server.py`'s `_ROUND` schema description and the matching docstring in `handlers.py::_calibration` to state the floor precisely per mode (`[BLOCKER]`/`[MAJOR]` for code review, `[FATAL]`/`[MAJOR]` for plan review).

## Test plan
- [x] Grepped the repo for other references to the old wording — none found.
- Docs-only change; no behavior touched (the actual severity-floor logic lives in `prompts.py` and was already correct).

🤖 Generated with [Claude Code](https://claude.com/claude-code)