### PR TITLE
arbitrate: fix the eight defects the first production run surfaced

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,7 +149,9 @@ raised before the cleaner runs.
 - **A vendor that never changed its mind is not asked to cite the other's evidence.**
   In round 2 the carried-evidence requirement applies only to a vendor whose selection
   *moved* — that is what it is for, since capitulation is a change. A vendor that held
-  its round-1 position needs only a citation that resolves.
+  its round-1 position needs only a citation that resolves, **provided its round-1
+  decisive citation resolved too**; a holder that was never substantiated in the first
+  place must ground in gained evidence like a mover.
 - **It only decides things the repository can settle.** A converging vote must
   cite a line. A decision that does not turn on repo-verifiable grounds will
   never return `CONVERGED` here.

--- a/README.md
+++ b/README.md
@@ -111,6 +111,32 @@ The reply ends with a machine-readable trailer whose fields are always present:
 `ARBITRATION`, `SELECTED`, `ADVISORY`, `AUTHORITY-POLICY`, `CLEANING`,
 `SNAPSHOT`, `ORDER-SEED`, `REFS-MOVED`, `AUDIT`, `ROUNDS`.
 
+### Shaping the input
+
+The framing is checked against numeric bounds **before** anything is spent, and one
+shape passes them naturally:
+
+> Put every shared fact, and the **full specification of whatever only one option
+> adopts**, into `context` — prefaced as "the rules under consideration, if adopted".
+> Leave each option statement to say only how much of it is adopted, and what follows.
+
+The reason is structural. "Adopt X, with this precedence and this invariant" carries
+more mechanism to state than "don't", so a scope decision written the obvious way
+trips the equalization bound by construction, and no amount of re-cleaning fixes it —
+shortening the longer option just deletes the specification the deciders need. Hoisting
+the mechanism turns both options into statements of *scope-of-adoption*, and they
+equalize on their own (~800 chars each is typical).
+
+| Bound | Limit | Why |
+|---|---|---|
+| option statement | 1200 chars | dense options cannot be round-tripped through the cleaner without the attester scoring a fidelity change |
+| longest ÷ shortest option | 2.0 | asymmetric detail is an argument regardless of wording |
+| `decision` | 2500 chars | it states what is being chosen, not the evidence for it |
+| `context` | 20000 chars | the designated home for detail; not per-option, so its length cannot be a vote |
+
+Failures name the gate, the measurement, and the remedy, and cost nothing — they are
+raised before the cleaner runs.
+
 ### Things to know before you rely on it
 
 - **Both CLIs must be installed.** Unlike the review tools, `arbitrate` drives
@@ -120,6 +146,10 @@ The reply ends with a machine-readable trailer whose fields are always present:
   owner should be authorizing the decision at all. That is reported, never gated
   — a `CONVERGED` with `ADVISORY: human-owner` is still `CONVERGED`. Enforcing it
   is your policy, not the tool's.
+- **A vendor that never changed its mind is not asked to cite the other's evidence.**
+  In round 2 the carried-evidence requirement applies only to a vendor whose selection
+  *moved* — that is what it is for, since capitulation is a change. A vendor that held
+  its round-1 position needs only a citation that resolves.
 - **It only decides things the repository can settle.** A converging vote must
   cite a line. A decision that does not turn on repo-verifiable grounds will
   never return `CONVERGED` here.

--- a/docs/arbitration_plan.md
+++ b/docs/arbitration_plan.md
@@ -797,7 +797,15 @@ the round; it says nothing about **use** within it.
   — computed server-side, since the round-2 session is cold and does not know what its
   own vendor cited before.
 
-**Why only a vendor that moved.** The carried-grounding rule is anti-*capitulation*:
+**Two vendors owe carried grounding: any that moved, and any whose round-1 vote was
+unsubstantiated.** The second clause is what makes the first sound — waiving the rule
+for a holder rests on that holder already having been substantiated in round 1, and a
+vendor that reached round 2 with no resolving decisive citation has no such standing.
+Without it, a vote that was never substantiated at all could ride to `CONVERGED` on a
+fresh citation that merely resolves, while the other vendor moved onto its supporting
+region.
+
+**Why a vendor that moved.** The carried-grounding rule is anti-*capitulation*:
 it proves a changed mind was changed by evidence rather than by the bare fact of
 disagreement. Capitulation is by definition a change, so a vendor that held its
 round-1 selection has nothing to disprove, and its position was already substantiated
@@ -953,7 +961,7 @@ own reading. That is what a function removes.
 | Reading prose to judge agreement | Python compares mapped `SELECTED` against an exact label set. |
 | Composing the round-2 packet | Mechanical: repository bytes only, no prose, no provenance (§3.6). |
 | A round 2 that reconciles nothing | The per-decider interval gate (§2.11). |
-| Agreement reached without using any evidence | Substantiation: every converging vote must resolve a citation, and in round 2 one novel to its own vendor (§3.5). |
+| Agreement reached without using any evidence | Substantiation: every converging vote must resolve a citation, and in round 2 one novel to its own vendor — required of any vendor that changed selection, or whose round-1 vote was itself unsubstantiated (§3.5). |
 | A cold round-2 decider losing its own evidence | Both receive the full region union (§2.6). |
 | Local labels colliding with framing or repository text | Seed-derived labels, absence verified against framing and snapshot, disjoint per decider so any echo fails membership (§2.4). |
 | The caller's view entering the framing | Cleaner + measured bands + field-by-field attestation. |
@@ -1162,10 +1170,12 @@ caller's input; the cleaner model default is `claude-opus-5` and is *not*
 inherited from `ClaudeEngine.default_model`.
 
 *Substantiation (§3.5).* Round-1 agreement with `DECISIVE-CITATION: NONE` from
-either decider yields `UNRESOLVED`; round-2 agreement where a converging vote's
+either decider yields `UNRESOLVED`; round-2 agreement where a MOVING vote's
 decisive anchor is its own prior region — even with the other vendor's novel region
 appended to supporting `CITATIONS` — yields `UNRESOLVED`, since only the decisive
-field gates; round-2 agreement where each decisive anchor lies within a carried
+field gates; a vendor that HELD a round-1 selection which was itself substantiated
+needs only a decisive citation that resolves, while one that held an unsubstantiated
+round-1 selection must ground in gained evidence like a mover; round-2 agreement where each decisive anchor lies within a carried
 region novel to its own vendor yields `CONVERGED`; a decisive anchor that merely
 *abuts* a carried interval (anchor 113 against carried `[104,110]` at `k=3`) does
 **not** substantiate, because `anchor_within` is point-in-interval and not

--- a/docs/arbitration_plan.md
+++ b/docs/arbitration_plan.md
@@ -316,6 +316,16 @@ for incidental `path:line` text, missing paths, lines past EOF, and
   as a separate defect across several review rounds. Enumerating rejected spellings
   cannot close that class; not rewriting does. A noncanonical path drops, costing
   one `UNRESOLVED`.
+- Hint paths are not normalized either. `validate_hints` folded `\` to `/` and stripped
+  `./`, and git tracks `policy\choice.py` distinctly from `policy/choice.py`, so a
+  caller hinting the former sent BOTH deciders to a different file's bytes — invisibly,
+  because the attester is shown the path the server resolved, not the one the caller
+  wrote. Literal membership here too.
+- Snapshot path reads use `git ls-tree -z`. Without it `--name-only` quotes any path
+  containing a backslash, a quote, or a non-ASCII byte, and `core.quotePath=false` does
+  not suppress it — so the membership set held `"policy\\choice.py"` while a citation
+  carries the raw name, making every legitimate reference to such a file unresolvable.
+  That was a latent break in the closure below rather than a new one.
 - The same rule reaches the one boundary where the string is repository data rather
   than model output: a **symlink target containing `..` fails closed**. Interpreting
   it lexically diverges from the worktree as soon as an earlier component is itself

--- a/docs/arbitration_plan.md
+++ b/docs/arbitration_plan.md
@@ -84,17 +84,54 @@ independence the mechanism runs on."* Today that is enforced by the caller
 remembering it. Closed by the cleaner (§3.2), validated and cross-vendor attested
 field by field (§3.3). Raw framing reaches no decider.
 
+### 2.1a Framing bounds are checked before anything is spent
+
+Three of the first four production invocations died after two Opus cleaning attempts
+each, on defects visible in the caller's own input: an inter-option length ratio, an
+over-long option, an over-long decision (issue #8). The measurements were right and the
+diagnostics were excellent — they were simply taken after the spend.
+
+`preflight_framing` now runs them before the cleaner: option statements ≤ 1200 chars,
+longest ÷ shortest ≤ 2.0, `decision` ≤ 2500, `context` ≤ 20000. Same measurements, same
+message shapes, no agent turn. `context` is bounded far more loosely because it is the
+designated home for detail and is not per-option, so its length cannot be a vote
+between the options.
+
+The inter-option ratio belongs here rather than only after cleaning because it is
+**structural, not stylistic**: "adopt X, with this precedence and this invariant"
+carries more mechanism to state than "don't", so any scope decision trips it by
+construction and no amount of re-cleaning fixes it. The supported remedy is therefore
+a framing idiom, and the error states it: hoist the shared mechanism — including the
+full specification of what only one option adopts — into `context`, and leave each
+option statement to say only how much of it is adopted and what follows. Both options
+then describe scope-of-adoption, and equalize on their own. The field run landed at
+~780 vs ~810 chars this way, having failed at 483 vs 1262.
+
 ### 2.2 Length and detail asymmetry are a vote — closed
 
-A four-line option beside a six-word option is an argument. The cleaner equalizes;
-**the server measures**, with both bands numeric and symmetric:
+A four-line option beside a six-word option is an argument. The caller's own ratio is
+bounded at preflight (§2.1a); what this band adds is what the **cleaner** is answerable
+for, which is not the same thing:
 
-- across cleaned options: `max/min ≤ 2.0`;
-- each cleaned option against its own original: `0.5 ≤ ratio ≤ 2.0`.
+- across cleaned options: the ratio may not exceed `max(2.0, the caller's own ratio)` —
+  equalized framing coming back skewed is the cleaner introducing a length vote;
+- each cleaned option against its own original: `ratio ≤ 2.0`. Growth keeps a ceiling
+  because a statement that doubles has gained content from somewhere, and the id-set
+  check cannot see added prose inside a preserved id.
 
-Revision 2 specified the second band as "within a ratio bound" with no number,
-which two implementations could satisfy differently while passing every stated
-test. Outside either band → one cleaner retry with the measurement, then fail.
+Revision 2 specified the second band as "within a ratio bound" with no number, which
+two implementations could satisfy differently while passing every stated test.
+
+**There is deliberately no lower bound.** Revisions 2-4 set one at `0.5`, and the first
+production run showed it firing on the wrong signal (issue #8): an option whose text was
+largely consequence-narration ("Outcome under this option: …") was compressed to 0.09x
+and rejected, though its meaning was intact — the cleaner had correctly identified
+restatement as compressible, while the option describing *mechanism* survived verbatim.
+A character ratio cannot distinguish dropped substance from dropped padding. The
+cross-vendor fidelity attestation can, and checks exactly that, per option, by id
+(§3.2). The floor was a cheap proxy for a check that already exists in stronger form,
+and its only observed effect was to penalise a caller for explaining an option's
+outcome. Outside a surviving band → one cleaner retry with the measurement, then fail.
 
 ### 2.3 Presentation order tilts both deciders the same way — **reduced**
 
@@ -754,10 +791,28 @@ nothing, or citing only regions their own vendor had already produced, after mer
 the round; it says nothing about **use** within it.
 
 - **Round 1:** every converging vote's `DECISIVE-CITATION` must resolve.
-- **Round 2:** every converging vote's `DECISIVE-CITATION` anchor must satisfy
-  `anchor_within` (§2.5) a region that was carried to it *and* was novel to its own
-  vendor — computed server-side, since the round-2 session is cold and does not know
-  what its own vendor cited before.
+- **Round 2:** every converging vote's `DECISIVE-CITATION` must resolve, and for a
+  vendor **whose selection changed between rounds** its anchor must additionally
+  satisfy `anchor_within` (§2.5) a region carried to it *and* novel to its own vendor
+  — computed server-side, since the round-2 session is cold and does not know what its
+  own vendor cited before.
+
+**Why only a vendor that moved.** The carried-grounding rule is anti-*capitulation*:
+it proves a changed mind was changed by evidence rather than by the bare fact of
+disagreement. Capitulation is by definition a change, so a vendor that held its
+round-1 selection has nothing to disprove, and its position was already substantiated
+on its own resolved citation in round 1.
+
+Requiring it of every vendor produced a false negative on the very first production
+run (issue #8). Both vendors agreed; the vendor that flipped grounded correctly on the
+region the other had produced — the mechanism working exactly as designed — and the
+run still returned `UNRESOLVED`, because the vendor that had been right all along
+cited the *producer code* rather than re-citing the artifact it used in round 1. Its
+gains set held exactly one region: the other vendor's argument for the option it had
+rejected. The rule was demanding it cite the evidence against its own conclusion, and
+it penalised the deeper piece of work. This is the expensive failure mode — a correct
+convergence discarded silently, recoverable only by hand-verifying citations, and
+fatal to an autonomous caller, which simply halts.
 
 Supporting `CITATIONS` never substantiate. Otherwise `UNRESOLVED`. This is faithful to the protocol being mechanized, which
 already demands *"the single decisive constraint behind your selection, with a

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -907,6 +907,14 @@ def _clean_and_attest(
             parsed = parse_cleaned_packet(
                 cleaned_raw, list(originals), caller_gave_context=bool(context)
             )
+            if context and not parsed["context"]:
+                # Dropping a supplied context is invisible downstream: rendered back to
+                # the attester as "None." it matches a caller context that also reads
+                # "None.", so fidelity passes while the deciders receive nothing.
+                raise ArbitrationError(
+                    "the cleaner dropped the supplied context block; it may neutralize "
+                    "the context but not remove it"
+                )
             if parsed["context"] and not context:
                 # A context the caller never wrote is the cleaner adding facts, which
                 # it is forbidden to do — and it cannot be attested against anything.
@@ -1021,7 +1029,7 @@ def _attest_body(
     # to score empty→anything as a fidelity change, and the run then failed naming a
     # field the caller had no control over (issue #8, fix 4).
     if context:
-        pairs.append(f"[context]\nORIGINAL: {context}\nCLEANED:  {parsed['context'] or 'None.'}")
+        pairs.append(f"[context]\nORIGINAL: {context}\nCLEANED:  {parsed['context']}")
     if original_hints:
         # The real originals, not a placeholder: an auditor shown "(as given)"
         # cannot compare anything, so hint reasons went unchecked.

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -593,7 +593,8 @@ def _arbitrate(
     if escaping:
         raise ArbitrationError(
             "snapshot contains symlink(s) whose target escapes the repository, so the "
-            f"deciders could read unrecorded bytes: {', '.join(escaping)}"
+            "deciders could read unrecorded bytes: "
+            + ", ".join(evidence.printable(e) for e in escaping)
         )
     hints = evidence.validate_hints(repo, snapshot, list(arguments.get("files") or []))
 

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -108,7 +108,9 @@ def _snapshot(repo: Path) -> str:
 _BLOCK_RE = re.compile(r"^===\s*(?P<name>[A-Z]+)\s*===\s*$")
 
 
-def parse_cleaned_packet(text: str, ids: Sequence[str]) -> dict[str, Any]:
+def parse_cleaned_packet(
+    text: str, ids: Sequence[str], *, caller_gave_context: bool = False
+) -> dict[str, Any]:
     """Parse the cleaner's blocks and enforce fidelity mechanically.
 
     The id set must round-trip 1:1. A "neutralizer" that quietly drops or merges an
@@ -155,17 +157,26 @@ def parse_cleaned_packet(text: str, ids: Sequence[str]) -> dict[str, Any]:
 
     return {
         "decision": "\n".join(blocks["DECISION"]).strip(),
-        "context": _none_as_empty("\n".join(blocks.get("CONTEXT", [])).strip()),
+        "context": _cleaned_context(blocks.get("CONTEXT", []), caller_gave_context),
         "hints": parse_cleaned_hints(blocks.get("HINTS", [])),
         "statements": statements,
     }
 
 
-def _none_as_empty(text: str) -> str:
+def _cleaned_context(lines: Sequence[str], caller_gave_context: bool) -> str:
     """`CONTEXT: None.` is how the cleaner spells "the caller gave me none" — the same
-    sentinel the HINTS block uses. Treating it as content would make an absent field
-    look populated, which is exactly the confusion fix 4 removes."""
-    return "" if text.strip().rstrip(".").strip().lower() in ("", "none", "n/a") else text
+    sentinel the HINTS block uses, and treating it as content would make an absent
+    field look populated.
+
+    But it is only a sentinel when the caller supplied nothing. A caller whose context
+    legitimately *is* `None.` — the observed output of the thing being adjudicated, say
+    — must have it reach the deciders verbatim, so when context was supplied the block
+    is passed through untouched.
+    """
+    text = "\n".join(lines).strip()
+    if caller_gave_context:
+        return text
+    return "" if text.rstrip(".").strip().lower() in ("", "none", "n/a") else text
 
 
 def parse_cleaned_hints(lines: Sequence[str]) -> dict[str, str]:
@@ -550,7 +561,9 @@ def _arbitrate(
     # Input-only defects, checked before a single agent call: three of the first four
     # production invocations died after two Opus attempts each on exactly these
     # measurements (issue #8, fix 5).
-    arb.preflight_framing(decision=decision, context=context, options=canonical)
+    arb.preflight_framing(
+        decision=decision, context=context, options=canonical, cleaned=do_clean
+    )
 
     _preflight(deciders)
 
@@ -680,6 +693,13 @@ def _arbitrate(
             # whose selection actually moved (issue #8).
             first = {v.engine: v.selected for v in round1}
             moved = {v.engine for v in round2 if first.get(v.engine) != v.selected}
+            # Waiving carried grounding rests on the held position ALREADY being
+            # substantiated in round 1. A vendor that reached round 2 without a
+            # resolving decisive citation has no such standing, so it must ground in
+            # gained evidence like a mover: otherwise a vote that was never
+            # substantiated at all rides to CONVERGED on a citation that merely
+            # resolves, while the other vendor moves onto its supporting region.
+            moved |= {v.engine for v in round2 if not sub1.get(v.engine, False)}
             sub2 = arb.substantiation(
                 round2,
                 resolve=resolve_region,
@@ -884,7 +904,9 @@ def _clean_and_attest(
             timeout=CLEAN_TIMEOUT_SEC, text_only=True,
         )
         try:
-            parsed = parse_cleaned_packet(cleaned_raw, list(originals))
+            parsed = parse_cleaned_packet(
+                cleaned_raw, list(originals), caller_gave_context=bool(context)
+            )
             if parsed["context"] and not context:
                 # A context the caller never wrote is the cleaner adding facts, which
                 # it is forbidden to do — and it cannot be attested against anything.

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -155,10 +155,17 @@ def parse_cleaned_packet(text: str, ids: Sequence[str]) -> dict[str, Any]:
 
     return {
         "decision": "\n".join(blocks["DECISION"]).strip(),
-        "context": "\n".join(blocks.get("CONTEXT", [])).strip(),
+        "context": _none_as_empty("\n".join(blocks.get("CONTEXT", [])).strip()),
         "hints": parse_cleaned_hints(blocks.get("HINTS", [])),
         "statements": statements,
     }
+
+
+def _none_as_empty(text: str) -> str:
+    """`CONTEXT: None.` is how the cleaner spells "the caller gave me none" — the same
+    sentinel the HINTS block uses. Treating it as content would make an absent field
+    look populated, which is exactly the confusion fix 4 removes."""
+    return "" if text.strip().rstrip(".").strip().lower() in ("", "none", "n/a") else text
 
 
 def parse_cleaned_hints(lines: Sequence[str]) -> dict[str, str]:
@@ -182,29 +189,46 @@ def parse_cleaned_hints(lines: Sequence[str]) -> dict[str, str]:
 
 
 def check_length_bands(cleaned: Mapping[str, str], original: Mapping[str, str]) -> None:
-    """Both bands, numeric and symmetric.
+    """What the CLEANER is answerable for, which is not the same as what the caller is.
 
-    Across options `max/min <= 2.0`, because asymmetric detail is an argument
-    regardless of wording; per option `0.5 <= cleaned/original <= 2.0`, because a
-    statement that doubles or halves has probably changed substance. Stated
-    intention to equalize is not equalization.
+    The caller's own inter-option ratio is bounded at preflight
+    (`arb.preflight_framing`). What remains here is that the cleaner must not make the
+    asymmetry *worse* than the framing it was handed — equalized input coming back
+    skewed is the cleaner introducing a length vote.
+
+    There is deliberately **no lower bound** on how far a statement may compress.
+    Issue #8: an option whose text was largely consequence-narration ("Outcome under
+    this option: …") was cut to 0.09x and rejected, though the meaning was intact —
+    the cleaner had correctly identified restatement as compressible. A character
+    ratio cannot tell dropped substance from dropped padding; the cross-vendor
+    fidelity attestation can, and it checks exactly that, per option, by id. The floor
+    was a cheap proxy for a check that already exists in stronger form.
+
+    Growth keeps its ceiling: a statement that doubles has gained content from
+    somewhere, and the id-set check cannot see added prose inside a preserved id.
     """
-    lengths = {k: max(1, len(v)) for k, v in cleaned.items()}
-    if lengths and max(lengths.values()) / min(lengths.values()) > 2.0:
-        longest = max(lengths, key=lengths.get)
-        shortest = min(lengths, key=lengths.get)
-        raise ArbitrationError(
-            "cleaned options are not equalized: "
-            f"{longest} is {lengths[longest]} chars, {shortest} is {lengths[shortest]} "
-            "(ratio must be <= 2.0)"
-        )
-    for oid, text in cleaned.items():
-        before = max(1, len(original.get(oid, "")))
-        ratio = max(1, len(text)) / before
-        if not (0.5 <= ratio <= 2.0):
+    cleaned_lengths = {k: max(1, len(v)) for k, v in cleaned.items()}
+    orig_lengths = {k: max(1, len(v)) for k, v in original.items()}
+    if cleaned_lengths:
+        got = max(cleaned_lengths.values()) / min(cleaned_lengths.values())
+        allowed = arb.OPTION_RATIO_MAX
+        if orig_lengths:
+            allowed = max(allowed, max(orig_lengths.values()) / min(orig_lengths.values()))
+        if got > allowed:
+            longest = max(cleaned_lengths, key=cleaned_lengths.get)
+            shortest = min(cleaned_lengths, key=cleaned_lengths.get)
             raise ArbitrationError(
-                f"cleaned option {oid} is {ratio:.2f}x its original length "
-                "(must be between 0.5x and 2.0x)"
+                "the cleaner left the options less equalized than the framing it was "
+                f"given: {longest} is {cleaned_lengths[longest]} chars, {shortest} is "
+                f"{cleaned_lengths[shortest]} (ratio {got:.2f}, allowed {allowed:.2f})"
+            )
+    for oid, text in cleaned.items():
+        before = orig_lengths.get(oid, 1)
+        ratio = max(1, len(text)) / before
+        if ratio > 2.0:
+            raise ArbitrationError(
+                f"cleaned option {oid} is {ratio:.2f}x its original length — the "
+                "cleaner may compress, but not add (max 2.0x)"
             )
 
 
@@ -451,6 +475,26 @@ def arbitrate(
         # A failure still returns the full trailer. "Every field is always present"
         # must hold on the error path too, or a caller that parses `ARBITRATION:`
         # gets nothing and has to fall back to reading prose.
+        #
+        # It also still writes an audit record. The first production run rejected three
+        # framings and left nothing on disk, so gate churn could only be reconstructed
+        # from terminal scrollback (issue #8, fix 7). A rejection is the cheapest thing
+        # this tool produces and the most useful thing to count.
+        audit = logs.write_log(
+            log_dir,
+            tool="arbitrate",
+            record={
+                "outcome": arb.FAILED,
+                "reason": str(exc),
+                "gate": type(exc).__name__,
+                "rounds": [],
+                "raw_input": {
+                    k: arguments.get(k)
+                    for k in ("decision", "options", "context", "stakes", "files")
+                },
+            },
+            timestamp=now(),
+        )
         return "\n".join(
             [
                 "# Arbitration: FAILED",
@@ -464,7 +508,7 @@ def arbitrate(
                     snapshot="none",
                     seed=str(arguments.get("order_seed") or "none"),
                     refs_moved=False,
-                    audit="none",
+                    audit=str(audit) if audit else "none",
                     rounds=0,
                 ),
             ]
@@ -502,6 +546,11 @@ def _arbitrate(
     cleaner_model = str(arguments.get("cleaner_model") or eng.CLEANER_MODEL)
     effort = resolve("effort", arguments.get("effort"), cfg, "medium")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
+
+    # Input-only defects, checked before a single agent call: three of the first four
+    # production invocations died after two Opus attempts each on exactly these
+    # measurements (issue #8, fix 5).
+    arb.preflight_framing(decision=decision, context=context, options=canonical)
 
     _preflight(deciders)
 
@@ -627,8 +676,15 @@ def _arbitrate(
             transcripts.append(casts2)
             per_round.append({v.engine: v for v in round2})
             gained = {e: arb.gains_for(e, sent, own[e]) for e in own}
+            # Carried grounding is anti-capitulation, so it is owed only by a vendor
+            # whose selection actually moved (issue #8).
+            first = {v.engine: v.selected for v in round1}
+            moved = {v.engine for v in round2 if first.get(v.engine) != v.selected}
             sub2 = arb.substantiation(
-                round2, resolve=resolve_region, carried={e: list(g) for e, g in gained.items()}
+                round2,
+                resolve=resolve_region,
+                carried={e: list(g) for e, g in gained.items()},
+                moved=moved,
             )
             outcome = arb.compute_outcome(round2, substantiated=sub2)
             rounds = 2
@@ -804,6 +860,16 @@ def _clean_and_attest(
             "skipped",
         )
 
+    # Only fields the caller supplied are attestable. Naming `context` when none was
+    # passed produced `fidelity changed: ['context']` on the first production run —
+    # an error about a field the caller had no control over (issue #8, fix 4).
+    attest_fields = ["decision"]
+    if context:
+        attest_fields.append("context")
+    if hints:
+        attest_fields.append("hints")
+    attest_fields.extend(originals)
+
     complaint = ""
     last_error: str | None = None
     # One retry only, and deliberately: a longer loop would hill-climb the framing
@@ -819,6 +885,13 @@ def _clean_and_attest(
         )
         try:
             parsed = parse_cleaned_packet(cleaned_raw, list(originals))
+            if parsed["context"] and not context:
+                # A context the caller never wrote is the cleaner adding facts, which
+                # it is forbidden to do — and it cannot be attested against anything.
+                raise ArbitrationError(
+                    "the cleaner invented a context block; no context was supplied, "
+                    "and the cleaner may not add facts to the framing"
+                )
             check_length_bands(parsed["statements"], originals)
             cleaned_hints = _merge_hints(hints, parsed["hints"])
             arb.reject_reserved_tokens(
@@ -844,9 +917,7 @@ def _clean_and_attest(
             timeout=CLEAN_TIMEOUT_SEC, text_only=True,
         )
         try:
-            attestation = parse_attestation(
-                attested_raw, ["decision", "context", "hints", *originals]
-            )
+            attestation = parse_attestation(attested_raw, attest_fields)
         except ArbitrationError as exc:
             last_error = f"attestation unusable: {exc}"
             complaint = f"An independent auditor's reply was unusable: {exc}\nRe-clean and try again."
@@ -923,13 +994,19 @@ def _attest_body(
     originals: Mapping[str, str],
     parsed: Mapping[str, Any],
 ) -> str:
-    pairs = [
-        f"[decision]\nORIGINAL: {decision}\nCLEANED:  {parsed['decision']}",
-        f"[context]\nORIGINAL: {context or 'None.'}\nCLEANED:  {parsed['context'] or 'None.'}",
+    pairs = [f"[decision]\nORIGINAL: {decision}\nCLEANED:  {parsed['decision']}"]
+    # Only fields the caller supplied. Listing an empty `context` invited the attester
+    # to score empty→anything as a fidelity change, and the run then failed naming a
+    # field the caller had no control over (issue #8, fix 4).
+    if context:
+        pairs.append(f"[context]\nORIGINAL: {context}\nCLEANED:  {parsed['context'] or 'None.'}")
+    if original_hints:
         # The real originals, not a placeholder: an auditor shown "(as given)"
         # cannot compare anything, so hint reasons went unchecked.
-        f"[hints]\nORIGINAL: {_render_hints(original_hints)}\nCLEANED:  {_render_hints(cleaned_hints)}",
-    ]
+        pairs.append(
+            f"[hints]\nORIGINAL: {_render_hints(original_hints)}\n"
+            f"CLEANED:  {_render_hints(cleaned_hints)}"
+        )
     for oid, original in originals.items():
         pairs.append(f"[{oid}]\nORIGINAL: {original}\nCLEANED:  {parsed['statements'][oid]}")
     return (

--- a/src/paranoia_local/arbitration.py
+++ b/src/paranoia_local/arbitration.py
@@ -29,7 +29,7 @@ from __future__ import annotations
 import hashlib
 import re
 from dataclasses import dataclass, replace
-from typing import Callable, Iterable, Mapping, Sequence
+from typing import Callable, Collection, Iterable, Mapping, Sequence
 
 # --- shape limits -----------------------------------------------------------
 
@@ -52,6 +52,7 @@ _LABEL_RE = re.compile(rf"^{LABEL_PREFIX}[0-9a-f]{{{LABEL_HEX}}}$")
 # `decision`/`context`/`hints` are the attestation's own fidelity field names — an
 # option called `decision` would emit two `[decision]` sections and let one verdict
 # satisfy both, so a semantic change to either could be stamped `attested`.
+OPTION_KEYS = frozenset({"id", "statement"})
 RESERVED_IDS = frozenset({"none", "decision", "context", "hints", "stakes"})
 TRAILER_FIELDS = (
     "SELECTED",
@@ -109,6 +110,15 @@ def validate_options(raw: object) -> tuple[Option, ...]:
     for entry in raw:
         if not isinstance(entry, Mapping):
             raise ArbitrationError("each option must be an object with id and statement")
+        # Silently ignoring an unknown key hides a typo in the one field whose
+        # spelling the whole protocol keys on: `{"id": .., "statment": ..}` would
+        # arbitrate an empty option rather than telling the caller.
+        unknown = sorted(k for k in entry if k not in OPTION_KEYS)
+        if unknown:
+            raise ArbitrationError(
+                f"option object has unknown key(s): {', '.join(unknown)} "
+                f"(expected only {', '.join(sorted(OPTION_KEYS))})"
+            )
         oid = str(entry.get("id", "")).strip()
         statement = str(entry.get("statement", "")).strip()
         if not oid:
@@ -126,6 +136,73 @@ def validate_options(raw: object) -> tuple[Option, ...]:
         seen.add(oid)
         out.append(Option(id=oid, statement=statement))
     return tuple(out)
+
+
+# Framing bounds, enforced at preflight so an input-only defect never costs a
+# cleaner call. The numbers come from the first production run (issue #8): dense
+# ~1,800-char options and a ~4,500-char decision could not be round-tripped through
+# the cleaner without the cross-vendor attester scoring a fidelity change, while the
+# hoisted shape it converged on — shared mechanism in `context`, each option stating
+# only scope-of-adoption — landed at ~800 chars and passed first time.
+MAX_OPTION_CHARS = 1200
+MAX_DECISION_CHARS = 2500
+# `context` is the designated home for detail, and it is not per-option, so its
+# length cannot be a vote between the options. It gets a far looser bound.
+MAX_CONTEXT_CHARS = 20000
+OPTION_RATIO_MAX = 2.0
+
+_HOIST_REMEDY = (
+    "Hoist the shared mechanism into `context` — including the full specification "
+    "of what only one option adopts — and leave each option statement to say only "
+    "which of it is adopted, and what follows. Options then describe "
+    "scope-of-adoption rather than one describing mechanism and the other its "
+    "absence, and they equalize naturally."
+)
+
+
+def preflight_framing(
+    *, decision: str, context: str, options: Sequence[Option]
+) -> None:
+    """Reject framing defects visible in the caller's own input, before spending a
+    cleaner call on them.
+
+    Three of the first four production invocations died after two Opus attempts each
+    on exactly these arithmetic checks (issue #8). Same measurements, same message
+    shapes — just moved ahead of the spend.
+
+    The inter-option ratio is checked HERE rather than only after cleaning because
+    it is structural: "adopt X, with this precedence and this invariant" carries more
+    mechanism to state than "don't", so any scope decision trips it by construction
+    and no amount of re-cleaning fixes it. Telling the caller up front, with the
+    remedy, is the only useful response.
+    """
+    lengths = {o.id: max(1, len(o.statement)) for o in options}
+    if lengths:
+        longest = max(lengths, key=lengths.__getitem__)
+        shortest = min(lengths, key=lengths.__getitem__)
+        if lengths[longest] / lengths[shortest] > OPTION_RATIO_MAX:
+            raise ArbitrationError(
+                "options are not equalized: "
+                f"{longest} is {lengths[longest]} chars, {shortest} is "
+                f"{lengths[shortest]} (ratio must be <= {OPTION_RATIO_MAX}). "
+                + _HOIST_REMEDY
+            )
+    for oid, n in lengths.items():
+        if n > MAX_OPTION_CHARS:
+            raise ArbitrationError(
+                f"option statement {oid} is {n} chars (max {MAX_OPTION_CHARS}). "
+                + _HOIST_REMEDY
+            )
+    if len(decision) > MAX_DECISION_CHARS:
+        raise ArbitrationError(
+            f"decision is {len(decision)} chars (max {MAX_DECISION_CHARS}). "
+            "Move the supporting facts into `context`; the decision field states "
+            "what is being chosen, not the evidence for it."
+        )
+    if len(context) > MAX_CONTEXT_CHARS:
+        raise ArbitrationError(
+            f"context is {len(context)} chars (max {MAX_CONTEXT_CHARS})"
+        )
 
 
 def canonical_order(options: Iterable[Option]) -> tuple[Option, ...]:
@@ -766,14 +843,29 @@ def substantiation(
     *,
     resolve: Callable[[Citation], Region | None],
     carried: Mapping[str, Sequence[Region]] | None = None,
+    moved: Collection[str] | None = None,
 ) -> dict[str, bool]:
     """Per-engine substantiation.
 
-    Round 1 (`carried` None): the decisive citation must resolve. Round 2: its
-    anchor must land inside a region carried to that engine — the gate proved
-    evidence was *available*, and this is what proves it was *used*. Supporting
-    `CITATIONS` never substantiate: otherwise a decider could keep its own prior
-    region as its real reason and merely append the novel one.
+    Round 1 (`carried` None): the decisive citation must resolve.
+
+    Round 2: the carried-grounding rule is **anti-capitulation** — it proves a vendor
+    that changed its mind was moved by evidence rather than by the mere fact of
+    disagreement. So it applies only to vendors in `moved`. A vendor that held its
+    round-1 selection has no capitulation to disprove and its position was already
+    substantiated on its own resolved citation, so it needs only a citation that
+    resolves.
+
+    Applying it to every vendor produced a false negative on the first production run
+    (issue #8): both vendors agreed, the flipping vendor grounded correctly on carried
+    bytes, and the run still returned UNRESOLVED because the vendor that had been
+    right all along cited the producer code instead of the artifact. The only region
+    it could have grounded in was the other vendor's argument for the option it had
+    rejected — so the rule demanded it cite the evidence against its own conclusion.
+
+    `moved=None` means "treat every vendor as moved", the conservative reading.
+    Supporting `CITATIONS` never substantiate: otherwise a decider could keep its own
+    prior region as its real reason and merely append the novel one.
     """
     out: dict[str, bool] = {}
     for vote in votes:
@@ -785,6 +877,9 @@ def substantiation(
             out[vote.engine] = False
             continue
         if carried is None:
+            out[vote.engine] = True
+            continue
+        if moved is not None and vote.engine not in moved:
             out[vote.engine] = True
             continue
         out[vote.engine] = any(

--- a/src/paranoia_local/arbitration.py
+++ b/src/paranoia_local/arbitration.py
@@ -17,8 +17,9 @@ that was not reached:
 - **Regions, not anchors.** A citation is the interval actually carried; sameness
   is interval intersection, substantiation is strict point-in-interval (§2.5).
 - **Substantiation.** Agreement counts only when each converging vote's decisive
-  citation resolves, and in round 2 lands inside a region novel to its own vendor
-  (§3.5).
+  citation resolves, and in round 2 additionally lands inside a region novel to its
+  own vendor — for any vendor that CHANGED selection, or whose round-1 vote was
+  itself unsubstantiated (§3.5).
 
 Everything here is deterministic and free of I/O: the git reads it needs are
 injected by the caller.
@@ -161,7 +162,7 @@ _HOIST_REMEDY = (
 
 
 def preflight_framing(
-    *, decision: str, context: str, options: Sequence[Option]
+    *, decision: str, context: str, options: Sequence[Option], cleaned: bool = True
 ) -> None:
     """Reject framing defects visible in the caller's own input, before spending a
     cleaner call on them.
@@ -176,6 +177,12 @@ def preflight_framing(
     and no amount of re-cleaning fixes it. Telling the caller up front, with the
     remedy, is the only useful response.
     """
+    # The ratio is a BIAS bound — asymmetric detail is an argument regardless of
+    # wording — so it holds whether or not a cleaner runs. The character caps are
+    # CLEANER-CAPACITY bounds, justified by what can be round-tripped through the
+    # cleaner without the attester scoring a fidelity change, so `clean: false` (which
+    # sends the caller's statements verbatim and never invokes a cleaner) is not
+    # subject to them.
     lengths = {o.id: max(1, len(o.statement)) for o in options}
     if lengths:
         longest = max(lengths, key=lengths.__getitem__)
@@ -187,6 +194,8 @@ def preflight_framing(
                 f"{lengths[shortest]} (ratio must be <= {OPTION_RATIO_MAX}). "
                 + _HOIST_REMEDY
             )
+    if not cleaned:
+        return
     for oid, n in lengths.items():
         if n > MAX_OPTION_CHARS:
             raise ArbitrationError(

--- a/src/paranoia_local/evidence.py
+++ b/src/paranoia_local/evidence.py
@@ -31,7 +31,18 @@ _MAX_SYMLINK_HOPS = 8
 SNAPSHOT_REF_PREFIX = "refs/paranoia/arbitrate"
 
 
-def _git(args: list[str], cwd: Path, *, check: bool = True) -> str:
+def _git(args: list[str], cwd: Path, *, check: bool = True, raw: bool = False) -> str:
+    """`raw=True` decodes with `surrogateescape` instead of `replace`.
+
+    For the NUL-delimited tree reads this is the difference between a faithful path set
+    and a lossy one: `replace` maps every undecodable byte to U+FFFD, so two distinct
+    filenames can collapse to one string and the set no longer describes the tree.
+    Since citation and hint paths are matched against that set literally, a collapsed
+    entry silently makes a real file unciteable. `surrogateescape` is round-trippable
+    and is already this repository's convention for filesystem bytes
+    (`orientation.py`). No caller- or model-supplied string can contain a lone
+    surrogate, so such a path simply never matches rather than matching the wrong file.
+    """
     r = subprocess.run(["git", *args], cwd=cwd, capture_output=True)
     if r.returncode != 0:
         if not check:
@@ -39,7 +50,14 @@ def _git(args: list[str], cwd: Path, *, check: bool = True) -> str:
         raise RuntimeError(
             f"git {' '.join(args)} failed: {r.stderr.decode('utf-8', errors='replace').strip()}"
         )
-    return r.stdout.decode("utf-8", errors="replace")
+    return r.stdout.decode("utf-8", errors="surrogateescape" if raw else "replace")
+
+
+def printable(text: str) -> str:
+    """Surrogate-safe rendering for a path that reaches user-visible text — encoding a
+    lone surrogate to UTF-8 raises, and an error message must never be the thing that
+    crashes the run."""
+    return text.encode("utf-8", errors="backslashreplace").decode("utf-8")
 
 
 # --- ref movement -----------------------------------------------------------
@@ -86,7 +104,7 @@ def tree_paths(repo: Path, commit: str) -> frozenset[str]:
     match exists to avoid rather than cause. It also splits on NUL, so a path
     containing a newline cannot forge two entries.
     """
-    out = _git(["ls-tree", "-r", "--name-only", "-z", commit], repo)
+    out = _git(["ls-tree", "-r", "--name-only", "-z", commit], repo, raw=True)
     return frozenset(part for part in out.split("\0") if part)
 
 
@@ -101,7 +119,7 @@ def symlink_map(repo: Path, commit: str) -> dict[str, str]:
     # `-z` for the same reason as `tree_paths`: a quoted key would never match the
     # verbatim path a citation carries, so an aliased file would silently stop being
     # canonicalized.
-    out = _git(["ls-tree", "-r", "-z", commit], repo)
+    out = _git(["ls-tree", "-r", "-z", commit], repo, raw=True)
     links: dict[str, str] = {}
     for line in out.split("\0"):
         if not line:
@@ -384,8 +402,11 @@ def validate_hints(repo: Path, commit: str, hints: list[dict]) -> list[dict]:
     present = tree_paths(repo, commit)
     out: list[dict] = []
     for hint in hints:
-        raw = str(hint.get("path", "")).strip()
-        if not raw:
+        # NOT stripped: " spaced.py " and "spaced.py" are two tracked files, and
+        # trimming one onto the other is the same substitution the rest of this module
+        # refuses to make.
+        raw = str(hint.get("path", ""))
+        if not raw.strip():
             raise ArbitrationError("a file hint has no path")
         if raw.startswith("/") or ".." in raw.split("/"):
             raise ArbitrationError(

--- a/src/paranoia_local/evidence.py
+++ b/src/paranoia_local/evidence.py
@@ -75,8 +75,19 @@ def refs_digest(repo: Path) -> str:
 
 
 def tree_paths(repo: Path, commit: str) -> frozenset[str]:
-    out = _git(["ls-tree", "-r", "--name-only", commit], repo)
-    return frozenset(line for line in out.splitlines() if line)
+    """Every path in the snapshot, byte-faithfully.
+
+    `-z` is load-bearing, not a style choice. Without it `ls-tree --name-only` QUOTES
+    any path containing a backslash, a quote, or a non-ASCII byte —
+    `policy\\choice.py` comes back as `"policy\\\\choice.py"` — and `core.quotePath=false`
+    does not suppress it for this command. Since citation and hint paths are matched
+    against this set literally and never normalized, a quoted entry would make every
+    legitimate reference to such a file unresolvable, which is the failure the literal
+    match exists to avoid rather than cause. It also splits on NUL, so a path
+    containing a newline cannot forge two entries.
+    """
+    out = _git(["ls-tree", "-r", "--name-only", "-z", commit], repo)
+    return frozenset(part for part in out.split("\0") if part)
 
 
 def symlink_map(repo: Path, commit: str) -> dict[str, str]:
@@ -87,9 +98,12 @@ def symlink_map(repo: Path, commit: str) -> dict[str, str]:
     contents, so an uncanonicalized alias citation would carry a filename as
     though it were source, and would key as a different region from its referent.
     """
-    out = _git(["ls-tree", "-r", commit], repo)
+    # `-z` for the same reason as `tree_paths`: a quoted key would never match the
+    # verbatim path a citation carries, so an aliased file would silently stop being
+    # canonicalized.
+    out = _git(["ls-tree", "-r", "-z", commit], repo)
     links: dict[str, str] = {}
-    for line in out.splitlines():
+    for line in out.split("\0"):
         if not line:
             continue
         meta, _, path = line.partition("\t")
@@ -377,11 +391,19 @@ def validate_hints(repo: Path, commit: str, hints: list[dict]) -> list[dict]:
             raise ArbitrationError(
                 f"file hint {raw!r} must be a repo-relative path inside the snapshot"
             )
-        norm = "/".join(seg for seg in raw.replace("\\", "/").split("/") if seg not in ("", "."))
-        if norm not in present:
+        # NOT normalized, for the same reason citation paths are not (see
+        # `arbitration._normalize_path`): every rewrite can map one tracked file onto
+        # another. `policy\\choice.py` is a legal POSIX filename that git tracks
+        # distinctly from `policy/choice.py`, so folding the separator would send BOTH
+        # deciders to a different file's bytes — and since the attester is shown the
+        # path the server resolved, not the one the caller wrote, the swap is invisible
+        # to it. Literal tree membership, and a caller using `./` or a backslash as an
+        # alias gets an error naming the exact path to write instead.
+        if raw not in present:
             raise ArbitrationError(
-                f"file hint {norm!r} is not in the snapshot "
-                "(ignored/untracked files are not captured)"
+                f"file hint {raw!r} is not in the snapshot as spelled "
+                "(paths are used verbatim and must match a tracked path exactly; "
+                "ignored/untracked files are not captured)"
             )
-        out.append({"path": norm, "reason": str(hint.get("reason", "")).strip()})
+        out.append({"path": raw, "reason": str(hint.get("reason", "")).strip()})
     return out

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -175,9 +175,11 @@ You are given, field by field, the ORIGINAL text and the CLEANED text. Judge two
 
 Separately, read the STAKES text, which was deliberately NOT cleaned. Does it advocate for an option or pre-empt the decision ("this is low-stakes so just pick the fast one")? Stating a real deployment boundary is not advocacy; steering the answer is.
 
-Output EXACTLY these three lines, verbatim, nothing before or after:
+Output EXACTLY these three lines, nothing before or after. The FIDELITY line must
+name EVERY field that appears in the FIELD BY FIELD section below and NOTHING else —
+fields absent from it were never supplied and are not yours to judge:
 
-FIDELITY: decision PRESERVED|CHANGED; context PRESERVED|CHANGED; hints PRESERVED|CHANGED; <id> PRESERVED|CHANGED; <id> PRESERVED|CHANGED
+FIDELITY: <one "<field> PRESERVED" or "<field> CHANGED" per field, semicolon-separated>
 NEUTRALITY: PASS
 NEUTRALITY: FAIL <which option the packet favours, and the words that do it>
 STAKES-ADVOCACY: NONE

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -193,7 +193,13 @@ TOOLS: list[Tool] = [
             "counterbalanced option order under its own opaque labels. Python computes the "
             "verdict: CONVERGED only on a unanimous, unblocked, evidence-substantiated choice. "
             "On divergence it runs one fact-only reconciliation round, and only when there is "
-            "novel evidence to carry. Up to 8 agent turns across both subscriptions."
+            "novel evidence to carry. Up to 8 agent turns across both subscriptions. "
+            "SHAPE THE INPUT LIKE THIS: put every shared fact and the FULL specification of "
+            "whatever only one option adopts into `context`, prefaced as 'the rules under "
+            "consideration, if adopted'; leave each option statement to say only how much of it "
+            "is adopted and what follows. Options then describe scope-of-adoption rather than "
+            "one describing mechanism and the other its absence, so they equalize naturally "
+            "(~800 chars each is typical). Framing bounds are checked before anything is spent."
         ),
         inputSchema={
             "type": "object",
@@ -204,7 +210,7 @@ TOOLS: list[Tool] = [
                 },
                 "decision": {
                     "type": "string",
-                    "description": "What is being decided, and every property that bears on it. State it neutrally; your own recommendation will be stripped, and including it only wastes a cleaning round.",
+                    "description": "What is being decided, and the properties that bear on it — NOT the evidence for it, which belongs in `context` (max 2500 chars). State it neutrally; your own recommendation will be stripped, and including it only wastes a cleaning round.",
                 },
                 "options": {
                     "type": "array",
@@ -214,14 +220,14 @@ TOOLS: list[Tool] = [
                         "type": "object",
                         "properties": {
                             "id": {"type": "string", "description": "Stable id — the vocabulary of the record. Never shown to a decider."},
-                            "statement": {"type": "string", "description": "What this option is. Self-contained: never reference another option by id, since the two deciders see different orders."},
+                            "statement": {"type": "string", "description": "What this option is (max 1200 chars, and no option may be more than 2x the length of the shortest — asymmetric detail is an argument regardless of wording). Say only what this option adopts and what follows; hoist the shared mechanism into `context`. Self-contained: never reference another option by id, since the two deciders see different orders."},
                         },
                         "required": ["id", "statement"],
                     },
                     "description": "2-4 mutually exclusive options, each with a caller-stable id. Array order is irrelevant — canonical order is derived by sorting ids.",
                 },
                 "stakes": _STAKES_REQUIRED,
-                "context": {"type": "string", "description": "Background the deciders need. Neutralized before they see it."},
+                "context": {"type": "string", "description": "Background the deciders need, and the designated home for detail: the shared facts, and the full specification of whatever only one option adopts (max 20000 chars). Not per-option, so its length cannot be a vote between options. Neutralized before they see it.",},
                 "files": {
                     "type": "array",
                     "items": {

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -1141,3 +1141,84 @@ def test_clean_false_still_enforces_equalization(repo: Path, tmp_path: Path):
                           {"id": "B", "statement": "y" * 900}])
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "not equalized" in report
+
+
+def test_a_cleaner_that_omits_a_supplied_context_block_fails(repo: Path, tmp_path: Path):
+    """Round-2 review blocker: omitting the block entirely was invisible. Rendered back
+    to the attester as `None.` it matched a caller context that also reads `None.`, so
+    fidelity passed while the deciders received nothing."""
+    agent = Agent(lambda e, r: "opt-float", cleaner=(
+        "=== DECISION ===\nd\n\n"
+        "=== OPTIONS ===\nopt-float: Store the threshold as a float.\n"
+        "opt-decimal: Store the threshold as a Decimal.\n\n"
+        "=== HINTS ===\nNone.\n"
+    ))
+    report = run(repo, agent, tmp_path, context="None.")
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "dropped the supplied context" in report
+
+
+def test_the_attester_template_names_exactly_the_fields_it_is_given(repo: Path, tmp_path: Path):
+    """Round-2 review: the parser's expected set became dynamic while the prompt still
+    hardcoded `context` and `hints`. An attester obeying the prompt verbatim was then
+    rejected for covering unknown fields — reproducing the production false failure this
+    branch exists to remove. The prompt and the parser must agree."""
+    from paranoia_local import prompts
+
+    assert "context PRESERVED|CHANGED; hints PRESERVED|CHANGED" not in prompts.ATTEST_INSTRUCTIONS
+    assert "EVERY field that appears in the FIELD BY FIELD section" in prompts.ATTEST_INSTRUCTIONS
+
+    seen: dict[str, str] = {}
+
+    class Recorder(Agent):
+        def __call__(self, **kw):
+            if "TEXT AUDITOR" in kw["instructions"]:
+                seen["body"] = kw["body"]
+                # answer with exactly the fields the body carries, as instructed
+                fields = [
+                    line[1:-1] for line in kw["body"].splitlines()
+                    if line.startswith("[") and line.endswith("]")
+                ]
+                self.attest = (
+                    "FIDELITY: " + "; ".join(f"{f} PRESERVED" for f in fields) + "\n"
+                    "NEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"
+                )
+            return super().__call__(**kw)
+
+    report = run(repo, Recorder(lambda e, r: "opt-float"), tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert "[context]" not in seen["body"] and "[hints]" not in seen["body"]
+
+
+def test_the_attester_template_covers_context_and_hints_when_supplied(repo: Path, tmp_path: Path):
+    """The other half: when the caller DOES supply them, they must be in the body and
+    the parser must expect them."""
+    seen: dict[str, str] = {}
+
+    class Recorder(Agent):
+        def __call__(self, **kw):
+            if "TEXT AUDITOR" in kw["instructions"]:
+                seen["body"] = kw["body"]
+                fields = [
+                    line[1:-1] for line in kw["body"].splitlines()
+                    if line.startswith("[") and line.endswith("]")
+                ]
+                self.attest = (
+                    "FIDELITY: " + "; ".join(f"{f} PRESERVED" for f in fields) + "\n"
+                    "NEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"
+                )
+            if "NEUTRALIZER" in kw["instructions"]:
+                opts = "\n".join(f"{k}: {v}" for k, v in self.statements.items())
+                return (
+                    "=== DECISION ===\nd\n\n"
+                    f"=== OPTIONS ===\n{opts}\n\n"
+                    "=== CONTEXT ===\nThe threshold is written to a log line.\n\n"
+                    "=== HINTS ===\n- app.py: the module\n"
+                )
+            return super().__call__(**kw)
+
+    report = run(repo, Recorder(lambda e, r: "opt-float"), tmp_path,
+                 context="The threshold is written to a log line.",
+                 files=[{"path": "app.py", "reason": "the module"}])
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert "[context]" in seen["body"] and "[hints]" in seen["body"]

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -1071,3 +1071,73 @@ def test_the_cleaner_may_not_worsen_the_length_asymmetry(repo: Path, tmp_path: P
     report = run(repo, agent, tmp_path)
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "equaliz" in report.lower()
+
+
+def test_a_held_vote_that_was_never_substantiated_must_still_ground(repo: Path, tmp_path: Path):
+    """Round-1 review blocker. Waiving carried grounding for a holder rests on that
+    holder already being substantiated. A vendor that reached round 2 with no resolving
+    decisive citation has no such standing, and must not ride to CONVERGED on a fresh
+    citation that merely resolves while the other vendor moves onto its supporting
+    region."""
+    (repo / "elsewhere.py").write_text("e\n" * 40)
+    (repo / "third.py").write_text("t\n" * 40)
+    commit_all(repo, "elsewhere and third")
+    agent = Agent(
+        lambda engine, rnd: "opt-float" if (engine == "codex" and rnd == 1) else "opt-decimal",
+        extra={
+            # claude picks decimal in round 1 with NO decisive citation, but supplies a
+            # supporting region so reconciliation is still permitted
+            ("claude", 1): {"decisive": "NONE", "citations": "app.py:4"},
+            ("codex", 1): {"decisive": "elsewhere.py:20"},
+            # codex flips onto claude's supporting region
+            ("codex", 2): {"decisive": "app.py:4"},
+            # claude holds, on a citation that resolves but was NEVER carried to it
+            ("claude", 2): {"decisive": "third.py:20"},
+        },
+    )
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "UNRESOLVED"
+    assert "claude" in report
+
+
+def test_a_caller_context_that_reads_None_is_not_swallowed(repo: Path, tmp_path: Path):
+    """Round-1 review blocker: `None.` is a sentinel only when the caller supplied no
+    context. As a real datum — the observed output of the thing being adjudicated — it
+    must reach the deciders verbatim."""
+    agent = Agent(lambda e, r: "opt-float", cleaner=(
+        "=== DECISION ===\nd\n\n"
+        "=== OPTIONS ===\nopt-float: Store the threshold as a float.\n"
+        "opt-decimal: Store the threshold as a Decimal.\n\n"
+        "=== CONTEXT ===\nNone.\n\n"
+        "=== HINTS ===\nNone.\n"
+    ), attest=(
+        "FIDELITY: decision PRESERVED; context PRESERVED; opt-float PRESERVED; "
+        "opt-decimal PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"
+    ))
+    report = run(repo, agent, tmp_path, context="None.")
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    for call in agent.calls:
+        if call["cwd"] is None:
+            continue
+        assert "None." in call["body"], "the caller's context must reach the deciders"
+
+
+def test_clean_false_is_not_subject_to_cleaner_capacity_bounds(repo: Path, tmp_path: Path):
+    """Round-1 review: the char caps are justified by cleaner round-trip capacity, and
+    `clean: false` never invokes a cleaner. The equalization ratio is a bias bound and
+    still applies."""
+    long_a = "a" * 2000
+    long_b = "b" * 2000
+    report = run(repo, Agent(lambda e, r: "A", statements={"A": long_a, "B": long_b}),
+                 tmp_path, clean=False,
+                 options=[{"id": "A", "statement": long_a}, {"id": "B", "statement": long_b}])
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert trailer_field(report, "CLEANING") == "skipped"
+
+
+def test_clean_false_still_enforces_equalization(repo: Path, tmp_path: Path):
+    report = run(repo, Agent(lambda e, r: "A"), tmp_path, clean=False,
+                 options=[{"id": "A", "statement": "x" * 300},
+                          {"id": "B", "statement": "y" * 900}])
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "not equalized" in report

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -59,7 +59,16 @@ def cleaner_reply(ids_to_statements: dict[str, str]) -> str:
 
 
 ATTEST_OK = (
-    "FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+    "FIDELITY: decision PRESERVED; "
+    "opt-float PRESERVED; opt-decimal PRESERVED\n"
+    "NEUTRALITY: PASS\n"
+    "STAKES-ADVOCACY: NONE\n"
+)
+
+
+# For callers that DO supply files, `hints` becomes an attestable field.
+ATTEST_OK_WITH_HINTS = (
+    "FIDELITY: decision PRESERVED; hints PRESERVED; "
     "opt-float PRESERVED; opt-decimal PRESERVED\n"
     "NEUTRALITY: PASS\n"
     "STAKES-ADVOCACY: NONE\n"
@@ -509,7 +518,9 @@ def test_unequal_cleaned_options_are_retried_then_fail(repo: Path, tmp_path: Pat
         }),
     )
     report = run(repo, agent, tmp_path)
-    assert "not equalized" in report
+    # Same behaviour, sharper claim: the caller's framing was equalized, so the skew
+    # is the cleaner's doing.
+    assert "less equalized" in report
     assert len([c for c in agent.calls if "NEUTRALIZER" in c["instructions"]]) == 2
 
 
@@ -518,7 +529,7 @@ def test_attestation_failure_retries_once_then_fails(repo: Path, tmp_path: Path)
     attester until it passed, which is optimization, not attestation."""
     agent = Agent(
         lambda e, r: "opt-float",
-        attest=("FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        attest=("FIDELITY: decision PRESERVED; "
                 "opt-float CHANGED; opt-decimal PRESERVED\nNEUTRALITY: PASS\n"
                 "STAKES-ADVOCACY: NONE\n"),
     )
@@ -531,7 +542,7 @@ def test_stakes_advocacy_fails_to_the_caller(repo: Path, tmp_path: Path):
     """stakes is not the cleaner's to fix, so this goes back to the caller."""
     agent = Agent(
         lambda e, r: "opt-float",
-        attest=("FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        attest=("FIDELITY: decision PRESERVED; "
                 "opt-float PRESERVED; opt-decimal PRESERVED\nNEUTRALITY: PASS\n"
                 "STAKES-ADVOCACY: PRESENT 'just pick the fast one'\n"),
     )
@@ -625,7 +636,8 @@ def test_cleaned_hint_reason_reaches_the_deciders_not_the_original(repo: Path):
                 )
             return super().__call__(**kw)
 
-    agent = HintCleaner(lambda e, r: "opt-float")
+    # this caller DOES supply files, so `hints` is an attestable field for it
+    agent = HintCleaner(lambda e, r: "opt-float", attest=ATTEST_OK_WITH_HINTS)
     report = run(repo, agent, tmp_path=Path(repo.parent), files=[
         {"path": "app.py", "reason": "the APPROVED implementation, obviously"}
     ])
@@ -652,13 +664,13 @@ def test_attester_sees_the_real_original_hints(repo: Path, tmp_path: Path):
         # missing every field but one
         "FIDELITY: decision PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n",
         # a value that is neither PRESERVED nor CHANGED
-        ("FIDELITY: decision UNKNOWN; context PRESERVED; hints PRESERVED; "
+        ("FIDELITY: decision UNKNOWN; "
          "opt-float PRESERVED; opt-decimal PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"),
         # no neutrality verdict
-        ("FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        ("FIDELITY: decision PRESERVED; "
          "opt-float PRESERVED; opt-decimal PRESERVED\nSTAKES-ADVOCACY: NONE\n"),
         # no stakes verdict
-        ("FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        ("FIDELITY: decision PRESERVED; "
          "opt-float PRESERVED; opt-decimal PRESERVED\nNEUTRALITY: PASS\n"),
     ],
 )
@@ -887,7 +899,7 @@ def test_qualified_attestation_verdicts_are_not_accepted(repo: Path, tmp_path: P
     """Round-8 blocker: prefix matching let a demonstrably biased packet be stamped
     `attested`, sending the same bias to both deciders."""
     fidelity = (
-        "FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        "FIDELITY: decision PRESERVED; "
         "opt-float PRESERVED; opt-decimal PRESERVED\n"
     )
     agent = Agent(lambda e, r: "opt-float", attest=fidelity + verdicts)
@@ -899,7 +911,7 @@ def test_qualified_attestation_verdicts_are_not_accepted(repo: Path, tmp_path: P
 def test_stakes_advocacy_present_with_the_words_still_fails_to_the_caller(repo: Path, tmp_path: Path):
     agent = Agent(
         lambda e, r: "opt-float",
-        attest=("FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; "
+        attest=("FIDELITY: decision PRESERVED; "
                 "opt-float PRESERVED; opt-decimal PRESERVED\nNEUTRALITY: PASS\n"
                 "STAKES-ADVOCACY: PRESENT 'just pick the fast one'\n"),
     )
@@ -926,3 +938,136 @@ def test_commentary_in_the_attestation_is_rejected(repo: Path, tmp_path: Path, e
 def test_duplicate_attestation_verdicts_are_rejected(repo: Path, tmp_path: Path):
     agent = Agent(lambda e, r: "opt-float", attest=ATTEST_OK + "NEUTRALITY: PASS\n")
     assert trailer_field(run(repo, agent, tmp_path), "ARBITRATION") == "FAILED"
+
+
+# --- field-report fixes (issue #8) -------------------------------------------
+
+
+def test_the_field_scenario_now_converges(repo: Path, tmp_path: Path):
+    """Issue #8's actual run: round 1 diverges, codex flips onto claude's carried
+    region, claude holds and cites the producer code instead of the artifact. That
+    is a unanimous verdict on accurate citations and must not be UNRESOLVED."""
+    (repo / "writer.py").write_text("w\n" * 40)
+    (repo / "manifest.json").write_text("m\n" * 40)
+    (repo / "test_writer.py").write_text("t\n" * 40)
+    commit_all(repo, "field shapes")
+    agent = Agent(
+        lambda engine, rnd: "opt-float" if (engine == "codex" and rnd == 1) else "opt-decimal",
+        extra={
+            ("codex", 1): {"decisive": "test_writer.py:20"},
+            ("claude", 1): {"decisive": "manifest.json:20"},
+            # codex flips onto the region claude produced -> carried grounding
+            ("codex", 2): {"decisive": "manifest.json:20", "authority": "human-owner"},
+            # claude holds, and goes deeper: the producer code, never carried
+            ("claude", 2): {"decisive": "writer.py:20"},
+        },
+    )
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert trailer_field(report, "SELECTED") == "opt-decimal"
+    assert trailer_field(report, "ROUNDS") == "2"
+    assert trailer_field(report, "ADVISORY") == "human-owner (flagged by: codex)"
+
+
+def test_a_flip_onto_uncarried_evidence_is_still_unsubstantiated(repo: Path, tmp_path: Path):
+    """The anti-capitulation purpose end to end."""
+    (repo / "elsewhere.py").write_text("e\n" * 40)
+    commit_all(repo, "elsewhere")
+    agent = Agent(
+        lambda engine, rnd: "opt-float" if (engine == "codex" and rnd == 1) else "opt-decimal",
+        extra={("codex", 2): {"decisive": "elsewhere.py:20"}},
+    )
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "UNRESOLVED"
+    assert "codex" in report
+
+
+def test_attestation_does_not_cover_fields_the_caller_never_supplied(repo: Path, tmp_path: Path):
+    """Issue #8 fix 4: call 1 failed on `fidelity changed: ['context']` for a field
+    the caller had no control over."""
+    agent = Agent(lambda e, r: "opt-float", attest=(
+        "FIDELITY: decision PRESERVED; opt-float PRESERVED; opt-decimal PRESERVED\n"
+        "NEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"
+    ))
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    attest_bodies = [c["body"] for c in agent.calls if "TEXT AUDITOR" in c["instructions"]]
+    assert attest_bodies and "context" not in attest_bodies[0].lower().split("=== stakes")[0]
+
+
+def test_a_cleaner_invented_context_is_rejected(repo: Path, tmp_path: Path):
+    """The other half of fix 4: if the caller supplied no context, a populated one is
+    the cleaner ADDING facts, which it is forbidden to do."""
+    agent = Agent(lambda e, r: "opt-float", cleaner=(
+        "=== DECISION ===\nd\n\n"
+        "=== OPTIONS ===\nopt-float: Store the threshold as a float.\n"
+        "opt-decimal: Store the threshold as a Decimal.\n\n"
+        "=== CONTEXT ===\nThe system already uses floats everywhere.\n\n"
+        "=== HINTS ===\nNone.\n"
+    ))
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "context" in report.lower()
+
+
+def test_a_failed_run_writes_an_audit_record(repo: Path, tmp_path: Path):
+    """Issue #8 fix 7: the three field rejections left nothing on disk, so gate churn
+    was unmeasurable after the fact."""
+    log_dir = tmp_path / "logs"
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path,
+                 options=[{"id": "A", "statement": "x" * 400},
+                          {"id": "B", "statement": "y" * 1300}])
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "AUDIT") != "none"
+    written = list(log_dir.glob("*arbitrate*"))
+    assert written, "a FAILED run must still write an audit record"
+    import json
+    rec = json.loads(written[0].read_text())
+    assert rec["outcome"] == "FAILED"
+    assert "not equalized" in rec["reason"]
+    assert rec["raw_input"]["options"]
+
+
+def test_preflight_runs_before_any_cleaner_call(repo: Path, tmp_path: Path):
+    """Fix 5: the whole point is not spending Opus on input-only defects."""
+    agent = Agent(lambda e, r: "opt-float")
+    run(repo, agent, tmp_path,
+        options=[{"id": "A", "statement": "x" * 400}, {"id": "B", "statement": "y" * 1300}])
+    assert agent.calls == [], "no agent should have been invoked"
+
+
+def test_the_cleaner_may_compress_narration_without_tripping_the_floor(repo: Path, tmp_path: Path):
+    """Fix 3: option A's text was mostly consequence-narration and the cleaner cut it
+    to 0.09x. Meaning-preservation is the attester's job, not a char ratio's."""
+    long_a = "Ship the core only. " + "Outcome under this option: the manifest still fails. " * 12
+    long_b = "Ship the core plus both rules. " + "Outcome under this option: the manifest verifies. " * 12
+    agent = Agent(
+        lambda e, r: "A",
+        # label lookup matches on what the deciders actually see: the CLEANED text
+        statements={"A": "a" * 90, "B": "b" * 120},
+        cleaner=(
+            "=== DECISION ===\nd\n\n"
+            f"=== OPTIONS ===\nA: {'a' * 90}\nB: {'b' * 120}\n\n"
+            "=== HINTS ===\nNone.\n"
+        ),
+        attest=("FIDELITY: decision PRESERVED; A PRESERVED; B PRESERVED\n"
+                "NEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE\n"),
+    )
+    report = run(repo, agent, tmp_path,
+                 options=[{"id": "A", "statement": long_a}, {"id": "B", "statement": long_b}])
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+
+
+def test_the_cleaner_may_not_worsen_the_length_asymmetry(repo: Path, tmp_path: Path):
+    """The gate that survives: equalized input must not come back skewed."""
+    agent = Agent(
+        lambda e, r: "opt-float",
+        cleaner=(
+            "=== DECISION ===\nd\n\n"
+            f"=== OPTIONS ===\nopt-float: {'a' * 40}\nopt-decimal: {'b' * 600}\n\n"
+            "=== HINTS ===\nNone.\n"
+        ),
+    )
+    report = run(repo, agent, tmp_path)
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "equaliz" in report.lower()

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -737,3 +737,130 @@ def test_a_single_decisive_citation_parses():
 def test_decisive_none_parses_as_no_citation():
     p = _pres()
     assert arb.parse_verdict(trailer(p.items[0][0], decisive="NONE"), p).decisive is None
+
+
+# --- field-report fixes (issue #8) -------------------------------------------
+
+
+def test_a_vendor_that_held_its_selection_substantiates_on_its_own_evidence():
+    """Issue #8, top bug. The round-2 carried-grounding rule is anti-CAPITULATION,
+    so it belongs only to a vendor whose selection CHANGED. Applied to one that held
+    its round-1 position, the only region it could ground in was the other vendor's
+    argument for the option it rejected — so a unanimous, correctly-cited verdict
+    came back UNRESOLVED."""
+    held = vote("claude", "B", decisive=Citation("scripts/lib/writer.py", 184))
+    moved = vote("codex", "B", decisive=Citation("data/manifest.json", 436))
+    carried = {
+        # what each vendor gained from the other
+        "claude": [region("tests/test_writer.py", 929)],
+        "codex": [region("data/manifest.json", 436)],
+    }
+    sub = arb.substantiation(
+        [held, moved],
+        resolve=lambda c: region(c.path, c.line),
+        carried=carried,
+        moved={"codex"},
+    )
+    assert sub == {"claude": True, "codex": True}
+
+
+def test_a_vendor_that_flipped_still_needs_carried_grounding():
+    """The purpose survives intact: a flip onto evidence nobody carried is exactly
+    the unsubstantiated capitulation the gate exists to catch."""
+    flipped = vote("codex", "B", decisive=Citation("unrelated.py", 7))
+    held = vote("claude", "B", decisive=Citation("own.py", 3))
+    sub = arb.substantiation(
+        [flipped, held],
+        resolve=lambda c: region(c.path, c.line),
+        carried={"codex": [region("data/manifest.json", 436)], "claude": []},
+        moved={"codex"},
+    )
+    assert sub == {"codex": False, "claude": True}
+
+
+def test_both_vendors_swapping_positions_both_need_carried_grounding():
+    a = vote("codex", "B", decisive=Citation("carried_a.py", 5))
+    b = vote("claude", "A", decisive=Citation("nowhere.py", 5))
+    sub = arb.substantiation(
+        [a, b],
+        resolve=lambda c: region(c.path, c.line),
+        carried={"codex": [region("carried_a.py", 5)], "claude": [region("carried_b.py", 5)]},
+        moved={"codex", "claude"},
+    )
+    assert sub == {"codex": True, "claude": False}
+
+
+def test_a_held_selection_still_needs_a_citation_that_resolves():
+    """Relaxing the rule must not relax it to nothing."""
+    held = vote("claude", "B", decisive=Citation("gone.py", 4))
+    sub = arb.substantiation(
+        [held], resolve=lambda c: None, carried={"claude": []}, moved=set()
+    )
+    assert sub == {"claude": False}
+
+
+def test_preflight_rejects_unequal_option_lengths_before_spending_a_cleaner_call():
+    """Issue #8 fix 5: three of four field invocations burned two Opus attempts each
+    on defects visible in the input alone."""
+    with pytest.raises(arb.ArbitrationError) as exc:
+        arb.preflight_framing(
+            decision="d",
+            context="",
+            options=(Option("A_only", "x" * 400), Option("B_plus", "y" * 1300)),
+        )
+    msg = str(exc.value)
+    assert "not equalized" in msg and "1300" in msg and "400" in msg
+    # and it must teach the remedy, not just the bound
+    assert "context" in msg.lower()
+
+
+def test_preflight_rejects_an_over_long_option_statement():
+    with pytest.raises(arb.ArbitrationError) as exc:
+        arb.preflight_framing(
+            decision="d", context="",
+            options=(Option("A", "x" * 3000), Option("B", "y" * 3000)),
+        )
+    assert "option statement" in str(exc.value)
+    assert str(arb.MAX_OPTION_CHARS) in str(exc.value)
+
+
+def test_preflight_rejects_an_over_long_decision():
+    with pytest.raises(arb.ArbitrationError) as exc:
+        arb.preflight_framing(
+            decision="d" * 5000, context="",
+            options=(Option("A", "x" * 100), Option("B", "y" * 100)),
+        )
+    assert "decision" in str(exc.value) and str(arb.MAX_DECISION_CHARS) in str(exc.value)
+
+
+def test_preflight_accepts_the_hoisted_shape_that_worked_in_the_field():
+    """The shape the field report converged on: shared mechanism in context, each
+    option stating only scope-of-adoption. ~780 vs ~810 chars."""
+    arb.preflight_framing(
+        decision="How far should the fix go?" * 3,
+        context="The rules under consideration, if adopted: " + "spec. " * 800,
+        options=(Option("A_only", "x" * 780), Option("B_plus", "y" * 810)),
+    )
+
+
+def test_preflight_allows_a_long_context_because_it_is_the_hoist_target():
+    arb.preflight_framing(
+        decision="d", context="c" * (arb.MAX_CONTEXT_CHARS - 1),
+        options=(Option("A", "x" * 100), Option("B", "y" * 100)),
+    )
+    with pytest.raises(arb.ArbitrationError) as exc:
+        arb.preflight_framing(
+            decision="d", context="c" * (arb.MAX_CONTEXT_CHARS + 1),
+            options=(Option("A", "x" * 100), Option("B", "y" * 100)),
+        )
+    assert "context" in str(exc.value)
+
+
+def test_option_objects_reject_unknown_keys():
+    """Issue #8 fix 8: a stray "x" key was silently accepted and ignored."""
+    with pytest.raises(arb.ArbitrationError) as exc:
+        arb.validate_options([
+            {"id": "A", "statement": "a", "x": "typo"},
+            {"id": "B", "statement": "b"},
+        ])
+    assert "x" in str(exc.value)

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -592,3 +592,46 @@ def test_a_citation_to_a_path_git_would_quote_still_resolves(repo: Path):
         )
         assert got, f"{path} should resolve"
         assert want in got[1], f"{path} resolved to the wrong file's bytes"
+
+
+def test_a_hint_path_is_not_stripped(repo: Path):
+    """Round-4 blocker: `.strip()` folded one tracked file onto another. The repo
+    already tracks space-delimited filenames, so this was the same substitution class
+    the rest of the module refuses."""
+    (repo / " spaced.py ").write_text("PADDED\n" * 5)
+    (repo / "spaced.py").write_text("BARE\n" * 5)
+    commit_all(repo, "both spellings")
+    commit = snapshot(repo)
+    assert evidence.validate_hints(repo, commit, [{"path": " spaced.py "}]) == [
+        {"path": " spaced.py ", "reason": ""}
+    ]
+    assert evidence.validate_hints(repo, commit, [{"path": "spaced.py"}]) == [
+        {"path": "spaced.py", "reason": ""}
+    ]
+
+
+def test_tree_paths_do_not_collapse_on_undecodable_bytes(repo: Path):
+    """Round-4: `errors='replace'` mapped every undecodable byte to U+FFFD, so two
+    distinct filenames collapsed to one string and the membership set stopped
+    describing the tree."""
+    import os
+    (repo / os.fsdecode(b"caf\xe9.py")).write_bytes(b"LATIN1\n" * 5)
+    (repo / os.fsdecode(b"caf\xff.py")).write_bytes(b"OTHER\n" * 5)
+    commit_all(repo, "undecodable names")
+    paths = evidence.tree_paths(repo, snapshot(repo))
+    assert os.fsdecode(b"caf\xe9.py") in paths
+    assert os.fsdecode(b"caf\xff.py") in paths
+    assert "caf�.py" not in paths, "distinct names must not collapse"
+
+
+def test_an_escaping_symlink_with_an_undecodable_name_is_reportable(repo: Path):
+    """`surrogateescape` means a path can hold lone surrogates, and encoding one to
+    UTF-8 raises — an error message must never be the thing that crashes the run."""
+    import os
+    name = os.fsdecode(b"esc\xff")
+    (repo / name).symlink_to("../outside.py")
+    commit_all(repo, "undecodable escaping link")
+    escaping = evidence.escaping_symlinks(repo, snapshot(repo))
+    assert escaping
+    rendered = ", ".join(evidence.printable(e) for e in escaping)
+    rendered.encode("utf-8")  # must not raise

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -266,11 +266,36 @@ def test_symlink_target_is_read_verbatim(repo: Path):
     assert links["alias.py"] == " spaced.py "
 
 
-def test_valid_hint_normalizes(repo: Path):
+def test_a_hint_path_is_used_verbatim(repo: Path):
     commit = snapshot(repo)
-    assert evidence.validate_hints(repo, commit, [{"path": "./app.py", "reason": "the writer"}]) == [
+    assert evidence.validate_hints(repo, commit, [{"path": "app.py", "reason": "the writer"}]) == [
         {"path": "app.py", "reason": "the writer"}
     ]
+
+
+def test_a_hint_path_is_not_normalized(repo: Path):
+    """Round-3 blocker, and the same class as citation paths: every rewrite can map one
+    tracked file onto another. `./app.py` now errors rather than being folded."""
+    commit = snapshot(repo)
+    with pytest.raises(ArbitrationError, match="as spelled"):
+        evidence.validate_hints(repo, commit, [{"path": "./app.py"}])
+
+
+def test_a_backslash_hint_does_not_fold_onto_a_different_tracked_file(repo: Path):
+    """The concrete swap: git tracks both spellings as distinct files with different
+    bytes, and the attester is shown the path the SERVER resolved, so folding the
+    separator would steer both deciders invisibly."""
+    (repo / "policy").mkdir()
+    (repo / "policy" / "choice.py").write_text("FORWARD\n")
+    (repo / "policy\\choice.py").write_text("BACKSLASH\n")
+    commit_all(repo, "both spellings")
+    commit = snapshot(repo)
+    assert evidence.validate_hints(
+        repo, commit, [{"path": "policy\\choice.py"}]
+    ) == [{"path": "policy\\choice.py", "reason": ""}]
+    assert evidence.validate_hints(
+        repo, commit, [{"path": "policy/choice.py"}]
+    ) == [{"path": "policy/choice.py", "reason": ""}]
 
 
 @pytest.mark.parametrize("bad", ["/etc/hostname", "../outside.py", "missing.py"])
@@ -538,3 +563,32 @@ def test_a_dotdot_target_does_not_reject_the_whole_run(repo: Path):
     (repo / "pkg" / "link.py").symlink_to("../shared/x.py")
     commit_all(repo, "upward but inside")
     assert evidence.escaping_symlinks(repo, snapshot(repo)) == []
+
+
+def test_a_citation_to_a_path_git_would_quote_still_resolves(repo: Path):
+    """Latent break in the round-12 literal-membership closure, exposed by round 3:
+    `ls-tree --name-only` QUOTES paths containing a backslash or non-ASCII byte, so the
+    membership set held `"policy\\\\choice.py"` while a citation carries the raw name.
+    Every legitimate reference to such a file was therefore unresolvable — the opposite
+    of what the literal match is for. `-z` makes the read byte-faithful."""
+    (repo / "policy").mkdir()
+    (repo / "policy" / "choice.py").write_text("FORWARD\n" * 10)
+    (repo / "policy\\choice.py").write_text("BACKSLASH\n" * 10)
+    (repo / "café.py").write_text("UNICODE\n" * 10)
+    commit_all(repo, "paths git quotes")
+    commit = snapshot(repo)
+
+    paths = evidence.tree_paths(repo, commit)
+    assert "policy\\choice.py" in paths and "policy/choice.py" in paths
+    assert "café.py" in paths
+    assert not any(p.startswith('"') for p in paths), "no path may come back quoted"
+
+    links = evidence.LinkResolver(repo, commit, evidence.symlink_map(repo, commit))
+    for path, want in (("policy\\choice.py", "BACKSLASH"),
+                       ("policy/choice.py", "FORWARD"),
+                       ("café.py", "UNICODE")):
+        got = evidence.resolve_citation(
+            repo, Citation(path, 3), snapshot=commit, links=links, context=1
+        )
+        assert got, f"{path} should resolve"
+        assert want in got[1], f"{path} resolved to the wrong file's bytes"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -112,7 +112,7 @@ prompt="$(cat)"
 if printf '%s' "$prompt" | grep -q 'You are a NEUTRALIZER'; then
   body=$(printf '=== DECISION ===\nPick one.\n\n=== OPTIONS ===\nopt-a: Alpha approach.\nopt-b: Bravo approach.\n\n=== CONTEXT ===\nNone.\n\n=== HINTS ===\nNone.\n')
 elif printf '%s' "$prompt" | grep -q 'You are a TEXT AUDITOR'; then
-  body=$(printf 'FIDELITY: decision PRESERVED; context PRESERVED; hints PRESERVED; opt-a PRESERVED; opt-b PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE')
+  body=$(printf 'FIDELITY: decision PRESERVED; opt-a PRESERVED; opt-b PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE')
 else
   label=$(printf '%s' "$prompt" | grep -o 'OPTION-[0-9a-f]\{16\}' | head -1)
   body=$(printf 'Reasoning.\n\nSELECTED: %s\nSELECTED-RISK: NONE\nAUTHORITY: technical\nNEW-OPTION: NONE\nCONSTRAINT: A fact.\nDECISIVE-CITATION: app.py:4\nCITATIONS: NONE' "$label")


### PR DESCRIPTION
Closes #8.

`arbitrate` shipped after 22 review rounds. Then it met a real decision, and four
invocations later the field report in #8 recorded two things worth fixing: **the
framing gates rejected too easily and too late**, and **the tool discarded a correct
convergence** — the failure that halts an autonomous caller outright.

## The one that matters

Round-2 carried-evidence grounding was required of *every* vendor. It is
anti-**capitulation**, and capitulation is by definition a change, so it is owed only
by a vendor whose selection moved.

In the production run, Codex flipped onto exactly the region Claude had produced —
the reconciliation round working precisely as designed — while Claude held its
correct round-1 position and cited the *producer code* instead of re-citing the
artifact. Its gains set held exactly one region: **Codex's argument for the option it
had rejected**. The rule was demanding it cite the evidence against its own
conclusion, and it penalised the deeper piece of work. Unanimous, unblocked, every
citation verifying by hand — returned `UNRESOLVED`.

**Verified by replay, not by argument.** The run's snapshot was retained at
`refs/paranoia/arbitrate/20260727T152550-80970961d039`, which still resolves to the
audit's snapshot, so the real recorded votes were re-run through the new verdict code
against the real pinned tree:

| | claude | codex | outcome |
|---|---|---|---|
| old rule | `False` | `True` | `UNRESOLVED` |
| new rule | `True` | `True` | **`CONVERGED`** → `B_additive_plus_reanchoring` |

## The rest

- **Framing bounds are preflighted** (fix 5). Three of four invocations burned two
  Opus attempts each on arithmetic visible in the input alone. Same measurements, same
  message shapes, now before the spend.
- **Equalization is structural, so the remedy is an idiom** (fix 2). "Adopt X, with
  this precedence and this invariant" carries more mechanism to state than "don't", so
  any scope decision trips the ratio by construction. The supported shape — hoist the
  shared mechanism into `context`, leave each option stating only its scope of
  adoption — is now in the error, the tool schema, and the README. Post-clean, the band
  becomes what the *cleaner* is answerable for: it may not leave the options less
  equalized than the framing it was given.
- **The compression floor is removed** (fix 3). It fired at 0.09x on an option that was
  mostly consequence-narration. A character ratio cannot tell dropped substance from
  dropped padding; the cross-vendor fidelity attestation can, and already does, per
  option, by id. Growth keeps its ceiling.
- **Attestation covers only supplied fields** (fix 4), and a cleaner-invented — or
  cleaner-dropped — context is an error.
- **Failed runs write an audit record** (fix 7), so gate churn is measurable rather
  than anecdotal.
- **Unknown keys on an option object are rejected** (fix 8).
- Fix 6 was to change nothing: every message already named its gate and its bound,
  which is the only reason four invocations converged instead of thrashing.

## Review

Four `paranoia-local` rounds against Codex, converged at the operator's call. Nine
findings, all real, all folded with regression tests — including three that were the
*same class* the original branch closed for citation paths, surviving elsewhere:

- `validate_hints` normalized `\` → `/` and stripped `./` and whitespace. Git tracks
  `policy\choice.py` and `" spaced.py "` as distinct files — verified on real
  checkouts — so a hint folded both deciders onto different bytes, **invisibly**,
  because fix 4 means the attester now sees the path the *server* resolved rather than
  the one the caller wrote. Hints are verbatim, with literal tree membership.
- Closing that exposed a latent break in the round-12 citation closure:
  `ls-tree --name-only` **quotes** any path containing a backslash or non-ASCII byte
  (and `core.quotePath=false` does not suppress it), so no citation to such a file
  could ever resolve. Both tree reads now use `-z` and `surrogateescape` — `replace`
  collapsed distinct undecodable filenames into one entry.
- The substantiation waiver assumed the held position had been substantiated, which
  the handler never required. Carried grounding is now owed by any vendor that moved
  **or** whose round-1 vote was unsubstantiated; the second clause is what makes the
  first sound.
- The attester prompt still hardcoded `context`/`hints` in its output template after
  the parser's expected set went dynamic — an obedient attester was rejected for
  covering unknown fields, reproducing the very false failure this branch removes.

405 tests pass. `docs/arbitration_plan.md` §2.1a, §2.2 and §3.5 carry the reasoning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)