### PR TITLE
Class closure: track defect classes across review rounds

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,6 +248,9 @@ says only "no blocking class is unclosed", never that the change is correct.
 
 State lives in `~/.paranoia/lineages/<id>.json`, keyed by repo + `base_ref` + the
 reviewed branch (override with `lineage`; required when reviewing a detached HEAD).
+That location is **fixed and independent of `--log-dir`**, which is the audit-log
+directory only — deriving it from the log directory would mean an operator who moved
+their logs silently got an empty lineage. Set `PARANOIA_STATE_ROOT` to relocate it.
 A false positive of a regex is dismissed with `exempt` — shown to every later reviewer
 for challenge, and revocable with `unexempt`. Unreadable or unwritable state **blocks**
 rather than starting a fresh lineage, because a storage fault must never read as an

--- a/README.md
+++ b/README.md
@@ -194,9 +194,67 @@ maximum paranoia and manufactures marginal/hardening findings for 20+ rounds):
   instead of chasing diminishing findings. Start at 1; raise as the design stabilises.
 
 Operator recipe: set `stakes` in `.paranoia.toml`, then loop `already_raised` +
-`round` (1, 2, 3, …); stop when a round returns `CONVERGED` or only
-`[OUT-OF-SCOPE]`/`[MINOR]` items. Fold `[FATAL]`/in-scope-`[MAJOR]` findings;
-record `[OUT-OF-SCOPE]` ones separately rather than growing the design to fix them.
+`round` (1, 2, 3, …). **Stop when the computed `CONVERGENCE:` trailer says
+`NOT-BLOCKED` and the round returns `CONVERGED` or only
+`[OUT-OF-SCOPE]`/`[MINOR]` items** — the trailer governs, and when it says
+`BLOCKED` a reviewer's own `CONVERGED` is void (see *Class closure* below). Fold
+`[FATAL]`/in-scope-`[MAJOR]` findings; record `[OUT-OF-SCOPE]` ones separately
+rather than growing the design to fix them.
+
+**Two signals that the loop is going wrong, both learned the hard way:**
+
+- *The same defect keeps reappearing in a new spelling.* You are fixing instances,
+  not the class. That is what class closure exists to stop.
+- *Findings stop being about your diff and start being about imaginable inputs.*
+  The stakes are wrong, not the code. Tighten `stakes` and re-run that round
+  rather than folding what it raised.
+
+### Class closure (`class_closure`, **on by default** for `critique_branch`)
+
+A convergence loop that reports one instance of a defect per round can run for ten
+rounds while a single invariant stays violated — each round the operator fixes the
+site that was named, and the next round finds a sibling. The protocol had nowhere to
+put the *class*: findings are `file:line` shaped, `already_raised` tells the reviewer
+not to look there again, and the round-3 severity floor meters the leak to one
+instance per round.
+
+With class closure on, the reviewer ends its review with a **class register**: for
+each defect class, the invariant, a severity, and a **regex that matches violations
+only** (or a `PROCEDURE`, when no regex can express it). The server then:
+
+- **re-runs every registered predicate itself, every round**, against the reviewed
+  snapshot — `git grep -l -z` decides, so a violation inside a binary blob still counts;
+- **injects the surviving matches** into the next packet, *after* `already_raised` and
+  with explicit precedence over it, exempt from the severity floor;
+- **computes the verdict in Python** and appends it:
+
+```
+LINEAGE: 9f2c1a4b0e77 (rounds recorded: 8)
+CLASS-REGISTER: parsed 1
+CLASS-CLOSURE: 1 open, 2 closed, 3 surviving matches, 0 exempt, 1 unmechanized
+CONVERGENCE: BLOCKED — 1 class(es) unclosed:
+  3f2a91c4 every open state must be in the v2 open set (mechanized: 3 match(es))
+```
+
+A class closes when its predicate returns **zero matches**, and reopens the moment it
+matches again. Only `BLOCKER`/`MAJOR` classes block; `MINOR` and `OUT-OF-SCOPE` ones
+are tracked and advisory, so the mechanism can't trap you on a marginal finding.
+
+**What it does not do.** It guarantees durability for a class the reviewer
+*registers*. A reviewer that finds a class and doesn't register it is
+indistinguishable from one that never found it, and no parser over free text closes
+that gap — so nothing in the review's prose is parsed at all. `NOT-BLOCKED` therefore
+says only "no blocking class is unclosed", never that the change is correct.
+
+State lives in `~/.paranoia/lineages/<id>.json`, keyed by repo + `base_ref` + the
+reviewed branch (override with `lineage`; required when reviewing a detached HEAD).
+A false positive of a regex is dismissed with `exempt` — shown to every later reviewer
+for challenge, and revocable with `unexempt`. Unreadable or unwritable state **blocks**
+rather than starting a fresh lineage, because a storage fault must never read as an
+all-clear. Pass `class_closure: false` to restore the previous behaviour exactly.
+
+Full design, and the sixteen review rounds behind it:
+[`docs/class_closure_plan.md`](docs/class_closure_plan.md).
 
 ### Convergence packet mode (`converge`, **on by default**)
 

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,0 +1,307 @@
+# Brief: class closure — make a defect *class* a tracked object, not an operator inference
+
+Status: DRAFT for review, revision 1.
+
+## 0. The defect this fixes
+
+A real ten-round `critique_branch` loop against Parallax
+(`runbook-v2-card-execution`, base `91f920a`, ten records in `~/.paranoia/logs/`
+between `20260728T142314` and `20260728T162438`) produced findings per round of
+7 → 9 → 5 → 2 → 2 → 2 → 3 → 2 → 1. Rounds 7, 8 and 9 were **the same defect three
+times**: the v2 "is anything open?" predicate was incomplete — round 7 found
+escalations missing from it, round 8 ungated progress, round 9 unresolved starts.
+Three sites, one invariant, three rounds, three instance-shaped fixes.
+
+The operator was not being careless. **The protocol never gave the class anywhere
+to live.** Three mechanisms in this repository actively produce that outcome:
+
+1. **The finding schema is instance-shaped.** `prompts._SECTION_BODIES` asks each
+   finding for `file:line`, the failure mechanism, and the observable symptom. It
+   never asks for the invariant, and never asks where else the invariant is
+   violated. The reviewer *derives* the class in order to find the instance, then
+   the protocol discards it. A remedy inferred from an instance-shaped finding is
+   instance-shaped.
+2. **The only cross-round channel is pointed the wrong way.** `already_raised`
+   (`orientation.build_orientation`, `orientation.build_packet`,
+   `handlers._plan_body`) is the sole memory between rounds, and it renders as
+   `=== Already-raised — do NOT restate these; hunt for what they missed ===`.
+   The one channel that could catch a recurrence instructs the reviewer to stop
+   looking there. Round 8 was not permitted to notice it was re-reporting round 7.
+3. **The severity floor meters the leak.** `prompts._CALIBRATION` tells round ≥ 3
+   to withhold everything below `[MAJOR]`. So a class surviving at a new site only
+   surfaces when that individual site clears the floor — which is precisely the
+   one-per-round trickle observed at rounds 7–9.
+
+There is no lineage state of any kind: `logs.write_log` writes one record per
+call and nothing links round 9 to round 7.
+
+**This is the same shape as the `arbitrate` substantiation defect fixed in #9** —
+a per-instance check with the general rule left to interpretation. Different
+tool, identical failure mode.
+
+## 1. What the fix must achieve, and what it must not claim
+
+**Must achieve.** A class reported in round N is a durable object with a
+*mechanically re-checkable* membership predicate. Round N+1 re-runs that
+predicate itself. A surviving unadjudicated site is a `[RECURRENCE]`, is exempt
+from the severity floor, and **blocks the round from being reported converged** —
+computed in Python, not asserted by the reviewer and not inferred by the operator.
+
+**Must NOT claim.** The mechanism can only assert the *negative*. "No class is
+unclosed" is not "the change is correct" — new findings are still the reviewer's
+judgement. The trailer must therefore never emit a positive convergence verdict;
+it emits `BLOCKED` or `NOT-BLOCKED`, and says which. Any wording that reads as
+"converged" would launder a mechanical check into an approval, which is the
+`arbitrate` failure mode in a new costume.
+
+## 2. Mechanism
+
+### 2.1 Findings declare their scope, and a class declares its predicate
+
+Add to the finding rules for "What doesn't work" and "Gaps": every finding
+carries `SCOPE: isolated` or `SCOPE: class`.
+
+`SCOPE: class` means *the reasoning that condemned this site would condemn
+another site if one existed* — a violated invariant, not a one-off. A genuine
+off-by-one is `isolated`, and requiring class machinery for it would be exactly
+the over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
+
+A `SCOPE: class` finding must additionally emit, contiguously:
+
+- `INVARIANT:` — one line, stated **without reference to the reported site**.
+- `ENUMERATION-PATTERN:` — a POSIX-extended regex that matches every *candidate*
+  site (violating and conforming alike).
+- `ENUMERATION-PATHSPEC:` — a git pathspec bounding the search, or `.` for the
+  whole tree.
+- `SITES:` — the reviewer's adjudication of what that pattern finds at this
+  snapshot: one `<path>: VIOLATING|CONFORMING — <reason>` per match.
+
+Or, when no regex can express membership:
+
+- `ENUMERATION: unmechanized — <the procedure a reviewer must follow>`
+
+The reviewer is the right author: it has just derived the class in order to
+report the instance. The cost is one paragraph at the moment it is cheapest.
+
+**A pattern, not a command.** The predicate is *data*, never an argv. The server
+runs one fixed invocation with the pattern and pathspec substituted as operands:
+
+```
+git grep -I -n -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>
+```
+
+`shell=False`, no pipes, no redirection, no reviewer-chosen binary or flags. This
+removes model-authored command execution from the design entirely rather than
+trying to sanitise it. `git` is already a hard prerequisite; `rg` is not present
+on the reference machine and is not introduced.
+
+**Pathspec magic must be rejected.** Verified empirically in this repository
+today: `git grep -E -e x main -- ':(exclude)src'` is accepted and silently
+changes the result set. A pathspec beginning with `:` is rejected at parse time,
+and the class is recorded `malformed` rather than run.
+
+**Bounds.** Per-class 10 s timeout and a 200-match cap. A class over the cap is
+recorded `over-broad`, blocks, and the block text tells the reviewer to narrow
+the pattern — an unbounded predicate is not a usable membership test.
+
+### 2.2 The class register makes it parseable
+
+Scraping classes out of five sections of prose is unreliable. The review must end
+with a machine-readable block, one record per class finding, following the
+`arbitrate` trailer idiom:
+
+```
+=== CLASS REGISTER ===
+CLASS: <invariant, one line>
+PATTERN: <regex>
+PATHSPEC: <pathspec>
+SITES: <path>: VIOLATING — <reason>; <path>: CONFORMING — <reason>
+CLOSED: <class-id>            # only for a prior unmechanized class judged closed
+```
+
+**Absent register → fail-open, but visibly.** If a review omits the block, the
+round records no classes and the trailer says `CLASS-REGISTER: absent`. Erroring
+would discard a paid review over a formatting miss; silence would hide the gap.
+The operator sees it.
+
+### 2.3 Class identity is the predicate, not the label
+
+`class_id = sha256(normalized_pattern + "\0" + normalized_pathspec)[:12]`.
+
+This is the load-bearing decision. Round 7 called the class "escalations" and
+round 9 "unresolved starts" — no label match would ever connect them, and asking
+a model to reuse a prior label is asking it to be consistent across cold
+sessions. A predicate hashes the same however it is described.
+
+Residual: a reviewer restating the same class with a slightly different regex
+mints a second overlapping class. That fails toward *more* tracking, not less,
+and is accepted.
+
+### 2.4 Lineage state
+
+`~/.paranoia/lineages/<lineage_id>.json`, holding per class: `class_id`,
+`invariant`, `pattern`, `pathspec`, `first_round`, `status`
+(`open|closed|unmechanized|over-broad|malformed`), the adjudicated site set, and
+exemptions.
+
+`lineage_id` defaults to `sha256(resolved_repo_path + "\0" + base_ref)[:12]`, and
+is overridable by a `lineage` call argument. Every round's trailer prints
+`LINEAGE: <id> (rounds recorded: N)` so that a silent split — the operator
+changed `base_ref` mid-loop and started a fresh lineage without noticing — is
+visible on the next round rather than never.
+
+State is read before the engine call and written only after a successful one, so
+a failed review does not corrupt the lineage.
+
+### 2.5 The closure check
+
+Each round N > 1, before invoking the engine, for every `open` class:
+
+1. Run the fixed `git grep` above against the snapshot commit the round is
+   reviewing (converge mode already resolves it; no checkout is needed —
+   `git grep <commit>` reads the tree directly).
+2. Compute survivors:
+   - every recorded `VIOLATING` site still present, **and**
+   - every match **not present in the recorded site set at all** — unadjudicated,
+     therefore not known to conform.
+3. Subtract recorded exemptions.
+
+A class is `closed` when survivors is empty. **A broad pattern therefore does not
+block forever**: sites the reviewer adjudicated `CONFORMING` are not survivors.
+Closure means *every site the predicate finds has been adjudicated and none is
+violating* — which is the actual definition of a closed class.
+
+**Site matching is by `(path, normalized matched line text)`, never by line
+number**, because line numbers shift under the very edits being reviewed. A site
+whose text changed no longer matches its record, becomes unadjudicated, and
+therefore becomes a survivor. That fails toward blocking, which is the correct
+direction.
+
+### 2.6 Recurrence injection
+
+`already_raised` keeps its current meaning and its current suppress instruction —
+it is caller-authored and stays a caller concern. A **second, server-generated**
+block is added to the packet, carrying the opposite instruction:
+
+```
+=== UNCLOSED CLASSES — re-verify these; do NOT suppress ===
+[class <id>, first raised round <K>] <invariant>
+  surviving sites: <path> — <matched line>
+```
+
+with: *these were reported in an earlier round and are not closed. Each surviving
+site is a `[RECURRENCE]`. Report every one. The ROUND severity floor does not
+apply to a recurrence.*
+
+Claimed exemptions are shown too, under `=== CLAIMED EXEMPT ===`, so the cold
+reviewer can challenge an illegitimate one. Nothing self-attested escapes review.
+
+### 2.7 The computed trailer
+
+Appended by `handlers._footer`, after the review text:
+
+```
+LINEAGE: <id> (rounds recorded: N)
+CLASS-REGISTER: parsed 3 | absent
+CLASS-CLOSURE: 2 open, 1 closed this round, 4 recurrences, 1 exempt
+CONVERGENCE: BLOCKED — 2 class(es) unclosed: <id> <invariant>; <id> <invariant>
+```
+
+or `CONVERGENCE: NOT-BLOCKED — no unclosed class; reviewer findings still govern.`
+
+The second wording is deliberate and non-negotiable per §1: it is not a
+convergence verdict.
+
+### 2.8 Exemptions
+
+A surviving site that is genuinely fine is exempted by an `exempt` call argument
+(`class_id`, `path`, `reason`), recorded in lineage state, echoed in every
+subsequent trailer, and shown to every subsequent reviewer for challenge. This is
+the single place operator judgement legitimately enters, and the design makes it
+a recorded, adversarially-reviewed artifact instead of a silent lapse.
+
+### 2.9 Severity-floor amendment
+
+`prompts._CALIBRATION` gains: *the ROUND severity floor never applies to a
+`[RECURRENCE]`. A class raised in an earlier round and still open is
+merge-blocking by construction, whatever the severity of the individual site.*
+
+### 2.10 Unmechanized classes
+
+Carried forward as a reviewer obligation ("re-verify by the stated procedure and
+report survivors"), always shown, never floor-suppressed, and marked
+`unmechanized` in the trailer so their weakness is visible rather than silent.
+They cannot block mechanically — there is nothing to run. They close only when a
+later reviewer names the `class_id` on a `CLOSED:` line: still a judgement, but
+an explicit, cold, recorded one rather than an operator's silent assumption.
+
+## 3. Scope
+
+**In:** `critique_branch` in converge mode (default), which is the only path with
+a resolved snapshot commit to run the predicate against.
+
+**Out:** `critique_plan` (a plan has no code sites to enumerate; its premises are
+checked against the repo, which is a different mechanism), `query`, `rebut`, and
+legacy non-converge `critique_branch` (dirty/in-place reviews have no stable
+commit; converge mode already synthesises one for dirty trees, so the gap is
+narrow and users on the default path are covered).
+
+**Kill switch:** `class_closure` call arg / `.paranoia.toml` key, default `true`.
+
+## 4. Residual risks, stated
+
+1. **A reviewer can tag everything `SCOPE: isolated`** and avoid the work
+   entirely. The prompt states the criterion, but nothing enforces it. This is
+   the largest residual and the mechanism does not close it.
+2. **`unmechanized` classes are materially weaker** — no mechanical check, and
+   closure is a model's word. They are marked, not solved.
+3. **A wrong `CONFORMING` adjudication permanently whitelists a real violation**
+   at that site. Mitigated only by the site record being shown to later reviewers,
+   not by anything mechanical.
+4. **Regex is a coarse membership test.** Classes that are genuinely semantic
+   (cross-file dataflow, type-level invariants) degrade to `unmechanized`.
+5. **A pattern matching > 200 sites blocks as `over-broad`** and needs reviewer
+   iteration; a class whose true membership really is that large is not
+   expressible under this design.
+
+## 5. Implementation
+
+New pure module `class_closure.py` (parse register, compute survivors, site
+normalization, class ids, render blocks) with the git call injected, keeping the
+repository's existing pure-core/injected-edge split. `handlers.py` wires it;
+`prompts.py` carries the schema and floor amendment; `orientation.py` renders the
+new block; `server.py` exposes `lineage`, `exempt`, `class_closure`.
+
+TDD, RED first. The behavioural tests that must exist:
+
+- a register with two classes parses to two records; an absent register yields
+  none and sets `CLASS-REGISTER: absent`
+- the same invariant described in two different words under the same pattern
+  collapses to one `class_id`; the same words under different patterns do not
+- a recorded `VIOLATING` site still present survives; a recorded `CONFORMING`
+  site does not; a match absent from the record survives
+- a site whose line moved but whose text is unchanged is matched; a site whose
+  text changed becomes a survivor
+- survivors non-empty ⇒ `CONVERGENCE: BLOCKED` and the ids are named
+- survivors empty ⇒ `NOT-BLOCKED`, and the text does **not** contain the word
+  converged
+- an exempt site is subtracted, appears under `CLAIMED EXEMPT`, and is echoed in
+  the trailer
+- a pathspec beginning with `:` is rejected and the class recorded `malformed`
+- \> 200 matches ⇒ `over-broad`, blocks, and the message says to narrow
+- a failed engine call leaves lineage state byte-identical
+- `class_closure: false` restores today's behaviour exactly
+
+## 6. Acceptance
+
+Replay the ten recorded rounds of the `runbook-v2-card-execution` lineage
+(`~/.paranoia/logs/`, `20260728T142314`–`20260728T162438`) through the register
+parser and closure checker. Rounds 7, 8 and 9 are the known-positive: the
+mechanism is only worth shipping if a class registered at round 7 has a surviving
+unadjudicated site at rounds 8 and 9 and blocks both.
+
+Those ten reviews predate the register, so their text carries no `CLASS REGISTER`
+block; the replay therefore tests the checker against a register hand-derived
+from round 7's finding text, and that derivation is stated in the test rather
+than hidden in it. This is a weaker acceptance than a live loop, and the live
+loop is the real test.

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,6 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 1.
+Status: DRAFT for review, revision 2. One codex plan-review round folded — 3 FATAL,
+15 MAJOR, 2 MINOR. Every finding accepted. Round 1's three FATALs were not
+patchable: they killed the candidate-enumeration design outright and it has been
+replaced (§2.1), which in turn deleted five of the MAJORs rather than answering
+them.
 
 ## 0. The defect this fixes
 
@@ -12,8 +16,8 @@ times**: the v2 "is anything open?" predicate was incomplete — round 7 found
 escalations missing from it, round 8 ungated progress, round 9 unresolved starts.
 Three sites, one invariant, three rounds, three instance-shaped fixes.
 
-The operator was not being careless. **The protocol never gave the class anywhere
-to live.** Three mechanisms in this repository actively produce that outcome:
+The operator was not being careless. **The protocol gives the class nowhere to
+live.** Three mechanisms in this repository produce that outcome:
 
 1. **The finding schema is instance-shaped.** `prompts._SECTION_BODIES` asks each
    finding for `file:line`, the failure mechanism, and the observable symptom. It
@@ -21,190 +25,272 @@ to live.** Three mechanisms in this repository actively produce that outcome:
    violated. The reviewer *derives* the class in order to find the instance, then
    the protocol discards it. A remedy inferred from an instance-shaped finding is
    instance-shaped.
-2. **The only cross-round channel is pointed the wrong way.** `already_raised`
+2. **The only cross-round channel does not carry classes.** `already_raised`
    (`orientation.build_orientation`, `orientation.build_packet`,
    `handlers._plan_body`) is the sole memory between rounds, and it renders as
    `=== Already-raised — do NOT restate these; hunt for what they missed ===`.
-   The one channel that could catch a recurrence instructs the reviewer to stop
-   looking there. Round 8 was not permitted to notice it was re-reporting round 7.
+   Nothing *prohibits* a reviewer from finding a sibling violation — `prompts`
+   also tells it to follow the blast radius — but the channel carries no class
+   state and its instruction points away from re-checking a site already reported.
+   Round 8 had no way to know it was re-reporting round 7's invariant.
 3. **The severity floor meters the leak.** `prompts._CALIBRATION` tells round ≥ 3
-   to withhold everything below `[MAJOR]`. So a class surviving at a new site only
-   surfaces when that individual site clears the floor — which is precisely the
-   one-per-round trickle observed at rounds 7–9.
+   to withhold everything below `[MAJOR]`. A class surviving at a new site only
+   surfaces when that individual site clears the floor — which is the one-per-round
+   trickle observed at rounds 7–9.
 
 There is no lineage state of any kind: `logs.write_log` writes one record per
 call and nothing links round 9 to round 7.
 
 **This is the same shape as the `arbitrate` substantiation defect fixed in #9** —
-a per-instance check with the general rule left to interpretation. Different
-tool, identical failure mode.
+a per-instance check with the general rule left to interpretation.
 
 ## 1. What the fix must achieve, and what it must not claim
 
 **Must achieve.** A class reported in round N is a durable object with a
 *mechanically re-checkable* membership predicate. Round N+1 re-runs that
-predicate itself. A surviving unadjudicated site is a `[RECURRENCE]`, is exempt
-from the severity floor, and **blocks the round from being reported converged** —
-computed in Python, not asserted by the reviewer and not inferred by the operator.
+predicate itself. A surviving match is a recurrence, is exempt from the severity
+floor, and **blocks the round from being reported converged** — computed in
+Python, not asserted by the reviewer and not inferred by the operator.
 
-**Must NOT claim.** The mechanism can only assert the *negative*. "No class is
-unclosed" is not "the change is correct" — new findings are still the reviewer's
-judgement. The trailer must therefore never emit a positive convergence verdict;
-it emits `BLOCKED` or `NOT-BLOCKED`, and says which. Any wording that reads as
-"converged" would launder a mechanical check into an approval, which is the
-`arbitrate` failure mode in a new costume.
+**Must NOT claim.** The mechanism only asserts the *negative*. "No class is
+unclosed" is not "the change is correct" — new findings remain the reviewer's
+judgement. The trailer therefore never emits a positive convergence verdict; it
+emits `BLOCKED` or `NOT-BLOCKED` and says which. Wording that reads as
+"converged" would launder a mechanical check into an approval — the `arbitrate`
+failure mode in a new costume.
+
+**Must not become a termination trap.** A mechanism that can block indefinitely
+on marginal findings would reproduce the failure it exists to prevent, in a form
+the operator cannot escape. §2.9 bounds what may block.
 
 ## 2. Mechanism
 
-### 2.1 Findings declare their scope, and a class declares its predicate
+### 2.1 The predicate matches violations only
 
-Add to the finding rules for "What doesn't work" and "Gaps": every finding
-carries `SCOPE: isolated` or `SCOPE: class`.
+*Round 1 [FATAL]: revision 1 defined the predicate as matching every candidate
+site — violating and conforming alike — then required the reviewer to adjudicate
+each match, and made the class identity the candidate regex. Two distinct
+invariants over the same syntax collapsed to one class; git could recheck only
+candidate presence, never whether the invariant was still violated; and the
+register had no way to express which of several matches in one file a given
+adjudication referred to. Revision 2 takes round 1's own remedy.*
+
+**A mechanized class's predicate is a regex that matches only violations.
+Closure is exactly: zero matches.**
+
+This deletes the entire adjudication apparatus — no `SITES` verdicts, no
+conforming whitelist, no site identity in the closure algorithm, no
+line-number-versus-text matching problem, and no "broad pattern blocks forever"
+trap. It buys that at a real cost, stated plainly: **more invariants will be
+inexpressible and fall to `unmechanized` (§2.10), which is materially weaker.**
+That trade is correct — a check that cannot be wrong about closure is worth more
+than a check with wider reach and an adjudication layer that can silently
+whitelist a live defect.
+
+### 2.2 Findings declare their scope
+
+Every finding in "What doesn't work" and "Gaps" carries `SCOPE: isolated` or
+`SCOPE: class`.
 
 `SCOPE: class` means *the reasoning that condemned this site would condemn
-another site if one existed* — a violated invariant, not a one-off. A genuine
-off-by-one is `isolated`, and requiring class machinery for it would be exactly
-the over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
+another site if one existed*. A genuine off-by-one is `isolated`; requiring class
+machinery for it is the over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS`
+already calls a defect.
 
-A `SCOPE: class` finding must additionally emit, contiguously:
+### 2.3 The class register
 
-- `INVARIANT:` — one line, stated **without reference to the reported site**.
-- `ENUMERATION-PATTERN:` — a POSIX-extended regex that matches every *candidate*
-  site (violating and conforming alike).
-- `ENUMERATION-PATHSPEC:` — a git pathspec bounding the search, or `.` for the
-  whole tree.
-- `SITES:` — the reviewer's adjudication of what that pattern finds at this
-  snapshot: one `<path>: VIOLATING|CONFORMING — <reason>` per match.
-
-Or, when no regex can express membership:
-
-- `ENUMERATION: unmechanized — <the procedure a reviewer must follow>`
-
-The reviewer is the right author: it has just derived the class in order to
-report the instance. The cost is one paragraph at the moment it is cheapest.
-
-**A pattern, not a command.** The predicate is *data*, never an argv. The server
-runs one fixed invocation with the pattern and pathspec substituted as operands:
-
-```
-git grep -I -n -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>
-```
-
-`shell=False`, no pipes, no redirection, no reviewer-chosen binary or flags. This
-removes model-authored command execution from the design entirely rather than
-trying to sanitise it. `git` is already a hard prerequisite; `rg` is not present
-on the reference machine and is not introduced.
-
-**Pathspec magic must be rejected.** Verified empirically in this repository
-today: `git grep -E -e x main -- ':(exclude)src'` is accepted and silently
-changes the result set. A pathspec beginning with `:` is rejected at parse time,
-and the class is recorded `malformed` rather than run.
-
-**Bounds.** Per-class 10 s timeout and a 200-match cap. A class over the cap is
-recorded `over-broad`, blocks, and the block text tells the reviewer to narrow
-the pattern — an unbounded predicate is not a usable membership test.
-
-### 2.2 The class register makes it parseable
-
-Scraping classes out of five sections of prose is unreliable. The review must end
-with a machine-readable block, one record per class finding, following the
-`arbitrate` trailer idiom:
+The review ends with a machine-readable block — one record per class, following
+the `arbitrate` trailer idiom. Mechanized:
 
 ```
 === CLASS REGISTER ===
-CLASS: <invariant, one line>
-PATTERN: <regex>
-PATHSPEC: <pathspec>
-SITES: <path>: VIOLATING — <reason>; <path>: CONFORMING — <reason>
-CLOSED: <class-id>            # only for a prior unmechanized class judged closed
+CLASS: <the invariant, one line, stated without reference to any site>
+SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
+PATTERN: <POSIX-extended regex matching VIOLATIONS ONLY>
+PATHSPEC: <git pathspec, or . for the whole tree>
 ```
 
-**Absent register → fail-open, but visibly.** If a review omits the block, the
-round records no classes and the trailer says `CLASS-REGISTER: absent`. Erroring
-would discard a paid review over a formatting miss; silence would hide the gap.
-The operator sees it.
+Unmechanized:
 
-### 2.3 Class identity is the predicate, not the label
+```
+CLASS: <the invariant, one line>
+SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
+PROCEDURE: <what a reviewer must do to find every violation>
+```
 
-`class_id = sha256(normalized_pattern + "\0" + normalized_pathspec)[:12]`.
+References to classes the server already carries:
 
-This is the load-bearing decision. Round 7 called the class "escalations" and
-round 9 "unresolved starts" — no label match would ever connect them, and asking
-a model to reuse a prior label is asking it to be consistent across cold
-sessions. A predicate hashes the same however it is described.
+```
+RECURRENCE: <class-id>          # this round's finding is an instance of it
+CLOSED: <class-id>              # unmechanized only; judged closed this round
+SUPERSEDED-BY: <class-id> | PATTERN: <regex> PATHSPEC: <pathspec>
+```
 
-Residual: a reviewer restating the same class with a slightly different regex
-mints a second overlapping class. That fails toward *more* tracking, not less,
-and is accepted.
+**The register is mandatory.** A review with no classes must emit
+`=== CLASS REGISTER ===` followed by `NONE`.
 
-### 2.4 Lineage state
+*Round 1 [FATAL]: revision 1 made an absent register fail open, which contradicts
+the durability guarantee — a reviewer could report a class in prose, omit the
+block, and have it neither tracked nor blocking.* An absent or unparseable
+register now yields `CONVERGENCE: BLOCKED — class register absent/malformed`.
+**The review text is still returned in full** — a paid review is never discarded
+over a formatting miss — but the round cannot be reported unblocked, so the
+operator either re-runs or exempts explicitly. Parsing is as strict as
+`arbitration.parse_*`: the block is terminal, every field required, duplicates
+and out-of-block records rejected.
+
+### 2.4 Class identity is server-assigned
+
+*Round 1 [MAJOR]: revision 1 hashed the reviewer's regex into the id, so a
+corrected predicate minted a new class and the old one blocked forever, and
+unmechanized classes had no id at all yet were required to be closed by id.*
+
+The server assigns `class_id` (8 hex chars) at first registration and it never
+changes. Reviewer-authored text never determines identity, so it does not matter
+that round 7 called the class "escalations" and round 9 "unresolved starts" — a
+label match would never have connected them anyway.
+
+Two guards against duplicate registration of one class: the open classes are
+shown to every subsequent reviewer with their ids and invariants, with the
+instruction to emit `RECURRENCE: <id>` rather than register a new class; and the
+server dedupes on identical normalized `(pattern, pathspec)` at registration.
+
+A corrected predicate is registered with `SUPERSEDED-BY`, which marks the old
+class `superseded` (non-blocking) and carries its `first_round` forward. This is
+the recovery transition `malformed` and `over-broad` classes need.
+
+### 2.5 The git invocation
+
+The predicate is *data*, never an argv:
+
+```
+git grep -I -z -n -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>
+```
+
+`shell=False`, no pipes, no redirection, no reviewer-chosen binary or flags. This
+removes model-authored command execution from the design rather than sanitising
+it. `git` is already a hard prerequisite; `rg` is not present on the reference
+machine and is not introduced. `git grep <commit>` reads the tree directly — no
+checkout needed.
+
+**Verified empirically in this repository today:**
+
+- `-z` output is `<commit>:<path>\0<line>\0<text>\n`. Paths are NUL-terminated,
+  so paths containing newlines or non-UTF-8 bytes parse unambiguously. Decode
+  with `surrogateescape`, matching the `orientation`/`evidence` precedent.
+  *(Round 1 [MINOR]: revision 1 omitted `-z` and would have mis-parsed such paths.)*
+- Exit codes: `0` = matches, `1` = **no matches, which is success and means
+  closed**, `≥2` = error. A malformed ERE exits `128` with
+  `fatal: -e option, 'a[': Invalid regular expression`.
+- Pathspec magic is accepted and silently changes the result set:
+  `git grep -E -e x main -- ':(exclude)src'` returned matches from outside `src`.
+  A pathspec beginning with `:` is therefore **rejected at parse time** and the
+  class recorded `malformed`.
+
+**Bounds and their outcomes.** Per-class 10 s timeout and a 200-match cap. Under
+violation-only semantics, many matches means many violations, so the cap is an
+output bound, not a verdict: the class blocks, the block text is truncated with a
+count. A regex exceeding the cap is additionally recorded `over-broad` so the
+reviewer is prompted to narrow it via `SUPERSEDED-BY`. Timeout, exit ≥ 2, and
+invalid ERE all record the class `malformed` and **block** — a predicate that
+cannot run has not proved closure. *(Round 1 [MAJOR] gap: none of these were
+specified or tested.)*
+
+### 2.6 The closure check
+
+Each round, for **every** mechanized class the lineage holds — `open`, `closed`,
+`over-broad`, or `malformed`, but not `superseded` — the server runs the
+invocation above against the snapshot commit under review, subtracts recorded
+exemptions (§2.8), and:
+
+- zero matches → `closed`
+- any match → `open`, and every match is a recurrence
+
+*Round 1 [MAJOR]: revision 1 rechecked only `open` classes and treated closure as
+permanent, so a later fix could reintroduce the defect while the trailer still
+reported nothing unclosed.* **A closed class reopens on any new match.** The cost
+of rechecking everything is one bounded git query per class per round.
+
+### 2.7 Lineage state
 
 `~/.paranoia/lineages/<lineage_id>.json`, holding per class: `class_id`,
-`invariant`, `pattern`, `pathspec`, `first_round`, `status`
-(`open|closed|unmechanized|over-broad|malformed`), the adjudicated site set, and
-exemptions.
+`invariant`, `severity`, `pattern`/`pathspec` or `procedure`, `first_round`,
+`status`, `superseded_by`, and exemptions.
 
-`lineage_id` defaults to `sha256(resolved_repo_path + "\0" + base_ref)[:12]`, and
-is overridable by a `lineage` call argument. Every round's trailer prints
-`LINEAGE: <id> (rounds recorded: N)` so that a silent split — the operator
-changed `base_ref` mid-loop and started a fresh lineage without noticing — is
-visible on the next round rather than never.
+*Round 1 [MAJOR]: revision 1 derived the lineage from repo + `base_ref` only, so
+two sequential feature branches reviewed against `main` would inherit each
+other's classes and exemptions.* `lineage_id` defaults to
+`sha256(resolved_repo_path, base_ref, head_branch)[:12]`, where `head_branch`
+comes from `git symbolic-ref --quiet HEAD` (verified: exits 0 with
+`refs/heads/<name>`). **On a detached HEAD there is no stable branch identity, so
+an explicit `lineage` argument is required and the call errors without one** —
+fail-closed rather than silently minting a fresh lineage every round. Every
+trailer prints `LINEAGE: <id> (rounds recorded: N)` so an unintended split is
+visible.
 
-State is read before the engine call and written only after a successful one, so
-a failed review does not corrupt the lineage.
+*Round 1 [MAJOR] risk: revision 1 said only when state is written, and
+`logs.write_log` sets a precedent of swallowing every write failure —
+deliberately, since a completed review is the expensive artifact.* **Lineage
+state must not follow that precedent**, because a silently lost write plus a
+`NOT-BLOCKED` footer is exactly the false clearance this design exists to
+prevent. State is read before the engine call and written after a successful one,
+via temp file + `os.replace` in the same directory. A write failure, or existing
+state that will not parse, yields `CLASS-CLOSURE: STATE-UNAVAILABLE` and
+`CONVERGENCE: BLOCKED`. The review text is still returned.
 
-### 2.5 The closure check
+### 2.8 Exemptions
 
-Each round N > 1, before invoking the engine, for every `open` class:
+A match that is a false positive of the regex is exempted by an `exempt` call
+argument of `(class_id, path, line_text)`; the server stores a fingerprint of the
+normalized line text. *Round 1 [MAJOR]: revision 1 keyed exemptions on
+`class_id` + path alone, so exempting one match suppressed every present and
+future match in that file.*
 
-1. Run the fixed `git grep` above against the snapshot commit the round is
-   reviewing (converge mode already resolves it; no checkout is needed —
-   `git grep <commit>` reads the tree directly).
-2. Compute survivors:
-   - every recorded `VIOLATING` site still present, **and**
-   - every match **not present in the recorded site set at all** — unadjudicated,
-     therefore not known to conform.
-3. Subtract recorded exemptions.
+Exemptions are echoed in every subsequent trailer and shown to every subsequent
+reviewer under `=== CLAIMED EXEMPT ===` for challenge. This is the one place
+operator judgement legitimately enters, and the design makes it a recorded,
+adversarially-reviewed artifact rather than a silent lapse.
 
-A class is `closed` when survivors is empty. **A broad pattern therefore does not
-block forever**: sites the reviewer adjudicated `CONFORMING` are not survivors.
-Closure means *every site the predicate finds has been adjudicated and none is
-violating* — which is the actual definition of a closed class.
+### 2.9 What may block, and the severity grammar
 
-**Site matching is by `(path, normalized matched line text)`, never by line
-number**, because line numbers shift under the very edits being reviewed. A site
-whose text changed no longer matches its record, becomes unadjudicated, and
-therefore becomes a survivor. That fails toward blocking, which is the correct
-direction.
+*Round 1 [MAJOR]: revision 1 made every recurrence merge-blocking "whatever the
+severity", so a class originating as `[MINOR]` or `[OUT-OF-SCOPE]` could prevent
+termination indefinitely — the termination trap §1 forbids.*
 
-### 2.6 Recurrence injection
+**Only classes registered `SEVERITY: BLOCKER` or `MAJOR` block.** `MINOR` and
+`OUT-OF-SCOPE` classes are tracked and reported as advisory; they never appear in
+`CONVERGENCE: BLOCKED`. This keeps the mechanism inside the same severity
+economy `_CALIBRATION` already runs on.
 
-`already_raised` keeps its current meaning and its current suppress instruction —
-it is caller-authored and stays a caller concern. A **second, server-generated**
-block is added to the packet, carrying the opposite instruction:
+*Round 1 [MAJOR]: revision 1 told reviewers to emit `[RECURRENCE]` while
+`prompts.CODE_REVIEW_INSTRUCTIONS` requires exactly one of
+`[BLOCKER]`/`[MAJOR]`/`[MINOR]`/`[OUT-OF-SCOPE]` per finding.* Recurrence is
+**not** a severity tag. It is a marker adjacent to one:
+`[MAJOR] [RECURRENCE 3f2a91c4] …`. The existing grammar is untouched, and a
+recurrence of a blocking class is reported at `[MAJOR]` or higher.
 
-```
-=== UNCLOSED CLASSES — re-verify these; do NOT suppress ===
-[class <id>, first raised round <K>] <invariant>
-  surviving sites: <path> — <matched line>
-```
+`_CALIBRATION` gains: *the ROUND severity floor never applies to a finding marked
+`[RECURRENCE]`.*
 
-with: *these were reported in an earlier round and are not closed. Each surviving
-site is a `[RECURRENCE]`. Report every one. The ROUND severity floor does not
-apply to a recurrence.*
+### 2.10 Unmechanized classes
 
-Claimed exemptions are shown too, under `=== CLAIMED EXEMPT ===`, so the cold
-reviewer can challenge an illegitimate one. Nothing self-attested escapes review.
+Registered with `PROCEDURE:` instead of `PATTERN:`/`PATHSPEC:`, given a server
+id like any other class, carried forward as a reviewer obligation, always shown,
+never floor-suppressed, and marked `unmechanized` in the trailer so the weakness
+is visible. They cannot block mechanically — there is nothing to run — and they
+close only when a later reviewer names the id on a `CLOSED:` line: still a
+judgement, but an explicit, cold, recorded one rather than an operator's silent
+assumption.
 
-### 2.7 The computed trailer
+### 2.11 The computed trailer, and the `CONVERGED` collision
 
-Appended by `handlers._footer`, after the review text:
+Appended by `handlers._footer`:
 
 ```
 LINEAGE: <id> (rounds recorded: N)
-CLASS-REGISTER: parsed 3 | absent
-CLASS-CLOSURE: 2 open, 1 closed this round, 4 recurrences, 1 exempt
-CONVERGENCE: BLOCKED — 2 class(es) unclosed: <id> <invariant>; <id> <invariant>
+CLASS-REGISTER: parsed 3 | NONE | absent | malformed: <reason>
+CLASS-CLOSURE: 2 open, 1 closed this round, 4 recurrences, 1 exempt, 1 unmechanized
+CONVERGENCE: BLOCKED — 2 class(es) unclosed: 3f2a91c4 <invariant>; 91b0e77d <invariant>
 ```
 
 or `CONVERGENCE: NOT-BLOCKED — no unclosed class; reviewer findings still govern.`
@@ -212,96 +298,134 @@ or `CONVERGENCE: NOT-BLOCKED — no unclosed class; reviewer findings still gove
 The second wording is deliberate and non-negotiable per §1: it is not a
 convergence verdict.
 
-### 2.8 Exemptions
+*Round 1 [MAJOR] risk: `_CALIBRATION` still instructs the reviewer to print
+`CONVERGED` when it has no blocking findings, and `README.md` still tells the
+operator to stop on that token — so one response could contain both `CONVERGED`
+and `CONVERGENCE: BLOCKED`, and the exact reviewer omission this mechanism exists
+to survive could still terminate the loop.* Closed on three surfaces:
+`_CALIBRATION` forbids emitting `CONVERGED` when the injected unclosed-class
+block is non-empty; when the computed verdict is `BLOCKED` the footer states in
+one line that any reviewer `CONVERGED` in the text above is void; and the README
+stop recipe is rewritten so the computed trailer is the documented stop signal.
 
-A surviving site that is genuinely fine is exempted by an `exempt` call argument
-(`class_id`, `path`, `reason`), recorded in lineage state, echoed in every
-subsequent trailer, and shown to every subsequent reviewer for challenge. This is
-the single place operator judgement legitimately enters, and the design makes it
-a recorded, adversarially-reviewed artifact instead of a silent lapse.
+### 2.12 Recurrence injection
 
-### 2.9 Severity-floor amendment
+`already_raised` keeps its current meaning and instruction — it is caller-authored
+and stays a caller concern. A **second, server-generated** block carries the
+opposite instruction:
 
-`prompts._CALIBRATION` gains: *the ROUND severity floor never applies to a
-`[RECURRENCE]`. A class raised in an earlier round and still open is
-merge-blocking by construction, whatever the severity of the individual site.*
+```
+=== UNCLOSED CLASSES — re-verify these; do NOT suppress ===
+[class 3f2a91c4, first raised round 7, MAJOR] <invariant>
+  surviving matches: <path>:<line>: <text>
+```
 
-### 2.10 Unmechanized classes
-
-Carried forward as a reviewer obligation ("re-verify by the stated procedure and
-report survivors"), always shown, never floor-suppressed, and marked
-`unmechanized` in the trailer so their weakness is visible rather than silent.
-They cannot block mechanically — there is nothing to run. They close only when a
-later reviewer names the `class_id` on a `CLOSED:` line: still a judgement, but
-an explicit, cold, recorded one rather than an operator's silent assumption.
+with: *these were reported in an earlier round and are not closed. Report every
+surviving match, marked `[RECURRENCE <id>]`. The ROUND severity floor does not
+apply. If a new finding of yours is an instance of one of these, emit
+`RECURRENCE: <id>` in the register instead of registering a new class.*
 
 ## 3. Scope
 
-**In:** `critique_branch` in converge mode (default), which is the only path with
-a resolved snapshot commit to run the predicate against.
+**In:** `critique_branch` in converge mode (the default).
 
-**Out:** `critique_plan` (a plan has no code sites to enumerate; its premises are
-checked against the repo, which is a different mechanism), `query`, `rebut`, and
-legacy non-converge `critique_branch` (dirty/in-place reviews have no stable
-commit; converge mode already synthesises one for dirty trees, so the gap is
-narrow and users on the default path are covered).
+*Round 1 [MINOR]: revision 1 justified this by claiming converge is the only path
+with a stable commit; `handlers.critique_branch` in fact reviews a committed
+`head_ref` in a detached worktree too.* The real reason is narrower and honest:
+converge is the default path, it already resolves an explicit snapshot id, and it
+is where the packet block is rendered. Extending to the legacy path is deferred,
+not impossible.
+
+**Out:** `critique_plan` (a plan has no code sites to enumerate), `query`,
+`rebut`, and legacy non-converge `critique_branch`.
 
 **Kill switch:** `class_closure` call arg / `.paranoia.toml` key, default `true`.
 
 ## 4. Residual risks, stated
 
-1. **A reviewer can tag everything `SCOPE: isolated`** and avoid the work
-   entirely. The prompt states the criterion, but nothing enforces it. This is
-   the largest residual and the mechanism does not close it.
-2. **`unmechanized` classes are materially weaker** — no mechanical check, and
-   closure is a model's word. They are marked, not solved.
-3. **A wrong `CONFORMING` adjudication permanently whitelists a real violation**
-   at that site. Mitigated only by the site record being shown to later reviewers,
-   not by anything mechanical.
-4. **Regex is a coarse membership test.** Classes that are genuinely semantic
-   (cross-file dataflow, type-level invariants) degrade to `unmechanized`.
-5. **A pattern matching > 200 sites blocks as `over-broad`** and needs reviewer
-   iteration; a class whose true membership really is that large is not
-   expressible under this design.
+1. **A reviewer can tag everything `SCOPE: isolated`** and avoid the work. The
+   prompt states the criterion; nothing enforces it. Largest residual, unclosed.
+2. **Violation-only regexes are hard to write**, so the `unmechanized` population
+   will be larger than revision 1 implied — and unmechanized closure is a model's
+   word, not a check. This is the price of §2.1 and it is not hidden.
+3. **A regex can be wrong in the safe direction** — too narrow, matching none of
+   the real violations, and reporting `closed` immediately. Nothing detects this;
+   a class that closes in the same round it was raised is suspicious and the
+   trailer flags it, but flagging is not detection.
+4. **Exemptions accumulate.** They are shown for challenge every round, which is
+   pressure, not a limit.
+5. **Semantic invariants** (cross-file dataflow, type-level) are not expressible
+   as a line regex at all.
 
 ## 5. Implementation
 
-New pure module `class_closure.py` (parse register, compute survivors, site
-normalization, class ids, render blocks) with the git call injected, keeping the
-repository's existing pure-core/injected-edge split. `handlers.py` wires it;
-`prompts.py` carries the schema and floor amendment; `orientation.py` renders the
-new block; `server.py` exposes `lineage`, `exempt`, `class_closure`.
+New pure module `class_closure.py` — register parsing, class ids, status
+transitions, survivor computation, block rendering — with the git call and the
+clock injected, keeping the repository's pure-core/injected-edge split.
+`handlers.py` wires it; `prompts.py` carries the register grammar, the
+`SCOPE`/`[RECURRENCE]` rules and the `_CALIBRATION` amendments; `orientation.py`
+renders the injected blocks; `server.py` exposes `lineage`, `exempt`,
+`class_closure`; `logs.py` records `base_id`/`head_id` (§6). **`README.md` is in
+scope, not optional** — *round 1 [MAJOR] gap: revision 1 listed code modules
+only, while the shipped README still documents caller-managed state and stopping
+on reviewer-emitted `CONVERGED`, so an operator following the docs would bypass
+the new authority.*
 
-TDD, RED first. The behavioural tests that must exist:
+TDD, RED first. Behavioural tests that must exist:
 
-- a register with two classes parses to two records; an absent register yields
-  none and sets `CLASS-REGISTER: absent`
-- the same invariant described in two different words under the same pattern
-  collapses to one `class_id`; the same words under different patterns do not
-- a recorded `VIOLATING` site still present survives; a recorded `CONFORMING`
-  site does not; a match absent from the record survives
-- a site whose line moved but whose text is unchanged is matched; a site whose
-  text changed becomes a survivor
-- survivors non-empty ⇒ `CONVERGENCE: BLOCKED` and the ids are named
-- survivors empty ⇒ `NOT-BLOCKED`, and the text does **not** contain the word
-  converged
-- an exempt site is subtracted, appears under `CLAIMED EXEMPT`, and is echoed in
-  the trailer
-- a pathspec beginning with `:` is rejected and the class recorded `malformed`
-- \> 200 matches ⇒ `over-broad`, blocks, and the message says to narrow
-- a failed engine call leaves lineage state byte-identical
-- `class_closure: false` restores today's behaviour exactly
+**Register parsing** (strictness matched to `arbitration.parse_*`, since this is
+a model-authored surface): two mechanized records parse; `NONE` parses as an
+empty register; absent → `CLASS-REGISTER: absent` and `BLOCKED`; duplicate field
+within a record rejected; missing required field rejected; a record after the
+block's end rejected; a field name appearing in earlier prose does not confuse
+the parser; unmechanized record with `PROCEDURE` parses; `RECURRENCE`/`CLOSED`
+naming an unknown id rejected.
+
+**Closure semantics:** zero matches → closed; any match → open with every match a
+recurrence; a closed class with a new match reopens; a superseded class is not
+rechecked; `first_round` survives supersession.
+
+**Git boundary:** exit 1 is closure, not failure; exit ≥ 2 → `malformed` +
+`BLOCKED`; invalid ERE → `malformed` + `BLOCKED`; timeout → `malformed` +
+`BLOCKED`; > 200 matches → `over-broad`, blocks, message says to narrow; a path
+containing a newline and a non-UTF-8 byte parses correctly under `-z`; a pathspec
+beginning with `:` is rejected before any git call.
+
+**Blocking policy:** `MAJOR` class blocks; `MINOR` and `OUT-OF-SCOPE` classes do
+not and are reported advisory; `BLOCKED` names the ids; `NOT-BLOCKED` text does
+not contain the word *converged*; when blocked, the footer voids a reviewer
+`CONVERGED`.
+
+**Lineage state:** detached HEAD without `lineage` errors; two branches off one
+base get different default lineages; unparseable state → `STATE-UNAVAILABLE` +
+`BLOCKED` and the review text still returned; write failure → same; state is
+replaced atomically; a failed engine call leaves state byte-identical.
+
+**Exemptions:** an exempt match is subtracted; a different match in the same file
+is not; the exemption appears under `CLAIMED EXEMPT` and in the trailer.
+
+**Kill switch:** `class_closure: false` reproduces today's behaviour exactly.
 
 ## 6. Acceptance
 
-Replay the ten recorded rounds of the `runbook-v2-card-execution` lineage
-(`~/.paranoia/logs/`, `20260728T142314`–`20260728T162438`) through the register
-parser and closure checker. Rounds 7, 8 and 9 are the known-positive: the
-mechanism is only worth shipping if a class registered at round 7 has a surviving
-unadjudicated site at rounds 8 and 9 and blocks both.
+*Round 1 [MAJOR] gap: revision 1 proposed replaying the ten production rounds
+through git. That is impossible — `handlers._log` records target text, mode,
+usage and duration but neither `base_id` nor `head_id`, and dirty wrapper commits
+are unreferenced and GC-eligible (`orientation.wrap_commit`). The reviewed
+commits are simply not recoverable from the logs.*
 
-Those ten reviews predate the register, so their text carries no `CLASS REGISTER`
-block; the replay therefore tests the checker against a register hand-derived
-from round 7's finding text, and that derivation is stated in the test rather
-than hidden in it. This is a weaker acceptance than a live loop, and the live
-loop is the real test.
+Acceptance is therefore two things, neither of which pretends to be that replay:
+
+1. **A fixture repository**, committed to `tests/`, carrying a real three-site
+   invariant across three commits that mirror the observed incident: round 7's
+   commit violates at site A, the round-7 fix closes A and leaves B and C, and so
+   on. The mechanism must register the class at round 7 and return
+   `CONVERGENCE: BLOCKED` at rounds 8 and 9 naming the same `class_id` both
+   times. This is the known-positive the design must reproduce.
+2. **The next real review loop in this repository**, run with the mechanism on.
+   That is the only honest end-to-end test, and the fixture exists so that
+   failure is caught before spending it.
+
+Separately and independently of this feature, `handlers._log` starts recording
+`base_id` and `head_id` so that a future incident *is* replayable. Round 1 found
+that gap; it is cheap and it should not wait for this design.

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 10. Nine codex plan-review rounds folded —
+Status: DRAFT for review, revision 11. Ten codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR. Every finding accepted.
+4 FATAL, 2 MAJOR; round 10: 1 FATAL, no risks, no gaps. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -378,6 +378,26 @@ exemptions (§2.8), and:
 permanent, so a later fix could reintroduce the defect while the trailer still
 reported nothing unclosed.* **A closed class reopens on any new match.**
 
+**The sweep runs twice: before the review, and again over whatever the register
+just minted.**
+
+*Round 10 [FATAL]: the sweep was specified only over classes the lineage already
+holds, and it runs before the engine call — but a class registered by **this**
+round's review does not exist until its register is parsed afterwards. So a brand
+new `MAJOR` class, or a `WITH-PATTERN` replacement whose predecessor was
+simultaneously marked non-blocking and never-rechecked, could be registered while
+the same round emitted `NOT-BLOCKED` — stopping the operator before the promised
+next-round check ever happened. Supersession made it worse than a one-round
+delay: the old blocker was retired in the same breath.*
+
+After a valid register is parsed, every **newly minted** mechanized predicate is
+evaluated against the same snapshot before the trailer is computed. A new class
+is `unchecked` until that pass runs it, and `unchecked` already blocks according
+to severity (§2.5, §2.9) — so the fail-safe direction holds even when the pass
+cannot run. The post-register pass draws on the same 60 s round budget; if the
+budget is exhausted the class stays `unchecked` and blocks per severity. A new
+unmechanized class starts `open` and blocks per severity with no pass needed.
+
 ### 2.7 Lineage state
 
 `~/.paranoia/lineages/<lineage_id>.json`, holding per class: `class_id`,
@@ -713,6 +733,13 @@ matches only in prose, with a register of `NONE`, **is well-formed and still
 blocks** on the git result; a review that omits the recurrence prose entirely
 **also still blocks**, because the verdict never depended on the reviewer's text;
 `[RECURRENCE <id>]` appearing anywhere changes no parse outcome.
+
+**New-class evaluation** (round 10's FATAL): a review registering a new `MAJOR`
+class whose predicate still matches **cannot** emit `NOT-BLOCKED` in that same
+round; `SUPERSEDE … WITH-PATTERN` cannot emit `NOT-BLOCKED` before the
+replacement predicate has been run and found closed; a new class the budget could
+not reach is `unchecked` and blocks per severity; a new `MINOR` class does not
+block whatever the pass finds.
 
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 15. Fourteen codex plan-review rounds folded —
+Status: DRAFT for review, revision 16. Fifteen codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR; round 10: 1 FATAL; rounds 11–14: one MAJOR each and nothing in
+4 FATAL, 2 MAJOR; round 10: 1 FATAL; rounds 11–15: one MAJOR each and nothing in
 any other section. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
@@ -338,8 +338,29 @@ clearance. The asymmetry decides it.
 The predicate is *data*, never an argv:
 
 ```
-git grep -I -z -n -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>
+git grep -l -z    -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>   # verdict
+git grep -I -z -n -E --no-color -e <pattern> <snapshot-commit> -- <pathspec>   # display
 ```
+
+**Two passes, and only the first decides.** *Round 15 [MAJOR]: a single `-I` pass
+cannot be the closure authority, because `-I` suppresses matches in files git
+classifies as binary — and this repository treats those as a supported case,
+`orientation.file_evidence` detecting any NUL-bearing blob and `tests/test_packet.py`
+pinning a late-NUL file. A registered predicate whose violation lives in such a
+blob returns exit 1, is recorded `closed`, and can emit `NOT-BLOCKED` in its own
+registration round while the violation survives.*
+
+Simply dropping `-I` does not work either. **Verified on a fresh repository:** with
+`-I` the binary match yields exit 1 and no output; without `-I` git emits the
+untyped English line `Binary file HEAD:blob.dat matches\n` — no NUL separators, not
+the `-z` record shape, and localizable. A parser fed that would mis-read it.
+
+So the **verdict** comes from `-l -z`, which lists matching paths NUL-separated and
+uniformly for text and binary alike (verified: `HEAD:blob.dat\0`), and the
+**display** list comes from the `-I -z -n` pass. A path present in the verdict pass
+but absent from the display pass is rendered `<path>: binary match (line not
+shown)`. The blocking decision therefore never depends on the richer, more fragile
+output — which is the same separation §2.2 reached for prose.
 
 `shell=False`, no pipes, no redirection, no reviewer-chosen binary or flags. This
 removes model-authored command execution from the design rather than sanitising
@@ -368,8 +389,8 @@ checkout needed.
   `orientation` into a shared helper for that. Injectivity matters as much as
   safety: two distinct paths must not collapse onto one label in a block the
   operator reads as an exhaustive match list.
-- Exit codes: `0` = matches, `1` = **no matches, which is success and means
-  closed**, `≥2` = error. A malformed ERE exits `128` with
+- Exit codes on the verdict pass: `0` = matches, `1` = **no matches, which is
+  success and means closed**, `≥2` = error. A malformed ERE exits `128` with
   `fatal: -e option, 'a[': Invalid regular expression`.
 - Pathspec magic is accepted and silently changes the result set:
   `git grep -E -e x main -- ':(exclude)src'` returned matches from outside `src`.
@@ -838,7 +859,11 @@ recheck sweep.
 **`REOPEN` on it blocks again** (round 6's `CLOSED → REOPEN → open` gap);
 `REOPEN` against a mechanized class is rejected, since those reopen from git.
 
-**Git boundary:** exit 1 is closure, not failure; exit ≥ 2, invalid ERE, and
+**Git boundary:** exit 1 **on the verdict pass** is closure, not failure; **a
+violation inside a binary-classified blob keeps the class open** and renders as
+`binary match (line not shown)` (round 15's MAJOR) — asserted with a late-NUL
+file like the one `tests/test_packet.py` already pins; a verdict-pass path absent
+from the display pass never silently disappears from the block; exit ≥ 2, invalid ERE, and
 timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,
 counted block; aggregate budget exhaustion → `unchecked`; a path containing a
 newline and a non-UTF-8 byte parses correctly under `-z`, **and the fully rendered

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 9. Eight codex plan-review rounds folded —
+Status: DRAFT for review, revision 10. Nine codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
-1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR. Every
-finding accepted.
+1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
+4 FATAL, 2 MAJOR. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -16,19 +16,32 @@ different spelling** (§2.4), and that the quarantine added for round 3 had
 *created* the fresh-lineage hole it was written to close (§2.7). Round 5 found
 the recurrence grammar contradictory again (§2.2) and a stale dedup test left
 standing in §5 that would have re-implemented the very collapse round 4 removed.
-Round 6 found the recurrence grammar broken a **third** time, and revision 7
-deletes it outright rather than repairing it once more (§2.2).
+Round 6 found the recurrence grammar broken a **third** time and it was deleted
+outright. Rounds 7 and 8 then escalated the same underlying attempt — make the
+review's prose provably account for every class — through a `FINDING:` header and
+a four-section record grammar. Round 9 showed that grammar was not merely broken
+but **impossible**: a record ran from its header to the next header, so a
+headerless continuation is by definition *inside* the preceding record, and the
+test demanding it be malformed could never be written.
 
-**Seven of the ten FATALs in this review were introduced by fixes to earlier
-findings, and the recurrence grammar alone accounted for three of them — the same
-defect in three spellings, exactly the pattern §0 describes.** That is the
-failure this brief exists to mechanize against, observed on the brief itself,
-under the very review protocol the brief argues is inadequate to catch it. The
-design is the argument; the review history is the evidence.
+**Revision 10 therefore abandons the goal rather than the eleventh attempt at
+it** (§2.2). A reviewer that finds a class and does not register it cannot be
+distinguished from one that never found it; no parser over free text closes that.
+§1 now scopes the guarantee to a *registered* class and §4.1 states the ceiling
+plainly, which is what the previous nine revisions were spending FATALs to avoid
+admitting.
 
-The three fixes that finally held all **removed** mechanism rather than adding
-it: dedup deleted (§2.4), the recurrence grammar deleted (§2.2), the adjudication
-layer deleted (§2.1). Each had been introduced to satisfy an earlier finding.
+**Eleven of the fourteen FATALs in this review were introduced by fixes to
+earlier findings**, and two distinct mechanisms — the recurrence grammar and the
+prose bijection — each accounted for three, the same defect in three spellings.
+That is the failure this brief exists to mechanize against, observed on the brief
+itself, under the very review protocol the brief argues is inadequate to catch it.
+The design is the argument; the review history is the evidence.
+
+**Every fix that finally held removed mechanism rather than adding it**: the
+adjudication layer (§2.1), dedup (§2.4), the recurrence grammar (§2.2), and now
+the prose bijection entirely (§2.2). Each had been introduced to satisfy an
+earlier finding.
 
 ## 0. The defect this fixes
 
@@ -70,11 +83,18 @@ a per-instance check with the general rule left to interpretation.
 
 ## 1. What the fix must achieve, and what it must not claim
 
-**Must achieve.** A class reported in round N is a durable object with a
+**Must achieve.** A class **registered** in round N is a durable object with a
 *mechanically re-checkable* membership predicate. Round N+1 re-runs that
 predicate itself. A surviving match is a recurrence, is exempt from the severity
 floor, and **blocks the round from being reported converged** — computed in
 Python, not asserted by the reviewer and not inferred by the operator.
+
+*Registered* is load-bearing and was added at revision 10. Eight rounds were
+spent trying to guarantee that a class the reviewer *described in prose* could
+not escape registration, and round 9 established the goal is unreachable in
+principle: a reviewer that finds a class and does not register it is
+indistinguishable from one that never found it (§2.2). The mechanism owns
+everything downstream of registration and claims nothing upstream of it.
 
 **Must NOT claim.** The mechanism only asserts the *negative*. "No class is
 unclosed" is not "the change is correct" — new findings remain the reviewer's
@@ -119,89 +139,63 @@ to `unmechanized` (§2.10), which is materially weaker.** That trade is correct 
 a check that cannot be wrong about closure is worth more than a check with wider
 reach and an adjudication layer that can silently whitelist a live defect.
 
-### 2.2 Every finding is a delimited record declaring its kind
+### 2.2 The register is the only class channel
 
-*Round 8 [FATAL]: revision 8 asserted "a header on every finding is what makes
-omission observable" while §2.2 itself conceded there is no boundary between
-findings — `prompts._SECTION_BODIES` defines prose, with no bullet or record
-delimiter. One valid `kind=isolated` header followed by prose containing a
-second, headerless class finding is indistinguishable from one long isolated
-finding, so `NONE` still parsed and the class still vanished. The header was
-necessary and not sufficient.*
+Revisions 2 through 9 each tried to make the review's *prose* provably account
+for every class it found: `SCOPE:` tags, a `CLASS-REF`/`REF` bijection, a second
+bijection for recurrences, a per-finding `FINDING:` header, and finally a record
+grammar over four sections. Every one of those broke something, and round 9
+showed the last one was not merely broken but **impossible**: a record was
+defined as running from its header to the next header, so a headerless
+continuation is *by definition* inside the preceding record, and the test
+demanding it be malformed could never be implemented.
 
-**The four severity-tagged sections therefore become a record grammar, not
-prose.** Each of "What doesn't work", "Risks", "Gaps" and "Improvements" contains
-either the exact sentinel `Nothing notable.` or a sequence of records. A record
-begins with a `FINDING:` header at column 0 and runs to the next `FINDING:` or
-the next section heading. **Any text inside those sections that is not the
-sentinel and does not sit inside a record makes the review malformed** — which is
-what closes the FATAL: there is nowhere left for an undeclared finding to hide.
+**Revision 10 abandons the attempt, because the goal was unreachable in
+principle.** A reviewer that finds a class and fails to register it is
+indistinguishable, from outside, from a reviewer that never found the class. No
+grammar over free text can separate those two, and every round spent trying
+produced a more elaborate parser and a new FATAL. Round 2's "durability" finding
+was asking for something no parser can deliver.
 
-*Round 8 [MAJOR]: revision 8 applied the grammar only to "What doesn't work" and
-"Gaps", but `prompts.CODE_REVIEW_INSTRUCTIONS` requires a severity tag on Risks
-and Improvements items too, and `_SECTION_BODIES` defines Risks as specific,
-testable failure modes — so a merge-blocking class could be reported under Risks
-with no header and no record at all.* All four are parsed; the "What works"
-section is prose and is not.
+So: **the register is the sole class channel.** Nothing in the five prose
+sections is parsed. There are no `SCOPE:` tags, no `FINDING:` headers, no record
+grammar, no bijection, and the existing prose format of
+`prompts.CODE_REVIEW_INSTRUCTIONS` is untouched — which also resolves round 9's
+finding that the record grammar made a clean late-round `CONVERGED` response
+unparseable, and round 9's finding that a class carried two severity
+declarations with only one validated. The register's `SEVERITY` is now the only
+severity a class has.
 
-Each record opens with exactly one machine-readable header line:
+What this costs is stated honestly in §1 and §4: the mechanism guarantees
+durability for a class **the reviewer registers**, and registration is a reviewer
+judgement exactly as finding the defect is. That was always the true ceiling —
+residual §4.1 has conceded since revision 1 that a reviewer can decline to
+declare a class at all. The bijection was pretending otherwise, at the cost of
+seven FATALs.
 
-```
-FINDING: kind=isolated
-FINDING: kind=new-class ref=<short token unique in this review> severity=<BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE>
-FINDING: kind=recurrence class=<class-id>
-```
-
-`new-class` means *the reasoning that condemned this site would condemn another
-site if one existed, and the lineage does not already hold that invariant*. A
-genuine off-by-one is `isolated`; requiring class machinery for it is the
-over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
-
-*Round 6 [MAJOR]: revision 6 asked the parser to associate a `CLASS-REF` with
-"its finding's severity tag", but `prompts._SECTION_BODIES` defines prose
-content, not machine-delimited finding records — there is no boundary to
-attribute a tag to, and the `arbitration` precedent only works because it slices
-a fixed terminal field count.* The header carries every field it needs, so no
-prose-boundary inference is needed anywhere.
-
-*Round 7 [FATAL]: revision 7 headed only new-class findings, and then compared
-header refs against register refs — so a reviewer that omitted **both** the
-header and the record produced `∅ == ∅`, `NONE` parsed, no retry fired, and the
-class was never persisted. Round 2's durability FATAL, back in a spelling the
-parser could not see. It could not be fixed by rejecting headerless class-scoped
-findings, because recurrences are class-scoped too and deliberately carry
-nothing.* **The record grammar above is what makes omission observable**: every
-finding is a delimited record, every record declares its kind, and unrecorded
-text is malformed — so there is no longer anywhere to report a class without
-declaring it.
-
-The `kind=recurrence` form is the **minimal** discriminator round 7 requires — a
-class id and nothing else. No ref, no severity, no sites, no matches, and no
-register counterpart. It is validated only in that the id must name a class the
-lineage holds. This deliberately does not resurrect the grammar that broke in
-rounds 3, 5 and 6: omitting recurrence findings entirely cannot break the verdict,
-because the verdict comes from git regardless (§2.6).
+What the mechanism still does, mechanically and without operator interpretation,
+is everything after registration: recheck, recurrence detection, blocking,
+reopening, and the computed verdict. That is where the observed defect actually
+lived — rounds 7, 8 and 9 of the reference incident each *did* report the class
+in prose; nothing carried it forward.
 
 **Recurrences carry nothing.** *Round 3 [FATAL], round 5 [FATAL] and round 6
-[MAJOR] were all the same wound: a hand-authored recurrence grammar that had to
-stay consistent with the prose rules, the register rules and the tests, and did
-not — three times, in three different spellings.* Revision 7 deletes it, taking
-round 6's own remedy: **for a mechanized class, a recurrence is whatever the
-server's `git grep` found**, and nothing the reviewer writes is parsed to confirm
-it. The server already ran the predicate; asking a model to restate the matches
-and then machine-auditing the restatement was ceremony that repeatedly broke the
-one path the mechanism exists to serve. The reviewer is still *shown* the
-surviving matches and still asked to report them (§2.12) — that text is for the
-operator to read, not for the parser to validate.
+[MAJOR] were the same wound three times: a hand-authored recurrence grammar that
+had to stay consistent with the prose rules, the register rules and the tests,
+and did not.* **For a mechanized class, a recurrence is whatever the server's
+`git grep` found**, and nothing the reviewer writes is parsed to confirm it. The
+reviewer is still *shown* the surviving matches and still asked to report them
+(§2.12) — that text is for the operator to read, not for the parser to validate.
+`[RECURRENCE <id>]` remains a presentational marker so the floor exemption in
+§2.9 is expressible.
 
-### 2.3 The class register, and its binding to the prose
+### 2.3 The class register
 
 The review ends with a machine-readable block — one record per class, following
 the `arbitrate` trailer idiom. Mechanized:
 
 ```
 === CLASS REGISTER ===
-REF: <the CLASS-REF token from the finding>
 CLASS: <the invariant, one line, stated without reference to any site>
 SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
 PATTERN: <POSIX-extended regex matching VIOLATIONS ONLY>
@@ -210,100 +204,80 @@ PATHSPEC: <git pathspec, or . for the whole tree>
 
 Unmechanized records replace `PATTERN`/`PATHSPEC` with
 `PROCEDURE: <what a reviewer must do to find every violation>`. Transitions
-against classes the server already carries:
+against classes the server already carries, **one field per line** — *round 9
+[MAJOR]: the previous single-line `SUPERSEDE … WITH-PATTERN: <regex> PATHSPEC:
+<pathspec> [CLASS: <invariant>]` had no unique parse, because `PATHSPEC:` and
+`CLASS:` are legal content inside a regex, a pathspec and an invariant alike, so
+a legitimate correction containing one of those tokens would register the wrong
+predicate or stay malformed*:
 
 ```
 CLOSED: <class-id>                  # unmechanized only; judged closed this round
 REOPEN: <class-id>                  # unmechanized only; found violated again
 RECLASSIFY: <class-id> <severity>   # a later cold reviewer corrects the severity
-SUPERSEDE: <old-id> BY: <existing-id>
-SUPERSEDE: <old-id> WITH-PATTERN: <regex> PATHSPEC: <pathspec> [CLASS: <invariant>]
+
+SUPERSEDE: <old-id>
+BY: <existing-id>
+
+SUPERSEDE: <old-id>
+WITH-PATTERN: <regex>
+PATHSPEC: <pathspec>
+CLASS: <invariant>                  # optional
 ```
 
-*Round 6 [MAJOR]: a closed unmechanized class had no way back. `CLOSED` was
-listed but nothing reopened it, so once a reviewer judged such a class closed, a
-later reviewer finding it violated again could report that only in prose while
-the state stayed closed and the trailer said `NOT-BLOCKED`.* `REOPEN` closes
-that. It is unmechanized-only because a mechanized class reopens automatically on
-any match (§2.6).
-
-*Round 5 [MAJOR]: the earlier `SUPERSEDED-BY: <class-id> | PATTERN: … PATHSPEC: …`
-form could not name both sides — one id left the server unable to tell the
-superseded class from its replacement, and the pattern form named no class at
-all.* Both forms now name the source explicitly.
+*Round 6 [MAJOR]: a closed unmechanized class had no way back — `CLOSED` was
+listed but nothing reopened it, so a later reviewer finding it violated again
+could say so only in prose while the state stayed closed and the trailer said
+`NOT-BLOCKED`.* `REOPEN` closes that, and is unmechanized-only because a
+mechanized class reopens automatically on any match (§2.6).
 
 `WITH-PATTERN` mints a **new** server-assigned id inheriting the old class's
-`severity` and `first_round`. *Round 6 [MAJOR]: revision 6 said the replacement
-could restate its invariant but gave the form no field to do it in, forcing an
-implementation to either reject an undocumented field or carry stale invariant
-text that disagrees with the corrected predicate.* The optional `CLASS:` field is
-that form; omitted, the old invariant text carries over.
+`severity` and `first_round`; the optional `CLASS:` line restates the invariant,
+and the old text carries over when it is omitted.
 
 `BY` **requires a target that is distinct from the source, already registered in
-this lineage, and not itself superseded.** *Round 6 [FATAL]: revision 6 required
-only that the target "exist", so `SUPERSEDE: A BY: A` — or supersession by an
-already-superseded class — parsed, marked the source non-blocking and
-never-rechecked, and left no active blocker at all. A model-authored transition
-could therefore manufacture a false `NOT-BLOCKED`.* The distinctness and
+this lineage, and not itself superseded.** *Round 6 [FATAL]: requiring only that
+the target "exist" let `SUPERSEDE: A BY: A` — or supersession by an
+already-superseded class — parse, mark the source non-blocking and
+never-rechecked, and leave no active blocker at all.* The distinctness and
 liveness conditions also make cycles unreachable: `A BY B` marks A superseded, so
-a later `B BY A` fails on the liveness check. The target keeps its own
-`severity`; it inherits the **earlier** of the two `first_round` values.
+a later `B BY A` fails the liveness check. The target keeps its own `severity`
+and inherits the **earlier** of the two `first_round` values.
 
-In both forms the old class is marked `superseded`: non-blocking, and never
-rechecked again (§2.6). This is the recovery transition `malformed` and
-`over-broad` classes need.
+In both forms the old class becomes `superseded`: non-blocking, never rechecked
+(§2.6). This is the recovery transition `malformed` and `over-broad` classes need.
 
-**The register is mandatory and must be a bijection with the prose.**
-
-*Round 2 [FATAL]: revision 2 required `SCOPE: class` in prose and separately
-accepted `NONE` as an empty register, with nothing connecting them. A review
-containing `[MAJOR] … SCOPE: class` followed by `=== CLASS REGISTER === NONE`
-parsed, persisted nothing, and could return `NOT-BLOCKED` — the exact durability
-failure revision 2 claimed to close.*
-
-*Round 3 [FATAL]: revision 3's single bijection then made every **recurrence**
-response malformed, because a recurrence has no new `REF` and no severity of its
-own yet the rule demanded both. Revisions 4 and 5 answered that with a second,
-recurrence-specific bijection — which broke again at round 5 and again at round
-6.*
-
-**There is now exactly one bijection, over new classes only.** The set of
-`ref=` values on `kind=new-class` finding headers equals the set of `REF` values
-on register records, and each record's `SEVERITY` equals its header's
-`severity=`. Both sides of that comparison are single machine-readable tokens, so
-there is nothing left to infer — and because §2.2 requires a header on *every*
-finding, a class cannot be reported without appearing on one side of it.
-
-Recurrences are not in the register at all (§2.2) — the server computes them from
-git. `CLOSED`, `REOPEN`, `RECLASSIFY` and `SUPERSEDE` are state transitions, not
-findings, and bind to nothing in the prose. A prose header with no record, a
-record with no header, a duplicate ref, an unknown class id, or a severity
-disagreement is a malformed register. A review with no new classes and no
+**Parsing is as strict as `arbitration.parse_*`:** the block is terminal, every
+field required, duplicates and out-of-block records rejected, and an unknown
+class id on any transition is malformed. A review with no new classes and no
 transitions emits `=== CLASS REGISTER ===` followed by `NONE`.
 
-Parsing is as strict as `arbitration.parse_*`: the block is terminal, every field
-required, duplicates and out-of-block records rejected.
+**One retry, then durable debt.** An absent or malformed register triggers **one
+targeted re-ask on the same reviewer session** via `engines.Engine.resume` (the
+mechanism `rebut` already uses), requesting only the register block, not a
+re-review — the `arbitrate` cleaner idiom, one retry then fail, cheap because it
+does not re-run the review.
 
-**One retry, then block.** *Round 2 [MAJOR]: revision 2 said a malformed register
-blocks and "the operator either re-runs or exempts explicitly", but the exemption
-grammar needs a `class_id` that a missing register does not have — so the only
-real escape was the global kill switch.* An absent or malformed register triggers
-**one targeted re-ask on the same reviewer session** via `engines.Engine.resume`
-(the mechanism `rebut` already uses), requesting only the register block, not a
-re-review. This is the `arbitrate` cleaner idiom — one retry, then fail — and it
-is cheap because it does not re-run the review. If the retry also fails,
-`CONVERGENCE: BLOCKED — class register absent/malformed` and the block text
-quotes the exact expected grammar. **The review text is always returned in full**;
-a paid review is never discarded over a formatting miss.
-
-*Round 4 [MAJOR] gap: the retry is not always available. `Review.session_ref` is
+*Round 4 [MAJOR]: the retry is not always available. `Review.session_ref` is
 `str | None`, `Engine.resume` requires a `str`, and the Claude engine's supported
 non-JSON fallback returns `Review(text=…, session_ref=None)` — a contract
-`tests/test_engines.py` already pins. An unconditional retry on that path would
-raise and `dispatch` would replace the paid review with an error, which is the
-one outcome this section promises cannot happen.* **When `session_ref` is
-`None` the retry is skipped**, the original review is returned unchanged, and the
-malformed-register block is emitted directly.
+`tests/test_engines.py` already pins.* **When `session_ref` is `None` the retry
+is skipped**, the original review is returned unchanged, and the block is emitted
+directly. **The review text is always returned in full**; a paid review is never
+discarded over a formatting miss.
+
+*Round 9 [FATAL]: a twice-malformed register had no durable disposition. The
+per-response `BLOCKED` footer recorded nothing, so if that outcome cleared the
+pending latch the next round could initialize clean and the finding would be
+suppressed through the ordinary `already_raised` workflow; and if the latch
+stayed instead, it degraded into `STATE-UNAVAILABLE`, whose filesystem-only
+escape cannot repair a missing model register. The implementation had to choose
+between false clearance and an unrelated trap.* Neither is necessary: a failed
+register is written into lineage state as **register debt** — `{round, reason}` —
+which is a normal successful state write, so the latch clears cleanly. Debt
+blocks (`CONVERGENCE: BLOCKED — register debt from round N`) and is discharged by
+the next round whose register parses. It needs no new escape: the next clean
+review clears it, and that is a review the operator was going to run anyway.
 
 ### 2.4 Class identity is server-assigned
 
@@ -658,8 +632,11 @@ It is the escape of last resort, not the escape of first resort — §2.3, §2.8
 
 ## 4. Residual risks, stated
 
-1. **A reviewer can head every finding `kind=isolated`** and avoid the work. The
-   prompt states the criterion; nothing enforces it. Largest residual, unclosed.
+1. **A reviewer can simply not register a class it found**, or register nothing
+   at all. The prompt states the criterion; nothing enforces it, and round 9
+   established that nothing *can* — this is the ceiling of the whole design, not
+   an implementation gap (§2.2). Largest residual, unclosed, and now stated in §1
+   rather than papered over by a parser.
 2. **Violation-only regexes are hard to write**, so the `unmechanized` population
    will be larger than revision 1 implied — and unmechanized closure is a model's
    word, not a check. The price of §2.1, not hidden.
@@ -680,12 +657,12 @@ It is the escape of last resort, not the escape of first resort — §2.3, §2.8
 
 ## 5. Implementation
 
-New pure module `class_closure.py` — register parsing, prose/register bijection,
-class ids, status transitions, survivor computation, block rendering — with the
+New pure module `class_closure.py` — register parsing, class ids, status
+transitions, survivor computation, debt, block rendering — with the
 git call and the clock injected, keeping the repository's pure-core/injected-edge
 split. `handlers.py` wires it and owns the one register retry via
 `engines.Engine.resume`; `prompts.py` carries the register grammar, the
-the `FINDING:` header grammar and the `_CALIBRATION` amendments;
+the register grammar and the `_CALIBRATION` amendments;
 `orientation.py` renders the injected blocks after `already_raised`; `server.py`
 exposes `lineage`, `exempt`, `unexempt`, `class_closure`; `logs.py` records
 `base_id`/`head_id` (§6). **`README.md` is in scope, not optional** — *round 1
@@ -695,40 +672,47 @@ new authority.*
 
 TDD, RED first. Behavioural tests that must exist:
 
-**Register parsing and binding** (strictness matched to `arbitration.parse_*`,
-since this is a model-authored surface): two mechanized records parse; `NONE`
-parses as empty; absent → one retry, then `absent` + policy-dependent block;
-**a `kind=new-class` header with a `NONE` register is malformed** (round 2's
-FATAL); **a finding with no `FINDING:` header at all is malformed, so a
-class-scoped finding that omits both its header and its record cannot pass as
-`∅ == ∅`** (round 7's FATAL); **prose in a parsed section that is neither the
-exact `Nothing notable.` sentinel nor inside a record is malformed — including a
-second, headerless finding written as continuation prose under a valid
-`kind=isolated` record** (round 8's FATAL, the case a header alone could not
-catch); **a class reported under "Risks" or "Improvements" is subject to the same
-grammar**, and those sections parse exactly as "What doesn't work" does (round
-8's MAJOR), while "What works" is prose and is not parsed;
-**`kind=recurrence` naming an unknown class id is
-malformed, while a review with recurrence headers and a `NONE` register is
-well-formed**; header ref with no record, record with no header, duplicate ref, and
-**severity disagreement between header `severity=` and record `SEVERITY`** are
-each malformed; duplicate field within a record rejected; missing required field
-rejected; a record after the block's end rejected; a field name in earlier prose
+**Register parsing** (strictness matched to `arbitration.parse_*`, since this is
+the one model-authored surface that is parsed at all): two mechanized records
+parse; `NONE` parses as empty; absent → one retry, then register debt + block;
+duplicate field within a record rejected; missing required field rejected; a
+record after the block's end rejected; a field name appearing in earlier prose
 does not confuse the parser; unmechanized record with `PROCEDURE` parses;
 `CLOSED`/`REOPEN`/`RECLASSIFY`/`SUPERSEDE` naming an unknown id rejected; the
 retry path is taken exactly once and a successful retry parses; **a `Review` with
 `session_ref=None` skips the retry, returns its text unchanged, and blocks per
-policy** (round 4); **two new-class records sharing a pattern and pathspec get
-two distinct ids and two independent state objects** (round 4's dedup FATAL).
+policy** (round 4); **two records sharing a pattern and pathspec get two distinct
+ids and two independent state objects** (round 4's dedup FATAL).
+
+**Nothing outside the register is parsed** (round 9's FATAL — the record grammar
+was impossible, since a headerless continuation is by definition inside the
+preceding record): a review whose prose describes a class but whose register says
+`NONE` **parses cleanly and records nothing**, and the test asserts exactly that,
+because the opposite is unachievable and §1 now says so; **a clean late-round
+response whose "What doesn't work" body is `CONVERGED — no blocking findings at
+this round` parses** (round 9 — the record grammar made the existing calibration
+output unparseable); a prose `[MAJOR]` tag disagreeing with the register's
+`SEVERITY` is **not** a parse error, because the register's severity is the only
+one a class has (round 9's two-severity FATAL).
+
+**Multi-line supersession** (round 9's MAJOR): `SUPERSEDE`/`BY` and
+`SUPERSEDE`/`WITH-PATTERN`/`PATHSPEC`/`CLASS` each parse with one field per line;
+**a regex, pathspec or invariant whose text contains the literal `PATHSPEC:` or
+`CLASS:` still parses to the correct fields**, which the single-line form could
+not do.
+
+**Register debt** (round 9's FATAL): a twice-malformed register writes
+`{round, reason}` into lineage state, which is a **successful** state write that
+clears the pending latch; the debt blocks; the next round with a parsing register
+discharges it; a round whose register is malformed again keeps exactly one debt
+record rather than accumulating.
 
 **Recurrences are not parsed** (rounds 3, 5 and 6 — the mechanism's own hot path,
-broken three times by a hand-authored grammar that revision 7 deletes): a review
-that reports surviving matches only in prose, with a register of `NONE`, **is
-well-formed and still blocks** on the git result; a review that omits the
-recurrence prose entirely **also still blocks**, because the verdict never
-depended on the reviewer's text; `[RECURRENCE <id>]` appearing anywhere in the
-prose changes no parse outcome; a review mixing a new class and recurrence prose
-satisfies the single bijection over the new class alone.
+broken three times by a hand-authored grammar): a review that reports surviving
+matches only in prose, with a register of `NONE`, **is well-formed and still
+blocks** on the git result; a review that omits the recurrence prose entirely
+**also still blocks**, because the verdict never depended on the reviewer's text;
+`[RECURRENCE <id>]` appearing anywhere changes no parse outcome.
 
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,9 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 8. Seven codex plan-review rounds folded —
+Status: DRAFT for review, revision 9. Eight codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
-1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR. Every finding accepted.
+1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR. Every
+finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -118,10 +119,32 @@ to `unmechanized` (§2.10), which is materially weaker.** That trade is correct 
 a check that cannot be wrong about closure is worth more than a check with wider
 reach and an adjudication layer that can silently whitelist a live defect.
 
-### 2.2 Every finding declares its kind
+### 2.2 Every finding is a delimited record declaring its kind
 
-**Every** finding in "What doesn't work" and "Gaps" opens with exactly one
-machine-readable header line:
+*Round 8 [FATAL]: revision 8 asserted "a header on every finding is what makes
+omission observable" while §2.2 itself conceded there is no boundary between
+findings — `prompts._SECTION_BODIES` defines prose, with no bullet or record
+delimiter. One valid `kind=isolated` header followed by prose containing a
+second, headerless class finding is indistinguishable from one long isolated
+finding, so `NONE` still parsed and the class still vanished. The header was
+necessary and not sufficient.*
+
+**The four severity-tagged sections therefore become a record grammar, not
+prose.** Each of "What doesn't work", "Risks", "Gaps" and "Improvements" contains
+either the exact sentinel `Nothing notable.` or a sequence of records. A record
+begins with a `FINDING:` header at column 0 and runs to the next `FINDING:` or
+the next section heading. **Any text inside those sections that is not the
+sentinel and does not sit inside a record makes the review malformed** — which is
+what closes the FATAL: there is nowhere left for an undeclared finding to hide.
+
+*Round 8 [MAJOR]: revision 8 applied the grammar only to "What doesn't work" and
+"Gaps", but `prompts.CODE_REVIEW_INSTRUCTIONS` requires a severity tag on Risks
+and Improvements items too, and `_SECTION_BODIES` defines Risks as specific,
+testable failure modes — so a merge-blocking class could be reported under Risks
+with no header and no record at all.* All four are parsed; the "What works"
+section is prose and is not.
+
+Each record opens with exactly one machine-readable header line:
 
 ```
 FINDING: kind=isolated
@@ -147,9 +170,10 @@ header and the record produced `∅ == ∅`, `NONE` parsed, no retry fired, and 
 class was never persisted. Round 2's durability FATAL, back in a spelling the
 parser could not see. It could not be fixed by rejecting headerless class-scoped
 findings, because recurrences are class-scoped too and deliberately carry
-nothing.* **A header on every finding is what makes omission observable**: a
-finding with no header is a malformed review, so there is no longer a way to
-report a class without declaring what kind of thing it is.
+nothing.* **The record grammar above is what makes omission observable**: every
+finding is a delimited record, every record declares its kind, and unrecorded
+text is malformed — so there is no longer anywhere to report a class without
+declaring it.
 
 The `kind=recurrence` form is the **minimal** discriminator round 7 requires — a
 class id and nothing else. No ref, no severity, no sites, no matches, and no
@@ -423,6 +447,18 @@ in the same directory. A write failure, or existing state that will not parse,
 yields `CLASS-CLOSURE: STATE-UNAVAILABLE` and `CONVERGENCE: BLOCKED`. The review
 text is still returned.
 
+*Round 8 [FATAL]: the quarantine latch below covers a **parse** failure but not a
+**write** failure. If the very first registration fails to write — or an existing
+state fails to persist a new class — no `corrupt-*` sibling exists, so the next
+invocation reads nothing, initializes empty state, and reports `NOT-BLOCKED`. The
+false clearance this section forbids, reached by the one path the latch did not
+watch.* **A pending latch is therefore written before the engine call and cleared
+only after the round finishes with either a successful atomic state write or an
+explicit no-write outcome.** A latch present at read time is itself
+`STATE-UNAVAILABLE` + `BLOCKED`. It costs one small write per review and it makes
+the two failure modes symmetric: neither a corrupt read nor a failed write can
+silently become an empty lineage.
+
 **The escape from `STATE-UNAVAILABLE` is an operator filesystem action, named in
 the block text** (§1). Unparseable state is moved aside to
 `<lineage_id>.corrupt-<timestamp>.json`, and the message gives the absolute path
@@ -665,7 +701,14 @@ parses as empty; absent → one retry, then `absent` + policy-dependent block;
 **a `kind=new-class` header with a `NONE` register is malformed** (round 2's
 FATAL); **a finding with no `FINDING:` header at all is malformed, so a
 class-scoped finding that omits both its header and its record cannot pass as
-`∅ == ∅`** (round 7's FATAL); **`kind=recurrence` naming an unknown class id is
+`∅ == ∅`** (round 7's FATAL); **prose in a parsed section that is neither the
+exact `Nothing notable.` sentinel nor inside a record is malformed — including a
+second, headerless finding written as continuation prose under a valid
+`kind=isolated` record** (round 8's FATAL, the case a header alone could not
+catch); **a class reported under "Risks" or "Improvements" is subject to the same
+grammar**, and those sections parse exactly as "What doesn't work" does (round
+8's MAJOR), while "What works" is prose and is not parsed;
+**`kind=recurrence` naming an unknown class id is
 malformed, while a review with recurrence headers and a `NONE` register is
 well-formed**; header ref with no record, record with no header, duplicate ref, and
 **severity disagreement between header `severity=` and record `SEVERITY`** are
@@ -739,8 +782,12 @@ returned, **and the corrupt file is quarantined to a named path rather than
 overwritten or silently replaced by a fresh lineage**; **re-running after a
 quarantine does NOT start a fresh lineage — it blocks again until the quarantine
 sibling is gone** (round 4's latch FATAL); write failure → same outcome, message
-names directory and errno; state replaced atomically; a failed engine call leaves
-state byte-identical.
+names directory and errno; **a failed write leaves the pending latch in place, so
+the next invocation blocks instead of initializing empty state** (round 8's
+FATAL); **a pending latch found at read time blocks even with no state file and
+no quarantine sibling**; the latch is cleared after a successful write and after
+an explicit no-write outcome; state replaced atomically; a failed engine call
+leaves state byte-identical.
 
 **Exemptions:** an exempt match is subtracted; **a second, textually identical
 line in the same file is not** (round 2's collision); an exemption whose line

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,6 +1,13 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 16. Fifteen codex plan-review rounds folded —
+Status: **IMPLEMENTED**, revision 16. Fifteen codex plan-review rounds folded, then
+eight codex code-review rounds against the implementation (2 BLOCKER, 20 MAJOR, 6 MINOR,
+6 gaps; converged at round 8). Where the code and this brief differ, the code is now the
+authority — the implementation review changed real decisions, chiefly: the closure budget
+measures git-grep time rather than wall-clock (a deadline spanning the reviewer call left
+every newly registered class unchecked); an undisplayable match can never be exempted;
+lineage state is keyed to a fixed root rather than following `--log-dir`; and parse and
+apply are one retried transaction. Plan-review rounds —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,11 +1,11 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 14. Thirteen codex plan-review rounds folded —
+Status: DRAFT for review, revision 15. Fourteen codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR; round 10: 1 FATAL; rounds 11, 12 and 13: one MAJOR each and
-nothing in any other section. Every finding accepted.
+4 FATAL, 2 MAJOR; round 10: 1 FATAL; rounds 11–14: one MAJOR each and nothing in
+any other section. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -353,6 +353,21 @@ checkout needed.
   so paths containing newlines or non-UTF-8 bytes parse unambiguously. Decode
   with `surrogateescape`, matching the `orientation`/`evidence` precedent.
   *(Round 1 [MINOR]: revision 1 omitted `-z`.)*
+
+  *Round 14 [MAJOR]: parsing safely is not enough — revision 14 then injected
+  `<path>:<line>: <text>` into the packet verbatim. `orientation.ChangeEntry`'s
+  docstring already warns that `surrogateescape`-decoded paths must "never render
+  them into the packet directly", which is why `orientation._display` exists and
+  is documented as INJECTIVE; and both runner paths write stdin in text mode
+  (`runner.py` `text=True`), where the streaming writer catches only
+  `BrokenPipeError`/`OSError`. A `UnicodeEncodeError` is a `ValueError`, so a lone
+  surrogate would either abort the review outright or leave the child waiting on
+  an unwritten stdin until the timeout — over a filename.* **Every path *and every
+  matched line* is rendered through the injective display helper before it reaches
+  the packet, the footer or the trailer**; `_display` is promoted out of
+  `orientation` into a shared helper for that. Injectivity matters as much as
+  safety: two distinct paths must not collapse onto one label in a block the
+  operator reads as an exhaustive match list.
 - Exit codes: `0` = matches, `1` = **no matches, which is success and means
   closed**, `≥2` = error. A malformed ERE exits `128` with
   `fatal: -e option, 'a[': Invalid regular expression`.
@@ -826,7 +841,10 @@ recheck sweep.
 **Git boundary:** exit 1 is closure, not failure; exit ≥ 2, invalid ERE, and
 timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,
 counted block; aggregate budget exhaustion → `unchecked`; a path containing a
-newline and a non-UTF-8 byte parses correctly under `-z`; a pathspec beginning
+newline and a non-UTF-8 byte parses correctly under `-z`, **and the fully rendered
+packet, footer and trailer containing that match all encode as UTF-8** — asserted
+on the rendered output, not merely on the parsed grep result — **with two paths
+differing only in a non-UTF-8 byte rendering to distinct labels** (round 14); a pathspec beginning
 with `:` is rejected before any git call; registration beyond 100 non-superseded classes is
 refused.
 

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,11 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 11. Ten codex plan-review rounds folded —
+Status: DRAFT for review, revision 12. Eleven codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR; round 10: 1 FATAL, no risks, no gaps. Every finding accepted.
+4 FATAL, 2 MAJOR; round 10: 1 FATAL; round 11: 1 MAJOR, no FATALs, no risks, no
+gaps. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -348,8 +349,18 @@ checkout needed.
 risk: revision 2 bounded each class but not the round, so a lineage of 36
 timed-out classes would delay every round by six minutes before the reviewer even
 starts* — a **60 s aggregate budget** across all classes. Classes not reached are
-recorded `unchecked`. Registration is refused beyond 100 tracked classes, with a
-message.
+recorded `unchecked`. Registration is refused beyond 100 **non-superseded**
+classes, with a message.
+
+*Round 11 [MAJOR]: counting every tracked class made the cap remove the recovery
+path at exactly the boundary it establishes — with 100 classes held, correcting a
+unique malformed or over-broad `MAJOR` predicate needs a 101st object and would
+be refused, leaving permanent `BLOCKED` unless the reviewer dishonestly
+downgraded the severity or the operator reached for the kill switch. That
+contradicts §1's named-escape guarantee.* Superseded classes are inert — never
+rechecked, never blocking — so they do not consume the budget the cap exists to
+protect, and `SUPERSEDE … WITH-PATTERN` applies atomically as one active class
+retired and one added: net zero, and therefore always available at the boundary.
 
 Under violation-only semantics many matches means many violations, so the cap is
 an output bound, not a verdict: the block text is truncated with a count. A regex
@@ -734,6 +745,10 @@ blocks** on the git result; a review that omits the recurrence prose entirely
 **also still blocks**, because the verdict never depended on the reviewer's text;
 `[RECURRENCE <id>]` appearing anywhere changes no parse outcome.
 
+**Cap boundary** (round 11): at exactly 100 non-superseded classes a new
+registration is refused, **but `SUPERSEDE … WITH-PATTERN` still succeeds**
+because it is net zero; superseded classes do not count toward the cap.
+
 **New-class evaluation** (round 10's FATAL): a review registering a new `MAJOR`
 class whose predicate still matches **cannot** emit `NOT-BLOCKED` in that same
 round; `SUPERSEDE … WITH-PATTERN` cannot emit `NOT-BLOCKED` before the
@@ -771,7 +786,7 @@ recheck sweep.
 timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,
 counted block; aggregate budget exhaustion → `unchecked`; a path containing a
 newline and a non-UTF-8 byte parses correctly under `-z`; a pathspec beginning
-with `:` is rejected before any git call; registration beyond 100 classes is
+with `:` is rejected before any git call; registration beyond 100 non-superseded classes is
 refused.
 
 **Blocking policy:** `MAJOR` class blocks; `MINOR` and `OUT-OF-SCOPE` do not and

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 13. Twelve codex plan-review rounds folded —
+Status: DRAFT for review, revision 14. Thirteen codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR; round 10: 1 FATAL; round 11: 1 MAJOR; round 12: 1 MAJOR, and
+4 FATAL, 2 MAJOR; round 10: 1 FATAL; rounds 11, 12 and 13: one MAJOR each and
 nothing in any other section. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
@@ -224,7 +224,22 @@ SUPERSEDE: <old-id>
 WITH-PATTERN: <regex>
 PATHSPEC: <pathspec>
 CLASS: <invariant>                  # optional
+
+SUPERSEDE: <old-id>
+WITH-PROCEDURE: <procedure>
+CLASS: <invariant>                  # optional
 ```
+
+*Round 13 [MAJOR]: supersession could only mint another **mechanized** class, so
+the one transition §2.1 predicts would be needed most was missing. §2.1 concedes
+that under violation-only semantics "more invariants are inexpressible and fall
+to `unmechanized`" — but a `MAJOR` class first registered with a malformed or
+over-broad regex, and then found to be inexpressible, had no way to become a
+`PROCEDURE`. At the 100-active-class boundary ordinary registration is refused
+and only the net-zero pattern replacement was guaranteed available, so such a
+class stayed permanently `BLOCKED` short of an inaccurate downgrade or the kill
+switch — again contradicting §1's named-escape guarantee.* `WITH-PROCEDURE` is
+the same atomic net-zero transition into an unmechanized replacement.
 
 *Round 6 [MAJOR]: a closed unmechanized class had no way back — `CLOSED` was
 listed but nothing reopened it, so a later reviewer finding it violated again
@@ -232,9 +247,10 @@ could say so only in prose while the state stayed closed and the trailer said
 `NOT-BLOCKED`.* `REOPEN` closes that, and is unmechanized-only because a
 mechanized class reopens automatically on any match (§2.6).
 
-`WITH-PATTERN` mints a **new** server-assigned id inheriting the old class's
-`severity` and `first_round`; the optional `CLASS:` line restates the invariant,
-and the old text carries over when it is omitted.
+`WITH-PATTERN` and `WITH-PROCEDURE` each mint a **new** server-assigned id
+inheriting the old class's `severity` and `first_round`; the optional `CLASS:`
+line restates the invariant, and the old text carries over when it is omitted.
+Both are net zero against the cap (§2.5).
 
 `BY` **requires a target that is distinct from the source, already registered in
 this lineage, and not itself superseded.** *Round 6 [FATAL]: requiring only that
@@ -764,8 +780,15 @@ blocks** on the git result; a review that omits the recurrence prose entirely
 `[RECURRENCE <id>]` appearing anywhere changes no parse outcome.
 
 **Cap boundary** (round 11): at exactly 100 non-superseded classes a new
-registration is refused, **but `SUPERSEDE … WITH-PATTERN` still succeeds**
-because it is net zero; superseded classes do not count toward the cap.
+registration is refused, **but `SUPERSEDE … WITH-PATTERN` and
+`SUPERSEDE … WITH-PROCEDURE` both still succeed** because each is net zero;
+superseded classes do not count toward the cap.
+
+**Mechanized → unmechanized recovery** (round 13): a `MAJOR` class whose regex is
+`malformed` or `over-broad` and whose invariant turns out to be inexpressible can
+be replaced by `SUPERSEDE`/`WITH-PROCEDURE`; the replacement is unmechanized,
+starts `open`, blocks per severity, and closes only on a later `CLOSED:` — and
+this works at the cap boundary too.
 
 **New-class evaluation** (round 10's FATAL): a review registering a new `MAJOR`
 class whose predicate still matches **cannot** emit `NOT-BLOCKED` in that same

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,11 +1,11 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 12. Eleven codex plan-review rounds folded —
+Status: DRAFT for review, revision 13. Twelve codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
 1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR; round 8: 2 FATAL, 1 MAJOR; round 9:
-4 FATAL, 2 MAJOR; round 10: 1 FATAL; round 11: 1 MAJOR, no FATALs, no risks, no
-gaps. Every finding accepted.
+4 FATAL, 2 MAJOR; round 10: 1 FATAL; round 11: 1 MAJOR; round 12: 1 MAJOR, and
+nothing in any other section. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -424,13 +424,31 @@ exists precisely to review a branch that is not checked out — so reviewing
 detached checkout wrongly rejected a perfectly stable `head_ref`.*
 
 `lineage_id` = `sha256(resolved_repo_path, base_ref, head_symbolic_name)[:12]`,
-where `head_symbolic_name` is `git rev-parse --symbolic-full-name <head_ref>` on
-the **reviewed** ref. **Verified: for a commit sha this exits 0 and prints
-nothing** — so the test is empty output, not exit status. Empty means the
-reviewed ref is not a branch, and an explicit `lineage` argument is then
-required, the call erroring without one. Fail-closed beats silently minting a
-fresh lineage every round. Every trailer prints
-`LINEAGE: <id> (rounds recorded: N)` so an unintended split is visible.
+where `head_symbolic_name` comes from the **reviewed** ref by one of two commands:
+
+- **A named `head_ref`** → `git rev-parse --symbolic-full-name <head_ref>`.
+  **Verified: for a commit sha this exits 0 and prints nothing** — so the test is
+  empty output, not exit status. Empty means the reviewed ref is not a branch, an
+  explicit `lineage` argument is required, and the call errors without one.
+  Fail-closed beats silently minting a fresh lineage every round.
+- **The checkout itself** — a dirty target, or `head_ref` defaulted to `HEAD` →
+  `git symbolic-ref -q HEAD`.
+
+*Round 12 [MAJOR]: using `rev-parse --symbolic-full-name` for the checkout breaks
+the unborn-repository workflow this repo deliberately supports.
+`handlers._converge_branch_review` branches on `orientation.has_head(repo)` and
+falls back to `orientation.empty_tree`, and `tests/test_converge.py`'s
+`test_converge_on_unborn_repo` exercises exactly that path with
+`include_uncommitted: True` and no explicit lineage. With class closure on by
+default, that first-review workflow would have errored before the reviewer ran.
+Verified on a fresh `git init`: `rev-parse --symbolic-full-name HEAD` exits 128
+with `fatal: ambiguous argument 'HEAD'`, while `symbolic-ref -q HEAD` returns
+`refs/heads/master` and exit 0.* `symbolic-ref` reads the ref HEAD *points at*
+rather than resolving it to an object, which is why it works before the first
+commit — and an unborn branch is a perfectly good lineage key.
+
+Every trailer prints `LINEAGE: <id> (rounds recorded: N)` so an unintended split
+is visible.
 
 *Round 3 [MAJOR]: for dirty reviews that rule keys state to a branch the server
 is not reviewing. Verified: `orientation.resolve_target` returns `head_ref=None`
@@ -799,7 +817,10 @@ mechanized match counts from unmechanized awaiting-judgement; `NOT-BLOCKED` text
 does not contain the word *converged*; when blocked, the footer voids a reviewer
 `CONVERGED`.
 
-**Lineage:** a reviewed `head_ref` that is a branch but not checked out yields
+**Lineage:** **an unborn repository reviewed dirty with no explicit `lineage`
+succeeds and keys on `symbolic-ref -q HEAD`** — `test_converge_on_unborn_repo`
+must still pass with class closure at its default (round 12); a reviewed
+`head_ref` that is a branch but not checked out yields
 its own lineage, and two such branches off one base differ; a `head_ref` that is
 a sha (empty `--symbolic-full-name` output, exit 0) without `lineage` errors;
 **a dirty target uses the checkout's `HEAD` and rejects a supplied `head_ref`**

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,9 +1,9 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 7. Six codex plan-review rounds folded —
+Status: DRAFT for review, revision 8. Seven codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
 1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
-1 FATAL, 5 MAJOR. Every finding accepted.
+1 FATAL, 5 MAJOR; round 7: 1 FATAL, 3 MAJOR. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -118,29 +118,45 @@ to `unmechanized` (§2.10), which is materially weaker.** That trade is correct 
 a check that cannot be wrong about closure is worth more than a check with wider
 reach and an adjudication layer that can silently whitelist a live defect.
 
-### 2.2 Findings declare their scope and carry a reference
+### 2.2 Every finding declares its kind
 
-Every finding in "What doesn't work" and "Gaps" carries `SCOPE: isolated` or
-`SCOPE: class`. `SCOPE: class` means *the reasoning that condemned this site
-would condemn another site if one existed*. A genuine off-by-one is `isolated`;
-requiring class machinery for it is the over-engineering
-`prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
-
-A finding reporting a **new class** — an invariant the lineage does not yet hold
-— additionally opens with one machine-readable line:
+**Every** finding in "What doesn't work" and "Gaps" opens with exactly one
+machine-readable header line:
 
 ```
-CLASS-FINDING: ref=<short token unique in this review> severity=<BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE>
+FINDING: kind=isolated
+FINDING: kind=new-class ref=<short token unique in this review> severity=<BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE>
+FINDING: kind=recurrence class=<class-id>
 ```
+
+`new-class` means *the reasoning that condemned this site would condemn another
+site if one existed, and the lineage does not already hold that invariant*. A
+genuine off-by-one is `isolated`; requiring class machinery for it is the
+over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
 
 *Round 6 [MAJOR]: revision 6 asked the parser to associate a `CLASS-REF` with
 "its finding's severity tag", but `prompts._SECTION_BODIES` defines prose
 content, not machine-delimited finding records — there is no boundary to
 attribute a tag to, and the `arbitration` precedent only works because it slices
-a fixed terminal field count. Multiple findings, or a severity tag quoted inside
-one, made ownership ambiguous, and the register-only retry could not repair
-prose.* The header carries both fields itself, so no prose-boundary inference is
-needed anywhere.
+a fixed terminal field count.* The header carries every field it needs, so no
+prose-boundary inference is needed anywhere.
+
+*Round 7 [FATAL]: revision 7 headed only new-class findings, and then compared
+header refs against register refs — so a reviewer that omitted **both** the
+header and the record produced `∅ == ∅`, `NONE` parsed, no retry fired, and the
+class was never persisted. Round 2's durability FATAL, back in a spelling the
+parser could not see. It could not be fixed by rejecting headerless class-scoped
+findings, because recurrences are class-scoped too and deliberately carry
+nothing.* **A header on every finding is what makes omission observable**: a
+finding with no header is a malformed review, so there is no longer a way to
+report a class without declaring what kind of thing it is.
+
+The `kind=recurrence` form is the **minimal** discriminator round 7 requires — a
+class id and nothing else. No ref, no severity, no sites, no matches, and no
+register counterpart. It is validated only in that the id must name a class the
+lineage holds. This deliberately does not resurrect the grammar that broke in
+rounds 3, 5 and 6: omitting recurrence findings entirely cannot break the verdict,
+because the verdict comes from git regardless (§2.6).
 
 **Recurrences carry nothing.** *Round 3 [FATAL], round 5 [FATAL] and round 6
 [MAJOR] were all the same wound: a hand-authored recurrence grammar that had to
@@ -228,10 +244,11 @@ recurrence-specific bijection — which broke again at round 5 and again at roun
 6.*
 
 **There is now exactly one bijection, over new classes only.** The set of
-`CLASS-FINDING` header `ref=` values in the prose equals the set of `REF` values
-on new-class records, and each record's `SEVERITY` equals its header's
+`ref=` values on `kind=new-class` finding headers equals the set of `REF` values
+on register records, and each record's `SEVERITY` equals its header's
 `severity=`. Both sides of that comparison are single machine-readable tokens, so
-there is nothing left to infer.
+there is nothing left to infer — and because §2.2 requires a header on *every*
+finding, a class cannot be reported without appearing on one side of it.
 
 Recurrences are not in the register at all (§2.2) — the server computes them from
 git. `CLOSED`, `REOPEN`, `RECLASSIFY` and `SUPERSEDE` are state transitions, not
@@ -492,7 +509,7 @@ recorded one rather than an operator's silent assumption.
 
 *Round 3 [MAJOR]: revision 3 said they "cannot block mechanically", which
 conflated **nothing to run** with **not blocking**. Since `NOT-BLOCKED` is
-defined as "no unclosed class" and is the documented stop signal, an open
+the documented stop signal, an open
 unmechanized `MAJOR` would have let the trailer report `NOT-BLOCKED` with a known
 major class outstanding — and §4.6 deliberately routes every semantic invariant
 down this path, so that is the common case, not an edge one.* **An unmechanized
@@ -513,9 +530,16 @@ CONVERGENCE: BLOCKED — 2 class(es) unclosed:
   91b0e77d <invariant> (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)
 ```
 
-or `CONVERGENCE: NOT-BLOCKED — no unclosed class; reviewer findings still govern.`
+or `CONVERGENCE: NOT-BLOCKED — no blocking class is unclosed; advisory classes
+may remain open. Reviewer findings still govern.`
 
-The second wording is deliberate and non-negotiable per §1: it is not a
+*Round 7 [MAJOR]: revision 7 mandated "no unclosed class", which is a false
+factual assertion whenever a `MINOR` or `OUT-OF-SCOPE` class is open — and those
+are tracked-but-advisory by §2.9, so the documented stop signal would routinely
+contradict the state in the same trailer.* The wording now says only what is
+true.
+
+That wording is otherwise deliberate and non-negotiable per §1: it is not a
 convergence verdict.
 
 *Round 1 [MAJOR] risk: `_CALIBRATION` still instructs the reviewer to print
@@ -550,6 +574,26 @@ Nothing in that instruction is parsed. The classes are already open and already
 blocking on the git result; the instruction exists so the review the operator
 reads addresses them, not so the parser can check that it did.
 
+A **second** reserved block lists every unmechanized class the lineage holds,
+**including closed ones**, with id and status:
+
+```
+=== UNMECHANIZED CLASSES — no predicate; you are the check ===
+[3f2a91c4, MAJOR, open, first raised round 7] <invariant>
+  procedure: <procedure>
+[91b0e77d, MAJOR, closed at round 9] <invariant>
+  procedure: <procedure>
+```
+
+*Round 7 [MAJOR] gap: §2.10 promised unmechanized classes are "always shown", but
+the only specified injection was `=== UNCLOSED CLASSES ===`, whose entries are by
+definition not closed. A closed unmechanized class was therefore invisible to
+every later reviewer, so the `REOPEN` added at round 6 was unreachable in
+practice — the defect could recur while the state stayed closed and the trailer
+said `NOT-BLOCKED`.* Closed entries are listed precisely so a later cold reviewer
+has the id it needs to emit `REOPEN`. Both blocks are reserved from the packet
+budget rather than trimmed.
+
 *Round 2 [MINOR] risk: `orientation.build_packet` appends `already_raised` last
 (`sections.append(reserved)` after the evidence and the truncation marker), so a
 recurrence block placed before it would leave the suppressive instruction nearest
@@ -578,7 +622,7 @@ It is the escape of last resort, not the escape of first resort — §2.3, §2.8
 
 ## 4. Residual risks, stated
 
-1. **A reviewer can tag everything `SCOPE: isolated`** and avoid the work. The
+1. **A reviewer can head every finding `kind=isolated`** and avoid the work. The
    prompt states the criterion; nothing enforces it. Largest residual, unclosed.
 2. **Violation-only regexes are hard to write**, so the `unmechanized` population
    will be larger than revision 1 implied — and unmechanized closure is a model's
@@ -605,7 +649,7 @@ class ids, status transitions, survivor computation, block rendering — with th
 git call and the clock injected, keeping the repository's pure-core/injected-edge
 split. `handlers.py` wires it and owns the one register retry via
 `engines.Engine.resume`; `prompts.py` carries the register grammar, the
-`SCOPE`/`CLASS-FINDING` rules and the `_CALIBRATION` amendments;
+the `FINDING:` header grammar and the `_CALIBRATION` amendments;
 `orientation.py` renders the injected blocks after `already_raised`; `server.py`
 exposes `lineage`, `exempt`, `unexempt`, `class_closure`; `logs.py` records
 `base_id`/`head_id` (§6). **`README.md` is in scope, not optional** — *round 1
@@ -618,8 +662,12 @@ TDD, RED first. Behavioural tests that must exist:
 **Register parsing and binding** (strictness matched to `arbitration.parse_*`,
 since this is a model-authored surface): two mechanized records parse; `NONE`
 parses as empty; absent → one retry, then `absent` + policy-dependent block;
-**a `CLASS-FINDING` header in prose with a `NONE` register is malformed** (round
-2's FATAL); header ref with no record, record with no header, duplicate ref, and
+**a `kind=new-class` header with a `NONE` register is malformed** (round 2's
+FATAL); **a finding with no `FINDING:` header at all is malformed, so a
+class-scoped finding that omits both its header and its record cannot pass as
+`∅ == ∅`** (round 7's FATAL); **`kind=recurrence` naming an unknown class id is
+malformed, while a review with recurrence headers and a `NONE` register is
+well-formed**; header ref with no record, record with no header, duplicate ref, and
 **severity disagreement between header `severity=` and record `SEVERITY`** are
 each malformed; duplicate field within a record rejected; missing required field
 rejected; a record after the block's end rejected; a field name in earlier prose
@@ -700,7 +748,10 @@ text changed is void and the match resurfaces; `unexempt` restores a match; both
 appear under `CLAIMED EXEMPT` and in the trailer.
 
 **Packet:** the unclosed-classes block is rendered after `already_raised` and
-survives budget trimming.
+survives budget trimming; **a closed unmechanized class still appears, with its
+id and `closed` status, in the unmechanized block of a later round's packet**
+(round 7 — without this, `REOPEN` is unreachable), and both reserved blocks
+survive trimming.
 
 **Kill switch:** `class_closure: false` reproduces today's behaviour exactly.
 

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,10 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 2. One codex plan-review round folded — 3 FATAL,
-15 MAJOR, 2 MINOR. Every finding accepted. Round 1's three FATALs were not
-patchable: they killed the candidate-enumeration design outright and it has been
-replaced (§2.1), which in turn deleted five of the MAJORs rather than answering
-them.
+Status: DRAFT for review, revision 3. Two codex plan-review rounds folded — round
+1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR. Every finding
+accepted. Round 1's FATALs killed the candidate-enumeration design outright and
+it was replaced (§2.1); round 2's FATAL found that the replacement still had no
+link between a prose finding and a register record, which §2.3 now closes.
 
 ## 0. The defect this fixes
 
@@ -35,8 +35,8 @@ live.** Three mechanisms in this repository produce that outcome:
    Round 8 had no way to know it was re-reporting round 7's invariant.
 3. **The severity floor meters the leak.** `prompts._CALIBRATION` tells round ≥ 3
    to withhold everything below `[MAJOR]`. A class surviving at a new site only
-   surfaces when that individual site clears the floor — which is the one-per-round
-   trickle observed at rounds 7–9.
+   surfaces when that individual site clears the floor — the one-per-round trickle
+   observed at rounds 7–9.
 
 There is no lineage state of any kind: `logs.write_log` writes one record per
 call and nothing links round 9 to round 7.
@@ -60,8 +60,9 @@ emits `BLOCKED` or `NOT-BLOCKED` and says which. Wording that reads as
 failure mode in a new costume.
 
 **Must not become a termination trap.** A mechanism that can block indefinitely
-on marginal findings would reproduce the failure it exists to prevent, in a form
-the operator cannot escape. §2.9 bounds what may block.
+on a marginal or mistaken finding would reproduce the failure it exists to
+prevent, in a form the operator cannot escape. §2.9 bounds what may block, and
+every blocking state has a named escape that is not the kill switch.
 
 ## 2. Mechanism
 
@@ -73,7 +74,7 @@ each match, and made the class identity the candidate regex. Two distinct
 invariants over the same syntax collapsed to one class; git could recheck only
 candidate presence, never whether the invariant was still violated; and the
 register had no way to express which of several matches in one file a given
-adjudication referred to. Revision 2 takes round 1's own remedy.*
+adjudication referred to. Revision 2 took round 1's own remedy.*
 
 **A mechanized class's predicate is a regex that matches only violations.
 Closure is exactly: zero matches.**
@@ -81,83 +82,98 @@ Closure is exactly: zero matches.**
 This deletes the entire adjudication apparatus — no `SITES` verdicts, no
 conforming whitelist, no site identity in the closure algorithm, no
 line-number-versus-text matching problem, and no "broad pattern blocks forever"
-trap. It buys that at a real cost, stated plainly: **more invariants will be
-inexpressible and fall to `unmechanized` (§2.10), which is materially weaker.**
-That trade is correct — a check that cannot be wrong about closure is worth more
-than a check with wider reach and an adjudication layer that can silently
-whitelist a live defect.
+trap. The cost is real and stated: **more invariants are inexpressible and fall
+to `unmechanized` (§2.10), which is materially weaker.** That trade is correct —
+a check that cannot be wrong about closure is worth more than a check with wider
+reach and an adjudication layer that can silently whitelist a live defect.
 
-### 2.2 Findings declare their scope
+### 2.2 Findings declare their scope and carry a reference
 
 Every finding in "What doesn't work" and "Gaps" carries `SCOPE: isolated` or
-`SCOPE: class`.
+`SCOPE: class`. `SCOPE: class` means *the reasoning that condemned this site
+would condemn another site if one existed*. A genuine off-by-one is `isolated`;
+requiring class machinery for it is the over-engineering
+`prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
 
-`SCOPE: class` means *the reasoning that condemned this site would condemn
-another site if one existed*. A genuine off-by-one is `isolated`; requiring class
-machinery for it is the over-engineering `prompts.CODE_REVIEW_INSTRUCTIONS`
-already calls a defect.
+A `SCOPE: class` finding additionally carries `CLASS-REF: <short token>`, unique
+within the review.
 
-### 2.3 The class register
+### 2.3 The class register, and its binding to the prose
 
 The review ends with a machine-readable block — one record per class, following
 the `arbitrate` trailer idiom. Mechanized:
 
 ```
 === CLASS REGISTER ===
+REF: <the CLASS-REF token from the finding>
 CLASS: <the invariant, one line, stated without reference to any site>
 SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
 PATTERN: <POSIX-extended regex matching VIOLATIONS ONLY>
 PATHSPEC: <git pathspec, or . for the whole tree>
 ```
 
-Unmechanized:
+Unmechanized records replace `PATTERN`/`PATHSPEC` with
+`PROCEDURE: <what a reviewer must do to find every violation>`. Transitions
+against classes the server already carries:
 
 ```
-CLASS: <the invariant, one line>
-SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
-PROCEDURE: <what a reviewer must do to find every violation>
-```
-
-References to classes the server already carries:
-
-```
-RECURRENCE: <class-id>          # this round's finding is an instance of it
-CLOSED: <class-id>              # unmechanized only; judged closed this round
+RECURRENCE: <class-id>              # this round's finding is an instance of it
+CLOSED: <class-id>                  # unmechanized only; judged closed this round
+RECLASSIFY: <class-id> <severity>   # a later cold reviewer corrects the severity
 SUPERSEDED-BY: <class-id> | PATTERN: <regex> PATHSPEC: <pathspec>
 ```
 
-**The register is mandatory.** A review with no classes must emit
-`=== CLASS REGISTER ===` followed by `NONE`.
+**The register is mandatory and must be a bijection with the prose.**
 
-*Round 1 [FATAL]: revision 1 made an absent register fail open, which contradicts
-the durability guarantee — a reviewer could report a class in prose, omit the
-block, and have it neither tracked nor blocking.* An absent or unparseable
-register now yields `CONVERGENCE: BLOCKED — class register absent/malformed`.
-**The review text is still returned in full** — a paid review is never discarded
-over a formatting miss — but the round cannot be reported unblocked, so the
-operator either re-runs or exempts explicitly. Parsing is as strict as
-`arbitration.parse_*`: the block is terminal, every field required, duplicates
-and out-of-block records rejected.
+*Round 2 [FATAL]: revision 2 required `SCOPE: class` in prose and separately
+accepted `NONE` as an empty register, with nothing connecting them. A review
+containing `[MAJOR] … SCOPE: class` followed by `=== CLASS REGISTER === NONE`
+parsed, persisted nothing, and could return `NOT-BLOCKED` — the exact durability
+failure revision 2 claimed to close.*
+
+The parser now cross-checks: **the set of `CLASS-REF` tokens in the prose and the
+set of `REF` values in the register must be equal**, and each record's `SEVERITY`
+must equal its finding's severity tag. A prose class with no record, a record
+with no prose, a duplicate ref, or a severity disagreement is a malformed
+register. A review with genuinely no classes emits `=== CLASS REGISTER ===`
+followed by `NONE` and no `SCOPE: class` finding.
+
+Parsing is as strict as `arbitration.parse_*`: the block is terminal, every field
+required, duplicates and out-of-block records rejected.
+
+**One retry, then block.** *Round 2 [MAJOR]: revision 2 said a malformed register
+blocks and "the operator either re-runs or exempts explicitly", but the exemption
+grammar needs a `class_id` that a missing register does not have — so the only
+real escape was the global kill switch.* An absent or malformed register triggers
+**one targeted re-ask on the same reviewer session** via `engines.Engine.resume`
+(the mechanism `rebut` already uses), requesting only the register block, not a
+re-review. This is the `arbitrate` cleaner idiom — one retry, then fail — and it
+is cheap because it does not re-run the review. If the retry also fails,
+`CONVERGENCE: BLOCKED — class register absent/malformed` and the block text
+quotes the exact expected grammar. **The review text is always returned in full**;
+a paid review is never discarded over a formatting miss.
 
 ### 2.4 Class identity is server-assigned
 
 *Round 1 [MAJOR]: revision 1 hashed the reviewer's regex into the id, so a
 corrected predicate minted a new class and the old one blocked forever, and
-unmechanized classes had no id at all yet were required to be closed by id.*
+unmechanized classes had no id at all yet were required to close by id.*
 
 The server assigns `class_id` (8 hex chars) at first registration and it never
 changes. Reviewer-authored text never determines identity, so it does not matter
 that round 7 called the class "escalations" and round 9 "unresolved starts" — a
 label match would never have connected them anyway.
 
-Two guards against duplicate registration of one class: the open classes are
-shown to every subsequent reviewer with their ids and invariants, with the
-instruction to emit `RECURRENCE: <id>` rather than register a new class; and the
-server dedupes on identical normalized `(pattern, pathspec)` at registration.
+Duplicate registration of one class is guarded twice: open classes are shown to
+every subsequent reviewer with ids and invariants, with the instruction to emit
+`RECURRENCE: <id>` rather than register anew; and the server dedupes on identical
+normalized `(pattern, pathspec)`.
 
-A corrected predicate is registered with `SUPERSEDED-BY`, which marks the old
-class `superseded` (non-blocking) and carries its `first_round` forward. This is
-the recovery transition `malformed` and `over-broad` classes need.
+*Round 2 [MAJOR]: revision 2 deduped without a conflict rule, so a `MINOR` and a
+`MAJOR` record sharing a predicate had an unspecified outcome — and discarding
+the latter would return `NOT-BLOCKED` for a registered major class.* **Dedup takes
+the maximum severity and retains both invariant texts.** Max severity fails
+toward blocking.
 
 ### 2.5 The git invocation
 
@@ -173,34 +189,45 @@ it. `git` is already a hard prerequisite; `rg` is not present on the reference
 machine and is not introduced. `git grep <commit>` reads the tree directly — no
 checkout needed.
 
-**Verified empirically in this repository today:**
+**Verified empirically in this repository:**
 
 - `-z` output is `<commit>:<path>\0<line>\0<text>\n`. Paths are NUL-terminated,
   so paths containing newlines or non-UTF-8 bytes parse unambiguously. Decode
   with `surrogateescape`, matching the `orientation`/`evidence` precedent.
-  *(Round 1 [MINOR]: revision 1 omitted `-z` and would have mis-parsed such paths.)*
+  *(Round 1 [MINOR]: revision 1 omitted `-z`.)*
 - Exit codes: `0` = matches, `1` = **no matches, which is success and means
   closed**, `≥2` = error. A malformed ERE exits `128` with
   `fatal: -e option, 'a[': Invalid regular expression`.
 - Pathspec magic is accepted and silently changes the result set:
   `git grep -E -e x main -- ':(exclude)src'` returned matches from outside `src`.
-  A pathspec beginning with `:` is therefore **rejected at parse time** and the
-  class recorded `malformed`.
+  A pathspec beginning with `:` is **rejected at parse time** and the class
+  recorded `malformed`.
 
-**Bounds and their outcomes.** Per-class 10 s timeout and a 200-match cap. Under
-violation-only semantics, many matches means many violations, so the cap is an
-output bound, not a verdict: the class blocks, the block text is truncated with a
-count. A regex exceeding the cap is additionally recorded `over-broad` so the
-reviewer is prompted to narrow it via `SUPERSEDED-BY`. Timeout, exit ≥ 2, and
-invalid ERE all record the class `malformed` and **block** — a predicate that
-cannot run has not proved closure. *(Round 1 [MAJOR] gap: none of these were
-specified or tested.)*
+**Bounds.** Per-class 10 s timeout, 200-match output cap, and — *round 2 [MINOR]
+risk: revision 2 bounded each class but not the round, so a lineage of 36
+timed-out classes would delay every round by six minutes before the reviewer even
+starts* — a **60 s aggregate budget** across all classes. Classes not reached are
+recorded `unchecked`. Registration is refused beyond 100 tracked classes, with a
+message.
+
+Under violation-only semantics many matches means many violations, so the cap is
+an output bound, not a verdict: the block text is truncated with a count. A regex
+exceeding it is recorded `over-broad` so the reviewer narrows it via
+`SUPERSEDED-BY`.
+
+**Execution failure inherits the class's blocking policy.** *Round 2 [MAJOR]:
+revision 2 said every timeout, invalid ERE or git error "blocks", contradicting
+its own promise that `MINOR` and `OUT-OF-SCOPE` classes never block, and
+recreating the termination trap for a marginal class.* A `malformed`,
+`over-broad` or `unchecked` class blocks **only if its severity is `BLOCKER` or
+`MAJOR`** (§2.9). A predicate that cannot run has not proved closure — but for an
+advisory class, not proving closure is not grounds to stop the loop.
 
 ### 2.6 The closure check
 
 Each round, for **every** mechanized class the lineage holds — `open`, `closed`,
-`over-broad`, or `malformed`, but not `superseded` — the server runs the
-invocation above against the snapshot commit under review, subtracts recorded
+`over-broad`, `malformed`, `unchecked`, but not `superseded` — the server runs
+the invocation above against the snapshot commit under review, subtracts recorded
 exemptions (§2.8), and:
 
 - zero matches → `closed`
@@ -208,74 +235,95 @@ exemptions (§2.8), and:
 
 *Round 1 [MAJOR]: revision 1 rechecked only `open` classes and treated closure as
 permanent, so a later fix could reintroduce the defect while the trailer still
-reported nothing unclosed.* **A closed class reopens on any new match.** The cost
-of rechecking everything is one bounded git query per class per round.
+reported nothing unclosed.* **A closed class reopens on any new match.**
 
 ### 2.7 Lineage state
 
 `~/.paranoia/lineages/<lineage_id>.json`, holding per class: `class_id`,
-`invariant`, `severity`, `pattern`/`pathspec` or `procedure`, `first_round`,
+`invariant`(s), `severity`, `pattern`/`pathspec` or `procedure`, `first_round`,
 `status`, `superseded_by`, and exemptions.
 
 *Round 1 [MAJOR]: revision 1 derived the lineage from repo + `base_ref` only, so
-two sequential feature branches reviewed against `main` would inherit each
-other's classes and exemptions.* `lineage_id` defaults to
-`sha256(resolved_repo_path, base_ref, head_branch)[:12]`, where `head_branch`
-comes from `git symbolic-ref --quiet HEAD` (verified: exits 0 with
-`refs/heads/<name>`). **On a detached HEAD there is no stable branch identity, so
-an explicit `lineage` argument is required and the call errors without one** —
-fail-closed rather than silently minting a fresh lineage every round. Every
-trailer prints `LINEAGE: <id> (rounds recorded: N)` so an unintended split is
-visible.
+two sequential feature branches reviewed against `main` inherited each other's
+classes. Round 2 [MAJOR]: revision 2's fix used the **checked-out** branch, but
+`handlers.critique_branch` accepts an independent `head_ref` and `worktree_at`
+exists precisely to review a branch that is not checked out — so reviewing
+`feature-a` and `feature-b` from a repo sitting on `main` still collided, and a
+detached checkout wrongly rejected a perfectly stable `head_ref`.*
 
-*Round 1 [MAJOR] risk: revision 1 said only when state is written, and
-`logs.write_log` sets a precedent of swallowing every write failure —
-deliberately, since a completed review is the expensive artifact.* **Lineage
-state must not follow that precedent**, because a silently lost write plus a
-`NOT-BLOCKED` footer is exactly the false clearance this design exists to
-prevent. State is read before the engine call and written after a successful one,
-via temp file + `os.replace` in the same directory. A write failure, or existing
-state that will not parse, yields `CLASS-CLOSURE: STATE-UNAVAILABLE` and
-`CONVERGENCE: BLOCKED`. The review text is still returned.
+`lineage_id` = `sha256(resolved_repo_path, base_ref, head_symbolic_name)[:12]`,
+where `head_symbolic_name` is `git rev-parse --symbolic-full-name <head_ref>` on
+the **reviewed** ref. **Verified: for a commit sha this exits 0 and prints
+nothing** — so the test is empty output, not exit status. Empty means the
+reviewed ref is not a branch, and an explicit `lineage` argument is then
+required, the call erroring without one. Fail-closed beats silently minting a
+fresh lineage every round. Every trailer prints
+`LINEAGE: <id> (rounds recorded: N)` so an unintended split is visible.
+
+*Round 1 [MAJOR] risk: `logs.write_log` deliberately swallows every write failure,
+since a completed review is the expensive artifact.* **Lineage state must not
+follow that precedent** — a silently lost write plus a `NOT-BLOCKED` footer is
+exactly the false clearance this design exists to prevent. State is read before
+the engine call and written after a successful one, via temp file + `os.replace`
+in the same directory. A write failure, or existing state that will not parse,
+yields `CLASS-CLOSURE: STATE-UNAVAILABLE` and `CONVERGENCE: BLOCKED`. The review
+text is still returned.
 
 ### 2.8 Exemptions
 
-A match that is a false positive of the regex is exempted by an `exempt` call
-argument of `(class_id, path, line_text)`; the server stores a fingerprint of the
-normalized line text. *Round 1 [MAJOR]: revision 1 keyed exemptions on
-`class_id` + path alone, so exempting one match suppressed every present and
-future match in that file.*
+*Round 1 [MAJOR]: revision 1 keyed exemptions on `class_id` + path, so exempting
+one match suppressed every present and future match in that file. Round 2
+[MAJOR]: revision 2's line-text fingerprint still collided — two identical
+normalized lines in one file share a fingerprint, so exempting a false positive
+also suppressed a real violation on the duplicate line and could falsely close
+the class.*
 
-Exemptions are echoed in every subsequent trailer and shown to every subsequent
-reviewer under `=== CLAIMED EXEMPT ===` for challenge. This is the one place
-operator judgement legitimately enters, and the design makes it a recorded,
-adversarially-reviewed artifact rather than a silent lapse.
+An exemption is `(class_id, path, line_number, line_text_fingerprint)`, all four
+matched exactly. A match at that path and line whose text has changed is **not**
+exempt — the exemption is void and the match resurfaces. Line drift therefore
+costs re-exemption churn, which is the correct direction: it fails toward
+blocking, never toward silent clearance.
+
+*Round 2 [MAJOR] gap: exemptions were shown "for challenge" but there was no way
+to act on a successful challenge.* An `unexempt` argument
+`(class_id, path, line_number)` revokes one. Both actions are echoed in every
+subsequent trailer and shown to every subsequent reviewer under
+`=== CLAIMED EXEMPT ===`. This is the one place operator judgement legitimately
+enters, and the design makes it a recorded, adversarially-reviewed, reversible
+artifact rather than a silent lapse.
 
 ### 2.9 What may block, and the severity grammar
 
 *Round 1 [MAJOR]: revision 1 made every recurrence merge-blocking "whatever the
 severity", so a class originating as `[MINOR]` or `[OUT-OF-SCOPE]` could prevent
-termination indefinitely — the termination trap §1 forbids.*
+termination indefinitely — the trap §1 forbids.*
 
-**Only classes registered `SEVERITY: BLOCKER` or `MAJOR` block.** `MINOR` and
-`OUT-OF-SCOPE` classes are tracked and reported as advisory; they never appear in
-`CONVERGENCE: BLOCKED`. This keeps the mechanism inside the same severity
-economy `_CALIBRATION` already runs on.
+**Only classes whose current severity is `BLOCKER` or `MAJOR` block.** `MINOR`
+and `OUT-OF-SCOPE` classes are tracked and reported as advisory. This holds for
+every blocking state, including `malformed`, `over-broad`, `unchecked` and
+`STATE-UNAVAILABLE`-adjacent conditions.
+
+*Round 2 [MAJOR]: a severity registered once was permanent, so a class mistakenly
+registered `MAJOR` blocked while its regex matched even if every later cold
+reviewer judged it `MINOR` — with no escape but the kill switch.* The
+`RECLASSIFY: <class-id> <severity>` transition (§2.3) lets a later **cold
+reviewer** correct it. The escape is therefore a recorded adversarial judgement,
+not an operator's silent override, and it is symmetric — a class can be raised as
+well as lowered.
 
 *Round 1 [MAJOR]: revision 1 told reviewers to emit `[RECURRENCE]` while
 `prompts.CODE_REVIEW_INSTRUCTIONS` requires exactly one of
 `[BLOCKER]`/`[MAJOR]`/`[MINOR]`/`[OUT-OF-SCOPE]` per finding.* Recurrence is
 **not** a severity tag. It is a marker adjacent to one:
-`[MAJOR] [RECURRENCE 3f2a91c4] …`. The existing grammar is untouched, and a
-recurrence of a blocking class is reported at `[MAJOR]` or higher.
+`[MAJOR] [RECURRENCE 3f2a91c4] …`. The existing grammar is untouched.
 
 `_CALIBRATION` gains: *the ROUND severity floor never applies to a finding marked
 `[RECURRENCE]`.*
 
 ### 2.10 Unmechanized classes
 
-Registered with `PROCEDURE:` instead of `PATTERN:`/`PATHSPEC:`, given a server
-id like any other class, carried forward as a reviewer obligation, always shown,
+Registered with `PROCEDURE:` instead of `PATTERN:`/`PATHSPEC:`, given a server id
+like any other class, carried forward as a reviewer obligation, always shown,
 never floor-suppressed, and marked `unmechanized` in the trailer so the weakness
 is visible. They cannot block mechanically — there is nothing to run — and they
 close only when a later reviewer names the id on a `CLOSED:` line: still a
@@ -303,12 +351,12 @@ convergence verdict.
 operator to stop on that token — so one response could contain both `CONVERGED`
 and `CONVERGENCE: BLOCKED`, and the exact reviewer omission this mechanism exists
 to survive could still terminate the loop.* Closed on three surfaces:
-`_CALIBRATION` forbids emitting `CONVERGED` when the injected unclosed-class
-block is non-empty; when the computed verdict is `BLOCKED` the footer states in
-one line that any reviewer `CONVERGED` in the text above is void; and the README
-stop recipe is rewritten so the computed trailer is the documented stop signal.
+`_CALIBRATION` forbids `CONVERGED` when the injected unclosed-class block is
+non-empty; when the computed verdict is `BLOCKED` the footer states in one line
+that any reviewer `CONVERGED` above is void; and the README stop recipe is
+rewritten so the computed trailer is the documented stop signal.
 
-### 2.12 Recurrence injection
+### 2.12 Recurrence injection, and block precedence
 
 `already_raised` keeps its current meaning and instruction — it is caller-authored
 and stays a caller concern. A **second, server-generated** block carries the
@@ -323,7 +371,16 @@ opposite instruction:
 with: *these were reported in an earlier round and are not closed. Report every
 surviving match, marked `[RECURRENCE <id>]`. The ROUND severity floor does not
 apply. If a new finding of yours is an instance of one of these, emit
-`RECURRENCE: <id>` in the register instead of registering a new class.*
+`RECURRENCE: <id>` in the register instead of registering a new class. **Where
+this block and the already-raised block conflict, this block governs.***
+
+*Round 2 [MINOR] risk: `orientation.build_packet` appends `already_raised` last
+(`sections.append(reserved)` after the evidence and the truncation marker), so a
+recurrence block placed before it would leave the suppressive instruction nearest
+the end and a reviewer could obey the closer one.* **Verified against the code;
+the unclosed-classes block is therefore rendered after `already_raised`**, and
+carries the precedence sentence above. Like `already_raised`, it is reserved from
+the packet budget rather than trimmed.
 
 ## 3. Scope
 
@@ -340,6 +397,8 @@ not impossible.
 `rebut`, and legacy non-converge `critique_branch`.
 
 **Kill switch:** `class_closure` call arg / `.paranoia.toml` key, default `true`.
+It is the escape of last resort, not the escape of first resort — §2.3, §2.8 and
+§2.9 each provide a bounded, recorded escape from their own blocking state.
 
 ## 4. Residual risks, stated
 
@@ -347,62 +406,79 @@ not impossible.
    prompt states the criterion; nothing enforces it. Largest residual, unclosed.
 2. **Violation-only regexes are hard to write**, so the `unmechanized` population
    will be larger than revision 1 implied — and unmechanized closure is a model's
-   word, not a check. This is the price of §2.1 and it is not hidden.
+   word, not a check. The price of §2.1, not hidden.
 3. **A regex can be wrong in the safe direction** — too narrow, matching none of
-   the real violations, and reporting `closed` immediately. Nothing detects this;
-   a class that closes in the same round it was raised is suspicious and the
-   trailer flags it, but flagging is not detection.
-4. **Exemptions accumulate.** They are shown for challenge every round, which is
-   pressure, not a limit.
-5. **Semantic invariants** (cross-file dataflow, type-level) are not expressible
+   the real violations, reporting `closed` immediately. A class that closes in
+   the round it was raised is flagged in the trailer, but flagging is not
+   detection.
+4. **`RECLASSIFY` is a downgrade path a reviewer could misuse** to clear a real
+   blocker. It is recorded and shown, which is pressure, not a limit.
+5. **Exemptions accumulate**, subject to the same pressure.
+6. **Semantic invariants** (cross-file dataflow, type-level) are not expressible
    as a line regex at all.
 
 ## 5. Implementation
 
-New pure module `class_closure.py` — register parsing, class ids, status
-transitions, survivor computation, block rendering — with the git call and the
-clock injected, keeping the repository's pure-core/injected-edge split.
-`handlers.py` wires it; `prompts.py` carries the register grammar, the
-`SCOPE`/`[RECURRENCE]` rules and the `_CALIBRATION` amendments; `orientation.py`
-renders the injected blocks; `server.py` exposes `lineage`, `exempt`,
-`class_closure`; `logs.py` records `base_id`/`head_id` (§6). **`README.md` is in
-scope, not optional** — *round 1 [MAJOR] gap: revision 1 listed code modules
-only, while the shipped README still documents caller-managed state and stopping
-on reviewer-emitted `CONVERGED`, so an operator following the docs would bypass
-the new authority.*
+New pure module `class_closure.py` — register parsing, prose/register bijection,
+class ids, status transitions, survivor computation, block rendering — with the
+git call and the clock injected, keeping the repository's pure-core/injected-edge
+split. `handlers.py` wires it and owns the one register retry via
+`engines.Engine.resume`; `prompts.py` carries the register grammar, the
+`SCOPE`/`CLASS-REF`/`[RECURRENCE]` rules and the `_CALIBRATION` amendments;
+`orientation.py` renders the injected blocks after `already_raised`; `server.py`
+exposes `lineage`, `exempt`, `unexempt`, `class_closure`; `logs.py` records
+`base_id`/`head_id` (§6). **`README.md` is in scope, not optional** — *round 1
+[MAJOR] gap: the shipped README documents caller-managed state and stopping on
+reviewer-emitted `CONVERGED`, so an operator following the docs would bypass the
+new authority.*
 
 TDD, RED first. Behavioural tests that must exist:
 
-**Register parsing** (strictness matched to `arbitration.parse_*`, since this is
-a model-authored surface): two mechanized records parse; `NONE` parses as an
-empty register; absent → `CLASS-REGISTER: absent` and `BLOCKED`; duplicate field
-within a record rejected; missing required field rejected; a record after the
-block's end rejected; a field name appearing in earlier prose does not confuse
-the parser; unmechanized record with `PROCEDURE` parses; `RECURRENCE`/`CLOSED`
-naming an unknown id rejected.
+**Register parsing and binding** (strictness matched to `arbitration.parse_*`,
+since this is a model-authored surface): two mechanized records parse; `NONE`
+parses as empty; absent → one retry, then `absent` + policy-dependent block;
+**`SCOPE: class` in prose with a `NONE` register is malformed** (round 2's
+FATAL); prose ref with no record, record with no prose ref, duplicate ref, and
+**severity disagreement between finding tag and record** are each malformed;
+duplicate field within a record rejected; missing required field rejected; a
+record after the block's end rejected; a field name in earlier prose does not
+confuse the parser; unmechanized record with `PROCEDURE` parses;
+`RECURRENCE`/`CLOSED`/`RECLASSIFY` naming an unknown id rejected; the retry path
+is taken exactly once and a successful retry parses.
 
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not
-rechecked; `first_round` survives supersession.
+rechecked; `first_round` survives supersession; **two records sharing a predicate
+but differing in severity dedupe to the maximum** and retain both invariants.
 
-**Git boundary:** exit 1 is closure, not failure; exit ≥ 2 → `malformed` +
-`BLOCKED`; invalid ERE → `malformed` + `BLOCKED`; timeout → `malformed` +
-`BLOCKED`; > 200 matches → `over-broad`, blocks, message says to narrow; a path
-containing a newline and a non-UTF-8 byte parses correctly under `-z`; a pathspec
-beginning with `:` is rejected before any git call.
+**Git boundary:** exit 1 is closure, not failure; exit ≥ 2, invalid ERE, and
+timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,
+counted block; aggregate budget exhaustion → `unchecked`; a path containing a
+newline and a non-UTF-8 byte parses correctly under `-z`; a pathspec beginning
+with `:` is rejected before any git call; registration beyond 100 classes is
+refused.
 
-**Blocking policy:** `MAJOR` class blocks; `MINOR` and `OUT-OF-SCOPE` classes do
-not and are reported advisory; `BLOCKED` names the ids; `NOT-BLOCKED` text does
-not contain the word *converged*; when blocked, the footer voids a reviewer
-`CONVERGED`.
+**Blocking policy:** `MAJOR` class blocks; `MINOR` and `OUT-OF-SCOPE` do not and
+are reported advisory; **`malformed`/`over-broad`/`unchecked` on a `MINOR` class
+does not block** (round 2's severity-policy contradiction); `RECLASSIFY` to
+`MINOR` unblocks and to `MAJOR` re-blocks; `BLOCKED` names the ids;
+`NOT-BLOCKED` text does not contain the word *converged*; when blocked, the
+footer voids a reviewer `CONVERGED`.
 
-**Lineage state:** detached HEAD without `lineage` errors; two branches off one
-base get different default lineages; unparseable state → `STATE-UNAVAILABLE` +
-`BLOCKED` and the review text still returned; write failure → same; state is
-replaced atomically; a failed engine call leaves state byte-identical.
+**Lineage:** a reviewed `head_ref` that is a branch but not checked out yields
+its own lineage, and two such branches off one base differ; a `head_ref` that is
+a sha (empty `--symbolic-full-name` output, exit 0) without `lineage` errors;
+unparseable state → `STATE-UNAVAILABLE` + `BLOCKED`, review text still returned;
+write failure → same; state replaced atomically; a failed engine call leaves
+state byte-identical.
 
-**Exemptions:** an exempt match is subtracted; a different match in the same file
-is not; the exemption appears under `CLAIMED EXEMPT` and in the trailer.
+**Exemptions:** an exempt match is subtracted; **a second, textually identical
+line in the same file is not** (round 2's collision); an exemption whose line
+text changed is void and the match resurfaces; `unexempt` restores a match; both
+appear under `CLAIMED EXEMPT` and in the trailer.
+
+**Packet:** the unclosed-classes block is rendered after `already_raised` and
+survives budget trimming.
 
 **Kill switch:** `class_closure: false` reproduces today's behaviour exactly.
 
@@ -412,20 +488,20 @@ is not; the exemption appears under `CLAIMED EXEMPT` and in the trailer.
 through git. That is impossible — `handlers._log` records target text, mode,
 usage and duration but neither `base_id` nor `head_id`, and dirty wrapper commits
 are unreferenced and GC-eligible (`orientation.wrap_commit`). The reviewed
-commits are simply not recoverable from the logs.*
+commits are not recoverable from the logs.*
 
-Acceptance is therefore two things, neither of which pretends to be that replay:
+Acceptance is therefore two things, neither pretending to be that replay:
 
 1. **A fixture repository**, committed to `tests/`, carrying a real three-site
-   invariant across three commits that mirror the observed incident: round 7's
+   invariant across three commits mirroring the observed incident: the round-7
    commit violates at site A, the round-7 fix closes A and leaves B and C, and so
    on. The mechanism must register the class at round 7 and return
    `CONVERGENCE: BLOCKED` at rounds 8 and 9 naming the same `class_id` both
    times. This is the known-positive the design must reproduce.
 2. **The next real review loop in this repository**, run with the mechanism on.
-   That is the only honest end-to-end test, and the fixture exists so that
-   failure is caught before spending it.
+   The only honest end-to-end test; the fixture exists so failure is caught
+   before spending it.
 
-Separately and independently of this feature, `handlers._log` starts recording
-`base_id` and `head_id` so that a future incident *is* replayable. Round 1 found
-that gap; it is cheap and it should not wait for this design.
+Separately and independently, `handlers._log` starts recording `base_id` and
+`head_id` so a future incident *is* replayable. Round 1 found that gap; it is
+cheap and should not wait for this design.

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,9 +1,9 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 6. Five codex plan-review rounds folded —
+Status: DRAFT for review, revision 7. Six codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
-1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR. Every
-finding accepted.
+1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR; round 6:
+1 FATAL, 5 MAJOR. Every finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
@@ -15,12 +15,19 @@ different spelling** (§2.4), and that the quarantine added for round 3 had
 *created* the fresh-lineage hole it was written to close (§2.7). Round 5 found
 the recurrence grammar contradictory again (§2.2) and a stale dedup test left
 standing in §5 that would have re-implemented the very collapse round 4 removed.
+Round 6 found the recurrence grammar broken a **third** time, and revision 7
+deletes it outright rather than repairing it once more (§2.2).
 
-**Six of the nine FATALs in this review were introduced by fixes to earlier
-findings, and two were the same defect recurring in a new spelling.** That is
-precisely the failure this brief exists to mechanize against, observed on the
-brief itself, under the very review protocol the brief says is inadequate to
-catch it. The design is the argument; the review history is the evidence.
+**Seven of the ten FATALs in this review were introduced by fixes to earlier
+findings, and the recurrence grammar alone accounted for three of them — the same
+defect in three spellings, exactly the pattern §0 describes.** That is the
+failure this brief exists to mechanize against, observed on the brief itself,
+under the very review protocol the brief argues is inadequate to catch it. The
+design is the argument; the review history is the evidence.
+
+The three fixes that finally held all **removed** mechanism rather than adding
+it: dedup deleted (§2.4), the recurrence grammar deleted (§2.2), the adjudication
+layer deleted (§2.1). Each had been introduced to satisfy an earlier finding.
 
 ## 0. The defect this fixes
 
@@ -119,23 +126,33 @@ would condemn another site if one existed*. A genuine off-by-one is `isolated`;
 requiring class machinery for it is the over-engineering
 `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
 
-A `SCOPE: class` finding is one of two kinds, and **only the first carries a
-`CLASS-REF`**:
+A finding reporting a **new class** — an invariant the lineage does not yet hold
+— additionally opens with one machine-readable line:
 
-- **A new class** — an invariant the lineage does not yet hold. Carries
-  `CLASS-REF: <short token>`, unique within the review.
-- **A recurrence** — an instance of a class the lineage already holds. Carries
-  `[RECURRENCE <class-id>]` adjacent to its severity tag (§2.9) and **no
-  `CLASS-REF`**: the class id already identifies it, and it has no severity of
-  its own to agree with.
+```
+CLASS-FINDING: ref=<short token unique in this review> severity=<BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE>
+```
 
-*Round 5 [FATAL]: revision 5 said flatly that every `SCOPE: class` finding
-carries a `CLASS-REF` while §2.3 said a recurrence carries none and the tests
-required rejecting one that did. A reviewer obeying §2.2 produced prose the
-parser had to reject, and since the retry re-asks only for the register it could
-not repair the prose — so every surviving class would have looped on
-malformed-register blocks. The mechanism's hot path, contradictory for the second
-time in three revisions (cf. round 3).*
+*Round 6 [MAJOR]: revision 6 asked the parser to associate a `CLASS-REF` with
+"its finding's severity tag", but `prompts._SECTION_BODIES` defines prose
+content, not machine-delimited finding records — there is no boundary to
+attribute a tag to, and the `arbitration` precedent only works because it slices
+a fixed terminal field count. Multiple findings, or a severity tag quoted inside
+one, made ownership ambiguous, and the register-only retry could not repair
+prose.* The header carries both fields itself, so no prose-boundary inference is
+needed anywhere.
+
+**Recurrences carry nothing.** *Round 3 [FATAL], round 5 [FATAL] and round 6
+[MAJOR] were all the same wound: a hand-authored recurrence grammar that had to
+stay consistent with the prose rules, the register rules and the tests, and did
+not — three times, in three different spellings.* Revision 7 deletes it, taking
+round 6's own remedy: **for a mechanized class, a recurrence is whatever the
+server's `git grep` found**, and nothing the reviewer writes is parsed to confirm
+it. The server already ran the predicate; asking a model to restate the matches
+and then machine-auditing the restatement was ceremony that repeatedly broke the
+one path the mechanism exists to serve. The reviewer is still *shown* the
+surviving matches and still asked to report them (§2.12) — that text is for the
+operator to read, not for the parser to validate.
 
 ### 2.3 The class register, and its binding to the prose
 
@@ -156,23 +173,43 @@ Unmechanized records replace `PATTERN`/`PATHSPEC` with
 against classes the server already carries:
 
 ```
-RECURRENCE: <class-id>              # this round's finding is an instance of it
 CLOSED: <class-id>                  # unmechanized only; judged closed this round
+REOPEN: <class-id>                  # unmechanized only; found violated again
 RECLASSIFY: <class-id> <severity>   # a later cold reviewer corrects the severity
 SUPERSEDE: <old-id> BY: <existing-id>
-SUPERSEDE: <old-id> WITH-PATTERN: <regex> PATHSPEC: <pathspec>
+SUPERSEDE: <old-id> WITH-PATTERN: <regex> PATHSPEC: <pathspec> [CLASS: <invariant>]
 ```
 
+*Round 6 [MAJOR]: a closed unmechanized class had no way back. `CLOSED` was
+listed but nothing reopened it, so once a reviewer judged such a class closed, a
+later reviewer finding it violated again could report that only in prose while
+the state stayed closed and the trailer said `NOT-BLOCKED`.* `REOPEN` closes
+that. It is unmechanized-only because a mechanized class reopens automatically on
+any match (§2.6).
+
 *Round 5 [MAJOR]: the earlier `SUPERSEDED-BY: <class-id> | PATTERN: … PATHSPEC: …`
-form could not name both sides. One id left the server unable to tell the
+form could not name both sides — one id left the server unable to tell the
 superseded class from its replacement, and the pattern form named no class at
-all — so the recovery §2.4 promises for `malformed` and `over-broad` classes
-could not deterministically reach the intended one, and such a `MAJOR` class
-would block permanently.* Both forms now name the source explicitly.
-`WITH-PATTERN` mints a **new** server-assigned id which inherits the old class's
-`severity` and `first_round`, and its own invariant text unless the record
-restates it; `BY` requires the target id to already exist in this lineage. In
-both forms the old class is marked `superseded`: non-blocking, and never
+all.* Both forms now name the source explicitly.
+
+`WITH-PATTERN` mints a **new** server-assigned id inheriting the old class's
+`severity` and `first_round`. *Round 6 [MAJOR]: revision 6 said the replacement
+could restate its invariant but gave the form no field to do it in, forcing an
+implementation to either reject an undocumented field or carry stale invariant
+text that disagrees with the corrected predicate.* The optional `CLASS:` field is
+that form; omitted, the old invariant text carries over.
+
+`BY` **requires a target that is distinct from the source, already registered in
+this lineage, and not itself superseded.** *Round 6 [FATAL]: revision 6 required
+only that the target "exist", so `SUPERSEDE: A BY: A` — or supersession by an
+already-superseded class — parsed, marked the source non-blocking and
+never-rechecked, and left no active blocker at all. A model-authored transition
+could therefore manufacture a false `NOT-BLOCKED`.* The distinctness and
+liveness conditions also make cycles unreachable: `A BY B` marks A superseded, so
+a later `B BY A` fails on the liveness check. The target keeps its own
+`severity`; it inherits the **earlier** of the two `first_round` values.
+
+In both forms the old class is marked `superseded`: non-blocking, and never
 rechecked again (§2.6). This is the recovery transition `malformed` and
 `over-broad` classes need.
 
@@ -184,29 +221,24 @@ containing `[MAJOR] … SCOPE: class` followed by `=== CLASS REGISTER === NONE`
 parsed, persisted nothing, and could return `NOT-BLOCKED` — the exact durability
 failure revision 2 claimed to close.*
 
-*Round 3 [FATAL]: revision 3's single bijection then made **every recurrence
-response malformed**. A recurrence finding reports an existing class, so it has
-no new `REF` and no severity of its own, yet the rule demanded both — a surviving
-class would fail validation, burn the retry on the same contradictory grammar,
-and return malformed without recording the recurrence. The mechanism would have
-broken on exactly the path it exists to serve.*
+*Round 3 [FATAL]: revision 3's single bijection then made every **recurrence**
+response malformed, because a recurrence has no new `REF` and no severity of its
+own yet the rule demanded both. Revisions 4 and 5 answered that with a second,
+recurrence-specific bijection — which broke again at round 5 and again at round
+6.*
 
-There are therefore **two bijections, one per kind of finding**:
+**There is now exactly one bijection, over new classes only.** The set of
+`CLASS-FINDING` header `ref=` values in the prose equals the set of `REF` values
+on new-class records, and each record's `SEVERITY` equals its header's
+`severity=`. Both sides of that comparison are single machine-readable tokens, so
+there is nothing left to infer.
 
-- **New classes.** The set of `CLASS-REF` tokens in the prose equals the set of
-  `REF` values on new-class records, and each record's `SEVERITY` equals its
-  finding's severity tag.
-- **Recurrences.** The set of `[RECURRENCE <class-id>]` markers in the prose
-  equals the set of `RECURRENCE: <class-id>` lines in the register. A recurrence
-  carries **no** `CLASS-REF` and **no** `SEVERITY` — the class id is the
-  reference, and the severity is the one the lineage already holds, changeable
-  only by `RECLASSIFY`.
-
-`CLOSED`, `RECLASSIFY` and `SUPERSEDE` are state transitions, not findings,
-and bind to nothing in the prose. A prose class with no record, a record with no
-prose, a duplicate ref, an unknown class id, or a severity disagreement is a
-malformed register. A review with genuinely no classes and no recurrences emits
-`=== CLASS REGISTER ===` followed by `NONE`.
+Recurrences are not in the register at all (§2.2) — the server computes them from
+git. `CLOSED`, `REOPEN`, `RECLASSIFY` and `SUPERSEDE` are state transitions, not
+findings, and bind to nothing in the prose. A prose header with no record, a
+record with no header, a duplicate ref, an unknown class id, or a severity
+disagreement is a malformed register. A review with no new classes and no
+transitions emits `=== CLASS REGISTER ===` followed by `NONE`.
 
 Parsing is as strict as `arbitration.parse_*`: the block is terminal, every field
 required, duplicates and out-of-block records rejected.
@@ -263,7 +295,8 @@ compared the fold against §2.1's own recorded FATAL.
 The remedy removes a mechanism rather than adding one: no dedup, no conflict
 rule, no shared state. Duplicate registration is guarded by the prompt alone —
 open classes are shown to every subsequent reviewer with ids and invariants, with
-the instruction to emit `RECURRENCE: <id>` rather than register anew — and the
+the instruction to report an instance of one as a recurrence of that id rather
+than registering a new class (§2.12) — and the
 100-class cap (§2.5) bounds the cost of the residual duplicates that guard
 misses. A duplicate class is redundant work; a collapsed class is a silent
 clearance. The asymmetry decides it.
@@ -440,6 +473,11 @@ well as lowered.
 **not** a severity tag. It is a marker adjacent to one:
 `[MAJOR] [RECURRENCE 3f2a91c4] …`. The existing grammar is untouched.
 
+Since revision 7 the marker is **presentational only** — it makes the review
+readable and keeps the floor exemption expressible, but nothing parses or
+validates it, so it can no longer contradict the register (§2.2). The blocking
+decision comes from git, not from whether the reviewer remembered to type it.
+
 `_CALIBRATION` gains: *the ROUND severity floor never applies to a finding marked
 `[RECURRENCE]`.*
 
@@ -449,8 +487,8 @@ Registered with `PROCEDURE:` instead of `PATTERN:`/`PATHSPEC:`, given a server i
 like any other class, carried forward as a reviewer obligation, always shown,
 never floor-suppressed, and marked `unmechanized` in the trailer so the weakness
 is visible. They close only when a later reviewer names the id on a `CLOSED:`
-line: still a judgement, but an explicit, cold, recorded one rather than an
-operator's silent assumption.
+line, and reopen on a `REOPEN:` line: still a judgement, but an explicit, cold,
+recorded one rather than an operator's silent assumption.
 
 *Round 3 [MAJOR]: revision 3 said they "cannot block mechanically", which
 conflated **nothing to run** with **not blocking**. Since `NOT-BLOCKED` is
@@ -504,9 +542,13 @@ opposite instruction:
 
 with: *these were reported in an earlier round and are not closed. Report every
 surviving match, marked `[RECURRENCE <id>]`. The ROUND severity floor does not
-apply. If a new finding of yours is an instance of one of these, emit
-`RECURRENCE: <id>` in the register instead of registering a new class. **Where
-this block and the already-raised block conflict, this block governs.***
+apply. If a finding of yours is an instance of one of these, report it as a
+recurrence of that id — do NOT register it as a new class. **Where this block and
+the already-raised block conflict, this block governs.***
+
+Nothing in that instruction is parsed. The classes are already open and already
+blocking on the git result; the instruction exists so the review the operator
+reads addresses them, not so the parser can check that it did.
 
 *Round 2 [MINOR] risk: `orientation.build_packet` appends `already_raised` last
 (`sections.append(reserved)` after the evidence and the truncation marker), so a
@@ -563,7 +605,7 @@ class ids, status transitions, survivor computation, block rendering — with th
 git call and the clock injected, keeping the repository's pure-core/injected-edge
 split. `handlers.py` wires it and owns the one register retry via
 `engines.Engine.resume`; `prompts.py` carries the register grammar, the
-`SCOPE`/`CLASS-REF`/`[RECURRENCE]` rules and the `_CALIBRATION` amendments;
+`SCOPE`/`CLASS-FINDING` rules and the `_CALIBRATION` amendments;
 `orientation.py` renders the injected blocks after `already_raised`; `server.py`
 exposes `lineage`, `exempt`, `unexempt`, `class_closure`; `logs.py` records
 `base_id`/`head_id` (§6). **`README.md` is in scope, not optional** — *round 1
@@ -576,25 +618,26 @@ TDD, RED first. Behavioural tests that must exist:
 **Register parsing and binding** (strictness matched to `arbitration.parse_*`,
 since this is a model-authored surface): two mechanized records parse; `NONE`
 parses as empty; absent → one retry, then `absent` + policy-dependent block;
-**`SCOPE: class` in prose with a `NONE` register is malformed** (round 2's
-FATAL); prose ref with no record, record with no prose ref, duplicate ref, and
-**severity disagreement between finding tag and record** are each malformed;
-duplicate field within a record rejected; missing required field rejected; a
-record after the block's end rejected; a field name in earlier prose does not
-confuse the parser; unmechanized record with `PROCEDURE` parses;
-`RECURRENCE`/`CLOSED`/`RECLASSIFY` naming an unknown id rejected; the retry path
-is taken exactly once and a successful retry parses; **a `Review` with
+**a `CLASS-FINDING` header in prose with a `NONE` register is malformed** (round
+2's FATAL); header ref with no record, record with no header, duplicate ref, and
+**severity disagreement between header `severity=` and record `SEVERITY`** are
+each malformed; duplicate field within a record rejected; missing required field
+rejected; a record after the block's end rejected; a field name in earlier prose
+does not confuse the parser; unmechanized record with `PROCEDURE` parses;
+`CLOSED`/`REOPEN`/`RECLASSIFY`/`SUPERSEDE` naming an unknown id rejected; the
+retry path is taken exactly once and a successful retry parses; **a `Review` with
 `session_ref=None` skips the retry, returns its text unchanged, and blocks per
 policy** (round 4); **two new-class records sharing a pattern and pathspec get
 two distinct ids and two independent state objects** (round 4's dedup FATAL).
 
-**Recurrence binding** (round 3's FATAL, which is the mechanism's own hot path):
-a review whose only class content is `[RECURRENCE <id>]` prose plus a matching
-`RECURRENCE: <id>` line **parses and is not malformed**; a recurrence carrying a
-`CLASS-REF` or a `SEVERITY` is rejected; a prose `[RECURRENCE <id>]` with no
-register line, and a register line with no prose marker, are each malformed; a
-review mixing one new class and one recurrence satisfies both bijections
-independently; `CLOSED`/`RECLASSIFY`/`SUPERSEDE` require no prose binding.
+**Recurrences are not parsed** (rounds 3, 5 and 6 — the mechanism's own hot path,
+broken three times by a hand-authored grammar that revision 7 deletes): a review
+that reports surviving matches only in prose, with a register of `NONE`, **is
+well-formed and still blocks** on the git result; a review that omits the
+recurrence prose entirely **also still blocks**, because the verdict never
+depended on the reviewer's text; `[RECURRENCE <id>]` appearing anywhere in the
+prose changes no parse outcome; a review mixing a new class and recurrence prose
+satisfies the single bijection over the new class alone.
 
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not
@@ -606,10 +649,21 @@ untouched** (round 5: revision 5 removed dedup in §2.4 but left the old
 pass and implementing the stale one would have recreated the collapsed-identity
 FATAL).
 
-**Supersession:** `SUPERSEDE: <old> BY: <existing>` requires the target to exist
-and errors otherwise; `SUPERSEDE: <old> WITH-PATTERN: …` mints a new id
-inheriting `severity` and `first_round`; the old class becomes `superseded`,
-stops blocking, and is excluded from the recheck sweep.
+**Supersession:** `SUPERSEDE: <old> BY: <existing>` requires a target that
+exists, **is not the source itself, and is not already superseded** — each of
+those three is rejected, and the self-target and superseded-target cases are
+round 6's FATAL, since either would leave no active blocker; a cyclic
+`A BY B` then `B BY A` is rejected on the second by the liveness rule; the target
+keeps its own severity even when lower than the source's, and inherits the
+earlier `first_round`. `SUPERSEDE: <old> WITH-PATTERN: …` mints a new id
+inheriting `severity` and `first_round`, takes the optional `CLASS:` field as the
+new invariant, and carries the old text over when it is omitted. In every form
+the old class becomes `superseded`, stops blocking, and is excluded from the
+recheck sweep.
+
+**Unmechanized lifecycle:** `CLOSED` on an open unmechanized `MAJOR` unblocks;
+**`REOPEN` on it blocks again** (round 6's `CLOSED → REOPEN → open` gap);
+`REOPEN` against a mechanized class is rejected, since those reopen from git.
 
 **Git boundary:** exit 1 is closure, not failure; exit ≥ 2, invalid ERE, and
 timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,20 +1,26 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 5. Four codex plan-review rounds folded —
+Status: DRAFT for review, revision 6. Five codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
-1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR. Every finding accepted.
+1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR; round 5: 2 FATAL, 1 MAJOR. Every
+finding accepted.
 
 The chain is worth reading as evidence for the brief's own thesis. Round 1's
 FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
 replacement had no link between a prose finding and a register record (§2.3).
 Round 3's FATAL found that link, as specified, made every recurrence response
-malformed — one round's fix breaking the next round's path. Round 4 then found
-that the dedup rule added for round 2 had **re-committed round 1's exact FATAL in
-a different spelling** (§2.4), and that the quarantine added for round 3 had
-*created* the fresh-lineage hole it was written to close (§2.7). Four of the
-seven FATALs across this review were introduced by fixes to earlier findings.
-That is the failure this brief exists to mechanize against, observed on the brief
-itself.
+malformed — one round's fix breaking the next round's path. Round 4 found that
+the dedup rule added for round 2 had **re-committed round 1's exact FATAL in a
+different spelling** (§2.4), and that the quarantine added for round 3 had
+*created* the fresh-lineage hole it was written to close (§2.7). Round 5 found
+the recurrence grammar contradictory again (§2.2) and a stale dedup test left
+standing in §5 that would have re-implemented the very collapse round 4 removed.
+
+**Six of the nine FATALs in this review were introduced by fixes to earlier
+findings, and two were the same defect recurring in a new spelling.** That is
+precisely the failure this brief exists to mechanize against, observed on the
+brief itself, under the very review protocol the brief says is inadequate to
+catch it. The design is the argument; the review history is the evidence.
 
 ## 0. The defect this fixes
 
@@ -113,8 +119,23 @@ would condemn another site if one existed*. A genuine off-by-one is `isolated`;
 requiring class machinery for it is the over-engineering
 `prompts.CODE_REVIEW_INSTRUCTIONS` already calls a defect.
 
-A `SCOPE: class` finding additionally carries `CLASS-REF: <short token>`, unique
-within the review.
+A `SCOPE: class` finding is one of two kinds, and **only the first carries a
+`CLASS-REF`**:
+
+- **A new class** — an invariant the lineage does not yet hold. Carries
+  `CLASS-REF: <short token>`, unique within the review.
+- **A recurrence** — an instance of a class the lineage already holds. Carries
+  `[RECURRENCE <class-id>]` adjacent to its severity tag (§2.9) and **no
+  `CLASS-REF`**: the class id already identifies it, and it has no severity of
+  its own to agree with.
+
+*Round 5 [FATAL]: revision 5 said flatly that every `SCOPE: class` finding
+carries a `CLASS-REF` while §2.3 said a recurrence carries none and the tests
+required rejecting one that did. A reviewer obeying §2.2 produced prose the
+parser had to reject, and since the retry re-asks only for the register it could
+not repair the prose — so every surviving class would have looped on
+malformed-register blocks. The mechanism's hot path, contradictory for the second
+time in three revisions (cf. round 3).*
 
 ### 2.3 The class register, and its binding to the prose
 
@@ -138,8 +159,22 @@ against classes the server already carries:
 RECURRENCE: <class-id>              # this round's finding is an instance of it
 CLOSED: <class-id>                  # unmechanized only; judged closed this round
 RECLASSIFY: <class-id> <severity>   # a later cold reviewer corrects the severity
-SUPERSEDED-BY: <class-id> | PATTERN: <regex> PATHSPEC: <pathspec>
+SUPERSEDE: <old-id> BY: <existing-id>
+SUPERSEDE: <old-id> WITH-PATTERN: <regex> PATHSPEC: <pathspec>
 ```
+
+*Round 5 [MAJOR]: the earlier `SUPERSEDED-BY: <class-id> | PATTERN: … PATHSPEC: …`
+form could not name both sides. One id left the server unable to tell the
+superseded class from its replacement, and the pattern form named no class at
+all — so the recovery §2.4 promises for `malformed` and `over-broad` classes
+could not deterministically reach the intended one, and such a `MAJOR` class
+would block permanently.* Both forms now name the source explicitly.
+`WITH-PATTERN` mints a **new** server-assigned id which inherits the old class's
+`severity` and `first_round`, and its own invariant text unless the record
+restates it; `BY` requires the target id to already exist in this lineage. In
+both forms the old class is marked `superseded`: non-blocking, and never
+rechecked again (§2.6). This is the recovery transition `malformed` and
+`over-broad` classes need.
 
 **The register is mandatory and must be a bijection with the prose.**
 
@@ -167,7 +202,7 @@ There are therefore **two bijections, one per kind of finding**:
   reference, and the severity is the one the lineage already holds, changeable
   only by `RECLASSIFY`.
 
-`CLOSED`, `RECLASSIFY` and `SUPERSEDED-BY` are state transitions, not findings,
+`CLOSED`, `RECLASSIFY` and `SUPERSEDE` are state transitions, not findings,
 and bind to nothing in the prose. A prose class with no record, a record with no
 prose, a duplicate ref, an unknown class id, or a severity disagreement is a
 malformed register. A review with genuinely no classes and no recurrences emits
@@ -271,7 +306,7 @@ message.
 Under violation-only semantics many matches means many violations, so the cap is
 an output bound, not a verdict: the block text is truncated with a count. A regex
 exceeding it is recorded `over-broad` so the reviewer narrows it via
-`SUPERSEDED-BY`.
+`SUPERSEDE`.
 
 **Execution failure inherits the class's blocking policy.** *Round 2 [MAJOR]:
 revision 2 said every timeout, invalid ERE or git error "blocks", contradicting
@@ -559,12 +594,22 @@ a review whose only class content is `[RECURRENCE <id>]` prose plus a matching
 `CLASS-REF` or a `SEVERITY` is rejected; a prose `[RECURRENCE <id>]` with no
 register line, and a register line with no prose marker, are each malformed; a
 review mixing one new class and one recurrence satisfies both bijections
-independently; `CLOSED`/`RECLASSIFY`/`SUPERSEDED-BY` require no prose binding.
+independently; `CLOSED`/`RECLASSIFY`/`SUPERSEDE` require no prose binding.
 
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not
-rechecked; `first_round` survives supersession; **two records sharing a predicate
-but differing in severity dedupe to the maximum** and retain both invariants.
+rechecked; `first_round` and `severity` survive supersession; **two classes
+sharing a pattern and pathspec are fully independent — `RECLASSIFY` or
+`SUPERSEDE` against one leaves the other's severity, status and matches
+untouched** (round 5: revision 5 removed dedup in §2.4 but left the old
+"dedupe to the maximum" test standing, so the two requirements could not both
+pass and implementing the stale one would have recreated the collapsed-identity
+FATAL).
+
+**Supersession:** `SUPERSEDE: <old> BY: <existing>` requires the target to exist
+and errors otherwise; `SUPERSEDE: <old> WITH-PATTERN: …` mints a new id
+inheriting `severity` and `first_round`; the old class becomes `superseded`,
+stops blocking, and is excluded from the recheck sweep.
 
 **Git boundary:** exit 1 is closure, not failure; exit ≥ 2, invalid ERE, and
 timeout each → `malformed`; > 200 matches → `over-broad` with a truncated,

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,14 +1,20 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 4. Three codex plan-review rounds folded —
+Status: DRAFT for review, revision 5. Four codex plan-review rounds folded —
 round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
-1 FATAL, 3 MAJOR, no risks, no gaps. Every finding accepted. Round 1's FATALs
-killed the candidate-enumeration design outright and it was replaced (§2.1);
-round 2's FATAL found the replacement had no link between a prose finding and a
-register record (§2.3); round 3's FATAL found that the link, as specified, made
-every recurrence response malformed — the fix for one round's finding breaking
-the next round's path, which is the class of error this whole design exists to
-catch.
+1 FATAL, 3 MAJOR; round 4: 2 FATAL, 1 MAJOR. Every finding accepted.
+
+The chain is worth reading as evidence for the brief's own thesis. Round 1's
+FATALs killed the candidate-enumeration design (§2.1). Round 2's FATAL found the
+replacement had no link between a prose finding and a register record (§2.3).
+Round 3's FATAL found that link, as specified, made every recurrence response
+malformed — one round's fix breaking the next round's path. Round 4 then found
+that the dedup rule added for round 2 had **re-committed round 1's exact FATAL in
+a different spelling** (§2.4), and that the quarantine added for round 3 had
+*created* the fresh-lineage hole it was written to close (§2.7). Four of the
+seven FATALs across this review were introduced by fixes to earlier findings.
+That is the failure this brief exists to mechanize against, observed on the brief
+itself.
 
 ## 0. The defect this fixes
 
@@ -182,6 +188,15 @@ is cheap because it does not re-run the review. If the retry also fails,
 quotes the exact expected grammar. **The review text is always returned in full**;
 a paid review is never discarded over a formatting miss.
 
+*Round 4 [MAJOR] gap: the retry is not always available. `Review.session_ref` is
+`str | None`, `Engine.resume` requires a `str`, and the Claude engine's supported
+non-JSON fallback returns `Review(text=…, session_ref=None)` — a contract
+`tests/test_engines.py` already pins. An unconditional retry on that path would
+raise and `dispatch` would replace the paid review with an error, which is the
+one outcome this section promises cannot happen.* **When `session_ref` is
+`None` the retry is skipped**, the original review is returned unchanged, and the
+malformed-register block is emitted directly.
+
 ### 2.4 Class identity is server-assigned
 
 *Round 1 [MAJOR]: revision 1 hashed the reviewer's regex into the id, so a
@@ -193,16 +208,30 @@ changes. Reviewer-authored text never determines identity, so it does not matter
 that round 7 called the class "escalations" and round 9 "unresolved starts" — a
 label match would never have connected them anyway.
 
-Duplicate registration of one class is guarded twice: open classes are shown to
-every subsequent reviewer with ids and invariants, with the instruction to emit
-`RECURRENCE: <id>` rather than register anew; and the server dedupes on identical
-normalized `(pattern, pathspec)`.
+**Every new-class record gets its own id. There is no deduplication.**
 
-*Round 2 [MAJOR]: revision 2 deduped without a conflict rule, so a `MINOR` and a
-`MAJOR` record sharing a predicate had an unspecified outcome — and discarding
-the latter would return `NOT-BLOCKED` for a registered major class.* **Dedup takes
-the maximum severity and retains both invariant texts.** Max severity fails
-toward blocking.
+*Round 2 [MAJOR] asked for a dedup conflict rule and revision 3 gave one — max
+severity, both invariant texts retained. Round 4 [FATAL] then showed that dedup
+is the round-1 FATAL wearing a new hat: `(pattern, pathspec)` is not an identity,
+so two genuinely distinct invariants expressible by one regex collapse into a
+single state object with one `severity`, one `status` and one `superseded_by`.
+`RECLASSIFY` or `SUPERSEDED-BY` against that shared id would then silently mutate
+an unrelated live class — retaining both invariant strings buys nothing, because
+identity and transitions are what collapsed, not the prose.*
+
+**This is worth naming rather than quietly patching: the design re-committed
+round 1's exact error, three revisions later, in a different spelling. That is
+the failure mode the whole brief exists to catch, occurring inside the brief.**
+It survived two intervening review rounds and was caught only because round 4
+compared the fold against §2.1's own recorded FATAL.
+
+The remedy removes a mechanism rather than adding one: no dedup, no conflict
+rule, no shared state. Duplicate registration is guarded by the prompt alone —
+open classes are shown to every subsequent reviewer with ids and invariants, with
+the instruction to emit `RECURRENCE: <id>` rather than register anew — and the
+100-class cap (§2.5) bounds the cost of the residual duplicates that guard
+misses. A duplicate class is redundant work; a collapsed class is a silent
+clearance. The asymmetry decides it.
 
 ### 2.5 The git invocation
 
@@ -311,12 +340,22 @@ text is still returned.
 
 **The escape from `STATE-UNAVAILABLE` is an operator filesystem action, named in
 the block text** (§1). Unparseable state is moved aside to
-`<lineage_id>.corrupt-<timestamp>.json` rather than left in place or silently
-overwritten, and the message gives the absolute path of both files; a write
-failure names the directory and the errno. The operator repairs or removes the
-file and re-runs. **Recovery is deliberately not automatic:** auto-starting a
-fresh lineage would discard every tracked class and then report `NOT-BLOCKED`,
-turning a storage fault into a false all-clear.
+`<lineage_id>.corrupt-<timestamp>.json`, and the message gives the absolute path
+of both files; a write failure names the directory and the errno.
+
+*Round 4 [FATAL]: quarantining alone **creates** the fresh-lineage path this
+section forbids. Once the canonical file is moved, the next invocation finds it
+absent, initializes an empty lineage, and reports `NOT-BLOCKED` — so merely
+re-running after a `STATE-UNAVAILABLE` discards every tracked class without the
+operator ever performing the named repair.* **A lineage therefore refuses to
+initialize fresh while any `<lineage_id>.corrupt-*.json` sibling exists**: it
+keeps returning `STATE-UNAVAILABLE` + `BLOCKED` until the operator repairs the
+canonical file or deletes the quarantined one. Quarantine is a latch, not a
+sweep.
+
+**Recovery is deliberately not automatic:** auto-starting a fresh lineage would
+discard every tracked class and then report `NOT-BLOCKED`, turning a storage
+fault into a false all-clear.
 
 ### 2.8 Exemptions
 
@@ -476,6 +515,11 @@ It is the escape of last resort, not the escape of first resort — §2.3, §2.8
 5. **Exemptions accumulate**, subject to the same pressure.
 6. **Semantic invariants** (cross-file dataflow, type-level) are not expressible
    as a line regex at all.
+7. **Duplicate classes are now possible**, since §2.4 removed dedup. Two
+   reviewers can register the same invariant under different ids, and both must
+   then be closed. Bounded by the prompt guard and the 100-class cap; accepted
+   deliberately, because a duplicate is redundant work while a collapsed class is
+   a silent clearance.
 
 ## 5. Implementation
 
@@ -504,7 +548,10 @@ duplicate field within a record rejected; missing required field rejected; a
 record after the block's end rejected; a field name in earlier prose does not
 confuse the parser; unmechanized record with `PROCEDURE` parses;
 `RECURRENCE`/`CLOSED`/`RECLASSIFY` naming an unknown id rejected; the retry path
-is taken exactly once and a successful retry parses.
+is taken exactly once and a successful retry parses; **a `Review` with
+`session_ref=None` skips the retry, returns its text unchanged, and blocks per
+policy** (round 4); **two new-class records sharing a pattern and pathspec get
+two distinct ids and two independent state objects** (round 4's dedup FATAL).
 
 **Recurrence binding** (round 3's FATAL, which is the mechanism's own hot path):
 a review whose only class content is `[RECURRENCE <id>]` prose plus a matching
@@ -542,9 +589,11 @@ a sha (empty `--symbolic-full-name` output, exit 0) without `lineage` errors;
 **a dirty target uses the checkout's `HEAD` and rejects a supplied `head_ref`**
 (round 3); unparseable state → `STATE-UNAVAILABLE` + `BLOCKED`, review text still
 returned, **and the corrupt file is quarantined to a named path rather than
-overwritten or silently replaced by a fresh lineage**; write failure → same
-outcome, message names directory and errno; state replaced atomically; a failed
-engine call leaves state byte-identical.
+overwritten or silently replaced by a fresh lineage**; **re-running after a
+quarantine does NOT start a fresh lineage — it blocks again until the quarantine
+sibling is gone** (round 4's latch FATAL); write failure → same outcome, message
+names directory and errno; state replaced atomically; a failed engine call leaves
+state byte-identical.
 
 **Exemptions:** an exempt match is subtracted; **a second, textually identical
 line in the same file is not** (round 2's collision); an exemption whose line

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -1,10 +1,14 @@
 # Brief: class closure — make a defect *class* a tracked object, not an operator inference
 
-Status: DRAFT for review, revision 3. Two codex plan-review rounds folded — round
-1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR. Every finding
-accepted. Round 1's FATALs killed the candidate-enumeration design outright and
-it was replaced (§2.1); round 2's FATAL found that the replacement still had no
-link between a prose finding and a register record, which §2.3 now closes.
+Status: DRAFT for review, revision 4. Three codex plan-review rounds folded —
+round 1: 3 FATAL, 15 MAJOR, 2 MINOR; round 2: 1 FATAL, 8 MAJOR, 2 MINOR; round 3:
+1 FATAL, 3 MAJOR, no risks, no gaps. Every finding accepted. Round 1's FATALs
+killed the candidate-enumeration design outright and it was replaced (§2.1);
+round 2's FATAL found the replacement had no link between a prose finding and a
+register record (§2.3); round 3's FATAL found that the link, as specified, made
+every recurrence response malformed — the fix for one round's finding breaking
+the next round's path, which is the class of error this whole design exists to
+catch.
 
 ## 0. The defect this fixes
 
@@ -63,6 +67,14 @@ failure mode in a new costume.
 on a marginal or mistaken finding would reproduce the failure it exists to
 prevent, in a form the operator cannot escape. §2.9 bounds what may block, and
 every blocking state has a named escape that is not the kill switch.
+
+*Round 3 [MAJOR]: revision 3 asserted that flatly, but `STATE-UNAVAILABLE` had no
+escape at all.* The claim is now narrowed to what is true: every blocking state
+has a named escape, and for `STATE-UNAVAILABLE` alone that escape is an operator
+filesystem action — repairing or removing a named file — rather than an in-tool
+transition. It is deliberately not automatic: silently starting a fresh lineage
+on unreadable state would discard every tracked class and report `NOT-BLOCKED`,
+which is precisely the false clearance this design exists to prevent (§2.7).
 
 ## 2. Mechanism
 
@@ -131,12 +143,29 @@ containing `[MAJOR] … SCOPE: class` followed by `=== CLASS REGISTER === NONE`
 parsed, persisted nothing, and could return `NOT-BLOCKED` — the exact durability
 failure revision 2 claimed to close.*
 
-The parser now cross-checks: **the set of `CLASS-REF` tokens in the prose and the
-set of `REF` values in the register must be equal**, and each record's `SEVERITY`
-must equal its finding's severity tag. A prose class with no record, a record
-with no prose, a duplicate ref, or a severity disagreement is a malformed
-register. A review with genuinely no classes emits `=== CLASS REGISTER ===`
-followed by `NONE` and no `SCOPE: class` finding.
+*Round 3 [FATAL]: revision 3's single bijection then made **every recurrence
+response malformed**. A recurrence finding reports an existing class, so it has
+no new `REF` and no severity of its own, yet the rule demanded both — a surviving
+class would fail validation, burn the retry on the same contradictory grammar,
+and return malformed without recording the recurrence. The mechanism would have
+broken on exactly the path it exists to serve.*
+
+There are therefore **two bijections, one per kind of finding**:
+
+- **New classes.** The set of `CLASS-REF` tokens in the prose equals the set of
+  `REF` values on new-class records, and each record's `SEVERITY` equals its
+  finding's severity tag.
+- **Recurrences.** The set of `[RECURRENCE <class-id>]` markers in the prose
+  equals the set of `RECURRENCE: <class-id>` lines in the register. A recurrence
+  carries **no** `CLASS-REF` and **no** `SEVERITY` — the class id is the
+  reference, and the severity is the one the lineage already holds, changeable
+  only by `RECLASSIFY`.
+
+`CLOSED`, `RECLASSIFY` and `SUPERSEDED-BY` are state transitions, not findings,
+and bind to nothing in the prose. A prose class with no record, a record with no
+prose, a duplicate ref, an unknown class id, or a severity disagreement is a
+malformed register. A review with genuinely no classes and no recurrences emits
+`=== CLASS REGISTER ===` followed by `NONE`.
 
 Parsing is as strict as `arbitration.parse_*`: the block is terminal, every field
 required, duplicates and out-of-block records rejected.
@@ -260,6 +289,17 @@ required, the call erroring without one. Fail-closed beats silently minting a
 fresh lineage every round. Every trailer prints
 `LINEAGE: <id> (rounds recorded: N)` so an unintended split is visible.
 
+*Round 3 [MAJOR]: for dirty reviews that rule keys state to a branch the server
+is not reviewing. Verified: `orientation.resolve_target` returns `head_ref=None`
+and `is_dirty=True` whenever `include_uncommitted` is set, and
+`handlers._converge_branch_review` then snapshots the **checkout's** `HEAD` — but
+the caller's raw `head_ref` is still in scope. With
+`include_uncommitted=true, head_ref="feature"` the server would review the current
+checkout and write its classes into `feature`'s lineage.* **For a dirty target
+the lineage derives from the checkout's own symbolic `HEAD`, and an
+independently supplied `head_ref` is rejected with an error** — the server is not
+reviewing that ref, so accepting it can only contaminate a lineage.
+
 *Round 1 [MAJOR] risk: `logs.write_log` deliberately swallows every write failure,
 since a completed review is the expensive artifact.* **Lineage state must not
 follow that precedent** — a silently lost write plus a `NOT-BLOCKED` footer is
@@ -268,6 +308,15 @@ the engine call and written after a successful one, via temp file + `os.replace`
 in the same directory. A write failure, or existing state that will not parse,
 yields `CLASS-CLOSURE: STATE-UNAVAILABLE` and `CONVERGENCE: BLOCKED`. The review
 text is still returned.
+
+**The escape from `STATE-UNAVAILABLE` is an operator filesystem action, named in
+the block text** (§1). Unparseable state is moved aside to
+`<lineage_id>.corrupt-<timestamp>.json` rather than left in place or silently
+overwritten, and the message gives the absolute path of both files; a write
+failure names the directory and the errno. The operator repairs or removes the
+file and re-runs. **Recovery is deliberately not automatic:** auto-starting a
+fresh lineage would discard every tracked class and then report `NOT-BLOCKED`,
+turning a storage fault into a false all-clear.
 
 ### 2.8 Exemptions
 
@@ -325,10 +374,19 @@ well as lowered.
 Registered with `PROCEDURE:` instead of `PATTERN:`/`PATHSPEC:`, given a server id
 like any other class, carried forward as a reviewer obligation, always shown,
 never floor-suppressed, and marked `unmechanized` in the trailer so the weakness
-is visible. They cannot block mechanically — there is nothing to run — and they
-close only when a later reviewer names the id on a `CLOSED:` line: still a
-judgement, but an explicit, cold, recorded one rather than an operator's silent
-assumption.
+is visible. They close only when a later reviewer names the id on a `CLOSED:`
+line: still a judgement, but an explicit, cold, recorded one rather than an
+operator's silent assumption.
+
+*Round 3 [MAJOR]: revision 3 said they "cannot block mechanically", which
+conflated **nothing to run** with **not blocking**. Since `NOT-BLOCKED` is
+defined as "no unclosed class" and is the documented stop signal, an open
+unmechanized `MAJOR` would have let the trailer report `NOT-BLOCKED` with a known
+major class outstanding — and §4.6 deliberately routes every semantic invariant
+down this path, so that is the common case, not an edge one.* **An unmechanized
+class of severity `BLOCKER` or `MAJOR` blocks until `CLOSED` or `RECLASSIFY`.**
+What it lacks is a mechanical *check*, not the ability to block; the trailer
+names it as awaiting a reviewer judgement rather than a git result.
 
 ### 2.11 The computed trailer, and the `CONVERGED` collision
 
@@ -338,7 +396,9 @@ Appended by `handlers._footer`:
 LINEAGE: <id> (rounds recorded: N)
 CLASS-REGISTER: parsed 3 | NONE | absent | malformed: <reason>
 CLASS-CLOSURE: 2 open, 1 closed this round, 4 recurrences, 1 exempt, 1 unmechanized
-CONVERGENCE: BLOCKED — 2 class(es) unclosed: 3f2a91c4 <invariant>; 91b0e77d <invariant>
+CONVERGENCE: BLOCKED — 2 class(es) unclosed:
+  3f2a91c4 <invariant> (mechanized: 4 matches)
+  91b0e77d <invariant> (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)
 ```
 
 or `CONVERGENCE: NOT-BLOCKED — no unclosed class; reviewer findings still govern.`
@@ -446,6 +506,14 @@ confuse the parser; unmechanized record with `PROCEDURE` parses;
 `RECURRENCE`/`CLOSED`/`RECLASSIFY` naming an unknown id rejected; the retry path
 is taken exactly once and a successful retry parses.
 
+**Recurrence binding** (round 3's FATAL, which is the mechanism's own hot path):
+a review whose only class content is `[RECURRENCE <id>]` prose plus a matching
+`RECURRENCE: <id>` line **parses and is not malformed**; a recurrence carrying a
+`CLASS-REF` or a `SEVERITY` is rejected; a prose `[RECURRENCE <id>]` with no
+register line, and a register line with no prose marker, are each malformed; a
+review mixing one new class and one recurrence satisfies both bijections
+independently; `CLOSED`/`RECLASSIFY`/`SUPERSEDED-BY` require no prose binding.
+
 **Closure semantics:** zero matches → closed; any match → open with every match a
 recurrence; a closed class with a new match reopens; a superseded class is not
 rechecked; `first_round` survives supersession; **two records sharing a predicate
@@ -460,17 +528,23 @@ refused.
 
 **Blocking policy:** `MAJOR` class blocks; `MINOR` and `OUT-OF-SCOPE` do not and
 are reported advisory; **`malformed`/`over-broad`/`unchecked` on a `MINOR` class
-does not block** (round 2's severity-policy contradiction); `RECLASSIFY` to
-`MINOR` unblocks and to `MAJOR` re-blocks; `BLOCKED` names the ids;
-`NOT-BLOCKED` text does not contain the word *converged*; when blocked, the
-footer voids a reviewer `CONVERGED`.
+does not block** (round 2's severity-policy contradiction); **an open
+unmechanized `MAJOR` blocks, and `NOT-BLOCKED` is never emitted while one is
+open** (round 3); `CLOSED` on it unblocks, as does `RECLASSIFY` to `MINOR`;
+`RECLASSIFY` to `MAJOR` re-blocks; `BLOCKED` names the ids and distinguishes
+mechanized match counts from unmechanized awaiting-judgement; `NOT-BLOCKED` text
+does not contain the word *converged*; when blocked, the footer voids a reviewer
+`CONVERGED`.
 
 **Lineage:** a reviewed `head_ref` that is a branch but not checked out yields
 its own lineage, and two such branches off one base differ; a `head_ref` that is
 a sha (empty `--symbolic-full-name` output, exit 0) without `lineage` errors;
-unparseable state → `STATE-UNAVAILABLE` + `BLOCKED`, review text still returned;
-write failure → same; state replaced atomically; a failed engine call leaves
-state byte-identical.
+**a dirty target uses the checkout's `HEAD` and rejects a supplied `head_ref`**
+(round 3); unparseable state → `STATE-UNAVAILABLE` + `BLOCKED`, review text still
+returned, **and the corrupt file is quarantined to a named path rather than
+overwritten or silently replaced by a fresh lineage**; write failure → same
+outcome, message names directory and errno; state replaced atomically; a failed
+engine call leaves state byte-identical.
 
 **Exemptions:** an exempt match is subtracted; **a second, textually identical
 line in the same file is not** (round 2's collision); an exemption whose line

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -1,0 +1,717 @@
+"""Class closure: make a defect *class* a tracked object rather than an operator inference.
+
+The pure core. Everything that touches git, the clock or the filesystem is injected,
+so the protocol itself is testable without a repository.
+
+Design contract: `docs/class_closure_plan.md`. The two rules that matter most, both
+arrived at by deleting mechanism rather than adding it:
+
+1. A mechanized class's predicate matches VIOLATIONS ONLY, so closure is exactly
+   "zero matches" and no adjudication layer can whitelist a live defect (§2.1).
+2. Nothing in the review's prose is parsed. The register is the sole class channel,
+   and a class the reviewer declines to register is simply not tracked — that is
+   unachievable to police and §1 scopes the guarantee accordingly (§2.2).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import tempfile
+from dataclasses import dataclass, field, replace
+from pathlib import Path
+from typing import Any, Callable, Iterable, Sequence
+
+from .textsafe import display
+
+# ── severities and statuses ───────────────────────────────────────────────────
+
+BLOCKER, MAJOR, MINOR, OUT_OF_SCOPE = "BLOCKER", "MAJOR", "MINOR", "OUT-OF-SCOPE"
+SEVERITIES = (BLOCKER, MAJOR, MINOR, OUT_OF_SCOPE)
+#: Only these two ever block. MINOR/OUT-OF-SCOPE classes are tracked and advisory —
+#: a mechanism that can block forever on a marginal finding reproduces the very
+#: failure it exists to prevent (plan §2.9).
+BLOCKING_SEVERITIES = frozenset({BLOCKER, MAJOR})
+
+OPEN, CLOSED, OVER_BROAD, MALFORMED, UNCHECKED, SUPERSEDED = (
+    "open", "closed", "over-broad", "malformed", "unchecked", "superseded",
+)
+#: Every status except `closed` and `superseded` means "closure not proven".
+UNPROVEN_STATUSES = frozenset({OPEN, OVER_BROAD, MALFORMED, UNCHECKED})
+
+MAX_MATCHES = 200          # output bound; over it the class is `over-broad`
+MAX_ACTIVE_CLASSES = 100   # counted over NON-SUPERSEDED classes only (plan §2.5)
+PER_CLASS_TIMEOUT = 10     # seconds
+ROUND_BUDGET = 60          # seconds, aggregate across all classes in a round
+
+REGISTER_MARKER = "=== CLASS REGISTER ==="
+NONE = "NONE"
+
+
+class RegisterError(ValueError):
+    """The register block is absent or does not parse."""
+
+
+# ── records parsed out of the register ────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class NewClass:
+    invariant: str
+    severity: str
+    pattern: str | None = None
+    pathspec: str | None = None
+    procedure: str | None = None
+
+    @property
+    def mechanized(self) -> bool:
+        return self.pattern is not None
+
+
+@dataclass(frozen=True)
+class Transition:
+    """`CLOSED`/`REOPEN`/`RECLASSIFY`/`SUPERSEDE` — a state change, not a finding."""
+
+    kind: str
+    class_id: str
+    severity: str | None = None
+    target: str | None = None
+    pattern: str | None = None
+    pathspec: str | None = None
+    procedure: str | None = None
+    invariant: str | None = None
+
+
+@dataclass(frozen=True)
+class Register:
+    new_classes: tuple[NewClass, ...] = ()
+    transitions: tuple[Transition, ...] = ()
+
+
+# ── the tracked class ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TrackedClass:
+    class_id: str
+    invariant: str
+    severity: str
+    first_round: int
+    status: str
+    pattern: str | None = None
+    pathspec: str | None = None
+    procedure: str | None = None
+    superseded_by: str | None = None
+    detail: str | None = None                 # why malformed / over-broad
+    matches: tuple[dict[str, Any], ...] = ()  # last sweep's surviving matches
+
+    @property
+    def mechanized(self) -> bool:
+        return self.pattern is not None
+
+    @property
+    def blocking(self) -> bool:
+        return self.severity in BLOCKING_SEVERITIES and self.status in UNPROVEN_STATUSES
+
+
+@dataclass(frozen=True)
+class Exemption:
+    class_id: str
+    path: str
+    line: int
+    fingerprint: str
+
+
+def fingerprint(text: str) -> str:
+    """Normalized-whitespace hash of a matched line. An exemption is void once the
+    line's text changes, which fails toward blocking rather than toward clearance."""
+    return hashlib.sha256(" ".join(text.split()).encode("utf-8", "surrogateescape")).hexdigest()[:16]
+
+
+# ── register parsing ──────────────────────────────────────────────────────────
+
+_NEW_MECHANIZED = {"CLASS", "SEVERITY", "PATTERN", "PATHSPEC"}
+_NEW_UNMECHANIZED = {"CLASS", "SEVERITY", "PROCEDURE"}
+_KNOWN_KEYS = _NEW_MECHANIZED | _NEW_UNMECHANIZED | {
+    "CLOSED", "REOPEN", "RECLASSIFY", "SUPERSEDE", "BY", "WITH-PATTERN", "WITH-PROCEDURE",
+}
+
+
+def parse_register(text: str) -> Register:
+    """Parse the terminal `=== CLASS REGISTER ===` block.
+
+    Strict in the manner of `arbitration.parse_*`, because this is the one
+    model-authored surface that is parsed at all: the block is terminal, records are
+    blank-line separated, every field is required for its record kind, and duplicate
+    or unknown keys are rejected. Nothing outside the block is examined.
+    """
+    idx = text.rfind(REGISTER_MARKER)
+    if idx < 0:
+        raise RegisterError("no === CLASS REGISTER === block")
+    if text.count(REGISTER_MARKER) > 1:
+        raise RegisterError("more than one === CLASS REGISTER === block")
+
+    body = text[idx + len(REGISTER_MARKER):].strip()
+    if body == NONE:
+        return Register()
+    if not body:
+        raise RegisterError("register block is empty (use NONE)")
+
+    new_classes: list[NewClass] = []
+    transitions: list[Transition] = []
+    for block in [b for b in body.split("\n\n") if b.strip()]:
+        fields = _parse_block(block)
+        keys = set(fields)
+        if "CLOSED" in keys or "REOPEN" in keys or "RECLASSIFY" in keys:
+            transitions.append(_simple_transition(fields, keys))
+        elif "SUPERSEDE" in keys:
+            transitions.append(_supersede(fields, keys))
+        elif "CLASS" in keys:
+            new_classes.append(_new_class(fields, keys))
+        else:
+            raise RegisterError(f"unrecognised record: {sorted(keys)}")
+    return Register(tuple(new_classes), tuple(transitions))
+
+
+def _parse_block(block: str) -> dict[str, str]:
+    fields: dict[str, str] = {}
+    for line in block.splitlines():
+        line = line.rstrip()
+        if not line.strip():
+            continue
+        if line.lstrip().startswith("#"):
+            continue
+        if ":" not in line:
+            raise RegisterError(f"register line is not KEY: value — {line!r}")
+        key, _, value = line.partition(":")
+        key = key.strip()
+        if key not in _KNOWN_KEYS:
+            raise RegisterError(f"unknown register key {key!r}")
+        if key in fields:
+            raise RegisterError(f"duplicate register key {key!r}")
+        fields[key] = value.strip()
+    if not fields:
+        raise RegisterError("empty register record")
+    return fields
+
+
+def _require(fields: dict[str, str], key: str) -> str:
+    value = fields.get(key, "")
+    if not value:
+        raise RegisterError(f"register record is missing {key}")
+    return value
+
+
+def _severity(raw: str) -> str:
+    if raw not in SEVERITIES:
+        raise RegisterError(f"unknown severity {raw!r}")
+    return raw
+
+
+def _new_class(fields: dict[str, str], keys: set[str]) -> NewClass:
+    invariant, severity = _require(fields, "CLASS"), _severity(_require(fields, "SEVERITY"))
+    if keys == _NEW_MECHANIZED:
+        pathspec = _require(fields, "PATHSPEC")
+        _reject_pathspec_magic(pathspec)
+        return NewClass(invariant, severity, pattern=_require(fields, "PATTERN"), pathspec=pathspec)
+    if keys == _NEW_UNMECHANIZED:
+        return NewClass(invariant, severity, procedure=_require(fields, "PROCEDURE"))
+    raise RegisterError(
+        "a new class needs CLASS+SEVERITY plus either PATTERN+PATHSPEC or PROCEDURE, "
+        f"got {sorted(keys)}"
+    )
+
+
+def _simple_transition(fields: dict[str, str], keys: set[str]) -> Transition:
+    for kind in ("CLOSED", "REOPEN"):
+        if kind in keys:
+            if keys != {kind}:
+                raise RegisterError(f"{kind} takes no other fields, got {sorted(keys)}")
+            return Transition(kind, _require(fields, kind))
+    if keys != {"RECLASSIFY"}:
+        raise RegisterError(f"RECLASSIFY takes no other fields, got {sorted(keys)}")
+    parts = _require(fields, "RECLASSIFY").split()
+    if len(parts) != 2:
+        raise RegisterError("RECLASSIFY takes '<class-id> <severity>'")
+    return Transition("RECLASSIFY", parts[0], severity=_severity(parts[1]))
+
+
+def _supersede(fields: dict[str, str], keys: set[str]) -> Transition:
+    old = _require(fields, "SUPERSEDE")
+    if keys == {"SUPERSEDE", "BY"}:
+        return Transition("SUPERSEDE", old, target=_require(fields, "BY"))
+    if keys <= {"SUPERSEDE", "WITH-PATTERN", "PATHSPEC", "CLASS"} and "WITH-PATTERN" in keys:
+        pathspec = _require(fields, "PATHSPEC")
+        _reject_pathspec_magic(pathspec)
+        return Transition(
+            "SUPERSEDE", old, pattern=_require(fields, "WITH-PATTERN"),
+            pathspec=pathspec, invariant=fields.get("CLASS") or None,
+        )
+    if keys <= {"SUPERSEDE", "WITH-PROCEDURE", "CLASS"} and "WITH-PROCEDURE" in keys:
+        return Transition(
+            "SUPERSEDE", old, procedure=_require(fields, "WITH-PROCEDURE"),
+            invariant=fields.get("CLASS") or None,
+        )
+    raise RegisterError(
+        "SUPERSEDE takes BY, or WITH-PATTERN+PATHSPEC, or WITH-PROCEDURE — "
+        f"got {sorted(keys)}"
+    )
+
+
+def _reject_pathspec_magic(pathspec: str) -> None:
+    """A leading `:` is git pathspec magic. Verified: `-- ':(exclude)src'` is accepted
+    and silently changes the result set, so a model-authored pathspec must not carry it."""
+    if pathspec.startswith(":"):
+        raise RegisterError(
+            f"pathspec magic is not allowed (leading ':') — {pathspec!r}"
+        )
+
+
+# ── lineage state ─────────────────────────────────────────────────────────────
+
+
+@dataclass
+class Lineage:
+    lineage_id: str
+    rounds: int = 0
+    next_seq: int = 1
+    classes: dict[str, TrackedClass] = field(default_factory=dict)
+    exemptions: list[Exemption] = field(default_factory=list)
+    debt: dict[str, Any] | None = None
+
+    def active(self) -> list[TrackedClass]:
+        return [c for c in self.classes.values() if c.status != SUPERSEDED]
+
+    def blocking(self) -> list[TrackedClass]:
+        return [c for c in self.active() if c.blocking]
+
+
+class StateUnavailable(RuntimeError):
+    """Lineage state could not be read or written. Blocks; never silently starts fresh —
+    a storage fault must not become a false all-clear (plan §2.7)."""
+
+
+def lineage_dir(root: Path) -> Path:
+    return Path(root) / "lineages"
+
+
+def _paths(root: Path, lineage_id: str) -> tuple[Path, Path]:
+    d = lineage_dir(root)
+    return d / f"{lineage_id}.json", d / f"{lineage_id}.pending"
+
+
+def load_lineage(root: Path, lineage_id: str, *, stamp: str) -> Lineage:
+    state_path, pending = _paths(root, lineage_id)
+    quarantined = sorted(lineage_dir(root).glob(f"{lineage_id}.corrupt-*.json"))
+    if quarantined:
+        raise StateUnavailable(
+            f"lineage {lineage_id} has quarantined state — repair or delete "
+            f"{quarantined[-1]} before this lineage can be used again"
+        )
+    if pending.exists():
+        raise StateUnavailable(
+            f"a previous round left a pending write latch at {pending}; its state write "
+            "may not have completed. Inspect and remove it to continue."
+        )
+    if not state_path.exists():
+        return Lineage(lineage_id)
+    try:
+        raw = json.loads(state_path.read_text(encoding="utf-8"))
+        return _from_json(lineage_id, raw)
+    except Exception as exc:  # noqa: BLE001 — any unreadable state blocks, none is repaired silently
+        dest = lineage_dir(root) / f"{lineage_id}.corrupt-{stamp}.json"
+        try:
+            state_path.replace(dest)
+        except OSError:
+            dest = state_path
+        raise StateUnavailable(
+            f"lineage state at {state_path} did not parse ({exc}); quarantined to {dest}. "
+            "Repair or delete it and re-run."
+        ) from exc
+
+
+def _from_json(lineage_id: str, raw: dict[str, Any]) -> Lineage:
+    return Lineage(
+        lineage_id=lineage_id,
+        rounds=int(raw.get("rounds", 0)),
+        next_seq=int(raw.get("next_seq", 1)),
+        classes={
+            c["class_id"]: TrackedClass(
+                class_id=c["class_id"], invariant=c["invariant"], severity=c["severity"],
+                first_round=int(c["first_round"]), status=c["status"],
+                pattern=c.get("pattern"), pathspec=c.get("pathspec"),
+                procedure=c.get("procedure"), superseded_by=c.get("superseded_by"),
+                detail=c.get("detail"), matches=tuple(c.get("matches", ())),
+            )
+            for c in raw.get("classes", [])
+        },
+        exemptions=[Exemption(**e) for e in raw.get("exemptions", [])],
+        debt=raw.get("debt"),
+    )
+
+
+def _to_json(lineage: Lineage) -> dict[str, Any]:
+    return {
+        "rounds": lineage.rounds,
+        "next_seq": lineage.next_seq,
+        "classes": [
+            {k: v for k, v in vars(c).items() if v not in (None, ())} | {"matches": list(c.matches)}
+            for c in lineage.classes.values()
+        ],
+        "exemptions": [vars(e) for e in lineage.exemptions],
+        "debt": lineage.debt,
+    }
+
+
+def open_latch(root: Path, lineage_id: str) -> None:
+    """Written before the engine call, cleared only once the round has finished writing.
+    Without it a *failed* write leaves no marker and the next round starts empty."""
+    _, pending = _paths(root, lineage_id)
+    pending.parent.mkdir(parents=True, exist_ok=True)
+    pending.write_text("pending\n", encoding="utf-8")
+
+
+def clear_latch(root: Path, lineage_id: str) -> None:
+    _, pending = _paths(root, lineage_id)
+    pending.unlink(missing_ok=True)
+
+
+def save_lineage(root: Path, lineage: Lineage) -> None:
+    state_path, _ = _paths(root, lineage.lineage_id)
+    state_path.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        fd, tmp = tempfile.mkstemp(dir=str(state_path.parent), suffix=".tmp")
+        with os.fdopen(fd, "w", encoding="utf-8") as fh:
+            json.dump(_to_json(lineage), fh, indent=2, default=str)
+        os.replace(tmp, state_path)
+    except OSError as exc:
+        raise StateUnavailable(
+            f"could not write lineage state under {state_path.parent}: {exc}"
+        ) from exc
+
+
+# ── applying a register ───────────────────────────────────────────────────────
+
+
+def mint_id(lineage_id: str, seq: int, invariant: str) -> str:
+    """Server-assigned and stable for life. Never derived from the predicate: two
+    distinct invariants expressible by one regex must stay two independent classes."""
+    return hashlib.sha256(f"{lineage_id}\0{seq}\0{invariant}".encode()).hexdigest()[:8]
+
+
+def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> list[str]:
+    """Fold a parsed register into the lineage. Returns the ids of newly minted classes,
+    which the caller must then evaluate before computing a verdict (plan §2.6)."""
+    minted: list[str] = []
+    for t in register.transitions:
+        _apply_transition(lineage, t, round_no=round_no, minted=minted)
+    for nc in register.new_classes:
+        if len(lineage.active()) >= MAX_ACTIVE_CLASSES:
+            raise RegisterError(
+                f"registration refused: {MAX_ACTIVE_CLASSES} non-superseded classes already "
+                "tracked. Close or supersede one first."
+            )
+        minted.append(_add(lineage, nc.invariant, nc.severity, round_no,
+                           nc.pattern, nc.pathspec, nc.procedure))
+    return minted
+
+
+def _add(lineage: Lineage, invariant: str, severity: str, round_no: int,
+         pattern: str | None, pathspec: str | None, procedure: str | None) -> str:
+    cid = mint_id(lineage.lineage_id, lineage.next_seq, invariant)
+    lineage.next_seq += 1
+    lineage.classes[cid] = TrackedClass(
+        class_id=cid, invariant=invariant, severity=severity, first_round=round_no,
+        # A mechanized class is UNCHECKED until its predicate has actually run, so a
+        # class registered this round cannot ride out the round as silently closed.
+        status=UNCHECKED if pattern else OPEN,
+        pattern=pattern, pathspec=pathspec, procedure=procedure,
+    )
+    return cid
+
+
+def _apply_transition(lineage: Lineage, t: Transition, *, round_no: int, minted: list[str]) -> None:
+    cls = lineage.classes.get(t.class_id)
+    if cls is None:
+        raise RegisterError(f"{t.kind} names unknown class id {t.class_id!r}")
+
+    if t.kind in ("CLOSED", "REOPEN"):
+        if cls.mechanized:
+            raise RegisterError(
+                f"{t.kind} is for unmechanized classes only; {t.class_id} has a predicate "
+                "and closes or reopens from git"
+            )
+        lineage.classes[t.class_id] = replace(cls, status=CLOSED if t.kind == "CLOSED" else OPEN)
+        return
+
+    if t.kind == "RECLASSIFY":
+        lineage.classes[t.class_id] = replace(cls, severity=t.severity or cls.severity)
+        return
+
+    # SUPERSEDE — the source must not survive as a blocker, so the replacement has to be real.
+    if t.target is not None:
+        if t.target == t.class_id:
+            raise RegisterError("SUPERSEDE ... BY cannot name the class it supersedes")
+        target = lineage.classes.get(t.target)
+        if target is None:
+            raise RegisterError(f"SUPERSEDE ... BY names unknown class id {t.target!r}")
+        if target.status == SUPERSEDED:
+            raise RegisterError(f"SUPERSEDE ... BY names an already-superseded class {t.target!r}")
+        lineage.classes[t.target] = replace(
+            target, first_round=min(target.first_round, cls.first_round)
+        )
+        new_id = t.target
+    else:
+        new_id = _add(
+            lineage, t.invariant or cls.invariant, cls.severity, cls.first_round,
+            t.pattern, t.pathspec, t.procedure,
+        )
+        minted.append(new_id)
+    lineage.classes[t.class_id] = replace(cls, status=SUPERSEDED, superseded_by=new_id)
+
+
+# ── the closure sweep ─────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class GrepResult:
+    """One class's two-pass git result. `paths` is the VERDICT (from `git grep -l -z`,
+    uniform across text and binary); `matches` is display only (from `-I -z -n`), so a
+    binary-only violation still blocks even though no line can be shown."""
+
+    paths: tuple[str, ...] = ()
+    matches: tuple[dict[str, Any], ...] = ()
+    error: str | None = None
+
+
+GitGrep = Callable[[str, str], GrepResult]
+
+
+def sweep(lineage: Lineage, grep: GitGrep, *, only: Iterable[str] | None = None,
+          budget: float = ROUND_BUDGET, clock: Callable[[], float] | None = None) -> None:
+    """Re-run every non-superseded mechanized predicate and update its status in place.
+
+    `closed` classes are swept too: a later fix can reintroduce a defect, and a class
+    that never reopens would let the trailer report nothing unclosed while it lives.
+    """
+    ids = list(only) if only is not None else list(lineage.classes)
+    now = clock or (lambda: 0.0)
+    started = now()
+    for cid in ids:
+        cls = lineage.classes.get(cid)
+        if cls is None or cls.status == SUPERSEDED or not cls.mechanized:
+            continue
+        if budget is not None and now() - started >= budget:
+            lineage.classes[cid] = replace(
+                cls, status=UNCHECKED, detail="round closure budget exhausted before this class ran"
+            )
+            continue
+        lineage.classes[cid] = _evaluate(cls, grep(cls.pattern or "", cls.pathspec or "."),
+                                         lineage.exemptions)
+
+
+def _evaluate(cls: TrackedClass, result: GrepResult, exemptions: Sequence[Exemption]) -> TrackedClass:
+    if result.error:
+        # A predicate that cannot run has not proved closure — but for an advisory class
+        # that is no reason to stop the loop, so blocking still follows severity.
+        return replace(cls, status=MALFORMED, detail=result.error, matches=())
+    if len(result.paths) > MAX_MATCHES:
+        return replace(
+            cls, status=OVER_BROAD, matches=(),
+            detail=f"{len(result.paths)} matching paths exceeds the {MAX_MATCHES} cap — narrow "
+                   "the predicate with SUPERSEDE ... WITH-PATTERN",
+        )
+
+    exempt = {(e.path, e.line, e.fingerprint) for e in exemptions if e.class_id == cls.class_id}
+    shown = [
+        m for m in result.matches
+        if (m["path"], m["line"], fingerprint(m["text"])) not in exempt
+    ]
+    exempt_paths = {e.path for e in exemptions if e.class_id == cls.class_id}
+    displayed_paths = {m["path"] for m in result.matches}
+    surviving_paths = [p for p in result.paths if p not in exempt_paths]
+    # A path the verdict pass found but the display pass could not read is a binary match:
+    # it must still block, and must still be visible, with no line to quote.
+    binary = [
+        {"path": p, "line": 0, "text": "", "binary": True}
+        for p in surviving_paths if p not in displayed_paths
+    ]
+    survivors = tuple(shown + binary)
+    if not survivors:
+        return replace(cls, status=CLOSED, matches=(), detail=None)
+    return replace(cls, status=OPEN, matches=survivors, detail=None)
+
+
+# ── the git edge ──────────────────────────────────────────────────────────────
+
+def make_grep(repo: Path, commit: str, *,
+              runner: Callable[[list[str], Path, int], tuple[int, bytes, bytes]]) -> GitGrep:
+    """Bind a two-pass `git grep` to one snapshot.
+
+    The predicate is DATA, never an argv: `shell=False`, no pipes, no reviewer-chosen
+    binary or flags, pattern and pathspec passed as operands. `git grep <commit>` reads
+    the tree directly, so no checkout is needed.
+    """
+
+    def grep(pattern: str, pathspec: str) -> GrepResult:
+        base = ["git", "grep", "-z", "-E", "--no-color", "-e", pattern, commit, "--", pathspec or "."]
+        try:
+            # Verdict pass: -l lists matching paths, uniformly for text AND binary blobs.
+            # -I would silently drop a binary violation and report the class closed.
+            code, out, err = runner(["git", "grep", "-l"] + base[2:], repo, PER_CLASS_TIMEOUT)
+        except TimeoutError:
+            return GrepResult(error=f"predicate timed out after {PER_CLASS_TIMEOUT}s")
+        if code == 1:
+            return GrepResult()               # no matches: closure, not failure
+        if code >= 2:
+            return GrepResult(error=_git_error(err))
+        paths = tuple(p for p in _decode(out).split("\0") if p)
+
+        # Display pass. Its failure is not a verdict failure — the verdict already stands.
+        matches: tuple[dict[str, Any], ...] = ()
+        try:
+            code2, out2, _ = runner(["git", "grep", "-I", "-n"] + base[2:], repo, PER_CLASS_TIMEOUT)
+            if code2 == 0:
+                matches = _parse_matches(_decode(out2))
+        except TimeoutError:
+            pass
+        return GrepResult(paths=_strip_commit(paths, commit), matches=matches)
+
+    return grep
+
+
+def _decode(raw: bytes) -> str:
+    return raw.decode("utf-8", "surrogateescape")
+
+
+def _git_error(err: bytes) -> str:
+    first = _decode(err).strip().splitlines()
+    return first[0] if first else "git grep failed"
+
+
+def _strip_commit(paths: Sequence[str], commit: str) -> tuple[str, ...]:
+    prefix = f"{commit}:"
+    return tuple(p[len(prefix):] if p.startswith(prefix) else p for p in paths)
+
+
+def _parse_matches(out: str) -> tuple[dict[str, Any], ...]:
+    """`-z -n` emits `<commit>:<path>\0<line>\0<text>\n` — paths are NUL-terminated, so a
+    path containing a newline or non-UTF-8 bytes still parses unambiguously."""
+    found: list[dict[str, Any]] = []
+    for record in out.split("\n"):
+        if not record:
+            continue
+        parts = record.split("\0")
+        if len(parts) < 3:
+            continue
+        path, line, text = parts[0], parts[1], "\0".join(parts[2:])
+        path = path.split(":", 1)[1] if ":" in path else path
+        try:
+            found.append({"path": path, "line": int(line), "text": text})
+        except ValueError:
+            continue
+    return tuple(found)
+
+
+# ── rendering (every path and line goes through the injective display helper) ──
+
+UNCLOSED_HEADER = "=== UNCLOSED CLASSES — re-verify these; do NOT suppress ==="
+UNMECHANIZED_HEADER = "=== UNMECHANIZED CLASSES — no predicate; you are the check ==="
+EXEMPT_HEADER = "=== CLAIMED EXEMPT — challenge any that is not genuinely a false positive ==="
+
+_UNCLOSED_INSTRUCTION = (
+    "These were reported in an earlier round and are NOT closed. Report every surviving "
+    "match, marked [RECURRENCE <id>]. The ROUND severity floor does not apply to them. If a "
+    "finding of yours is an instance of one of these, report it as a recurrence of that id — "
+    "do NOT register it as a new class. Where this block and the already-raised block "
+    "conflict, THIS block governs."
+)
+
+
+def render_unclosed(lineage: Lineage) -> str | None:
+    rows = [c for c in lineage.active() if c.mechanized and c.status in UNPROVEN_STATUSES]
+    if not rows:
+        return None
+    out = [UNCLOSED_HEADER, _UNCLOSED_INSTRUCTION, ""]
+    for c in sorted(rows, key=lambda c: (c.first_round, c.class_id)):
+        out.append(f"[class {c.class_id}, first raised round {c.first_round}, {c.severity}] "
+                   f"{display(c.invariant)}")
+        if c.detail:
+            out.append(f"  status {c.status}: {display(c.detail)}")
+        for m in c.matches[:MAX_MATCHES]:
+            if m.get("binary"):
+                out.append(f"  {display(m['path'])}: binary match (line not shown)")
+            else:
+                out.append(f"  {display(m['path'])}:{m['line']}: {display(m['text'])}")
+    return "\n".join(out)
+
+
+def render_unmechanized(lineage: Lineage) -> str | None:
+    """Closed entries are listed too — without their ids a later cold reviewer has no way
+    to emit REOPEN, and the class could recur while the state stayed closed."""
+    rows = [c for c in lineage.active() if not c.mechanized]
+    if not rows:
+        return None
+    out = [UNMECHANIZED_HEADER,
+           "No predicate can check these. Re-verify each by its procedure. Emit "
+           "`CLOSED: <id>` when one is genuinely closed, or `REOPEN: <id>` when a closed "
+           "one is violated again.", ""]
+    for c in sorted(rows, key=lambda c: (c.first_round, c.class_id)):
+        state = f"closed" if c.status == CLOSED else c.status
+        out.append(f"[{c.class_id}, {c.severity}, {state}, first raised round {c.first_round}] "
+                   f"{display(c.invariant)}")
+        out.append(f"  procedure: {display(c.procedure or '')}")
+    return "\n".join(out)
+
+
+def render_exempt(lineage: Lineage) -> str | None:
+    if not lineage.exemptions:
+        return None
+    out = [EXEMPT_HEADER]
+    for e in lineage.exemptions:
+        out.append(f"- class {e.class_id}: {display(e.path)}:{e.line}")
+    return "\n".join(out)
+
+
+def render_trailer(lineage: Lineage, *, register_status: str,
+                   minted: Sequence[str] = (), reopened: Sequence[str] = ()) -> str:
+    """The computed verdict. It only ever asserts the NEGATIVE: `NOT-BLOCKED` says no
+    blocking class is unclosed, never that the change is correct and never the word
+    `converged` — a mechanical check laundered into an approval is the failure mode
+    this whole design is built against."""
+    active = lineage.active()
+    blocking = lineage.blocking()
+    counts = (
+        f"{sum(1 for c in active if c.status in UNPROVEN_STATUSES)} open, "
+        f"{sum(1 for c in active if c.status == CLOSED)} closed, "
+        f"{sum(len(c.matches) for c in active)} surviving matches, "
+        f"{len(lineage.exemptions)} exempt, "
+        f"{sum(1 for c in active if not c.mechanized)} unmechanized"
+    )
+    lines = [
+        f"LINEAGE: {lineage.lineage_id} (rounds recorded: {lineage.rounds})",
+        f"CLASS-REGISTER: {register_status}",
+        f"CLASS-CLOSURE: {counts}",
+    ]
+    if lineage.debt:
+        lines.append(
+            f"CONVERGENCE: BLOCKED — register debt from round {lineage.debt.get('round')}: "
+            f"{lineage.debt.get('reason')}"
+        )
+    elif blocking:
+        lines.append(f"CONVERGENCE: BLOCKED — {len(blocking)} class(es) unclosed:")
+        for c in sorted(blocking, key=lambda c: (c.first_round, c.class_id)):
+            how = (f"mechanized: {len(c.matches)} match(es)" if c.mechanized
+                   else "unmechanized: awaiting reviewer CLOSED or RECLASSIFY")
+            if c.status in (MALFORMED, OVER_BROAD, UNCHECKED):
+                how = f"{c.status}: {display(c.detail or 'closure not proven')}"
+            lines.append(f"  {c.class_id} {display(c.invariant)} ({how})")
+        lines.append(
+            "  Any `CONVERGED` in the review text above is VOID: it is the reviewer's "
+            "judgement about new findings, not a statement about these classes."
+        )
+    else:
+        lines.append("CONVERGENCE: NOT-BLOCKED — no blocking class is unclosed; advisory "
+                     "classes may remain open. Reviewer findings still govern.")
+    return "\n".join(lines)

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -386,13 +386,27 @@ def open_latch(root: Path, lineage_id: str) -> None:
     """Written before the engine call, cleared only once the round has finished writing.
     Without it a *failed* write leaves no marker and the next round starts empty."""
     _, pending = _paths(root, lineage_id)
-    pending.parent.mkdir(parents=True, exist_ok=True)
-    pending.write_text("pending\n", encoding="utf-8")
+    try:
+        pending.parent.mkdir(parents=True, exist_ok=True)
+        pending.write_text("pending\n", encoding="utf-8")
+    except OSError as exc:
+        # Same treatment as a failed lineage save: block, but never prevent the review
+        # from running or discard its text over a storage fault.
+        raise StateUnavailable(f"could not write the pending latch at {pending}: {exc}") from exc
 
 
 def clear_latch(root: Path, lineage_id: str) -> None:
+    """Best-effort by design, and the ONE place in this module where that is right.
+
+    A latch that cannot be removed leaves the next round `STATE-UNAVAILABLE`, which is
+    exactly the fail-closed outcome the latch exists to produce. Raising here instead would
+    destroy a completed, paid review over a file that could not be unlinked.
+    """
     _, pending = _paths(root, lineage_id)
-    pending.unlink(missing_ok=True)
+    try:
+        pending.unlink(missing_ok=True)
+    except OSError:
+        pass
 
 
 def save_lineage(root: Path, lineage: Lineage) -> None:

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -441,7 +441,7 @@ def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> li
     was rejected — and once the debt was discharged the trailer could report `NOT-BLOCKED`
     on the strength of a transition from a register that never parsed.
     """
-    draft = _copy(lineage)
+    draft = copy_lineage(lineage)
     minted: list[str] = []
     seen_sources: set[str] = set()
     for t in register.transitions:
@@ -473,7 +473,7 @@ def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> li
     return minted
 
 
-def _copy(lineage: Lineage) -> Lineage:
+def copy_lineage(lineage: Lineage) -> Lineage:
     return Lineage(
         lineage_id=lineage.lineage_id, rounds=lineage.rounds, next_seq=lineage.next_seq,
         classes=dict(lineage.classes), exemptions=list(lineage.exemptions), debt=lineage.debt,

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -415,7 +415,16 @@ def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> li
     """
     draft = _copy(lineage)
     minted: list[str] = []
+    seen_sources: set[str] = set()
     for t in register.transitions:
+        if t.class_id in seen_sources:
+            # Two state changes against one class in a register have no defined order, and
+            # two SUPERSEDE ... WITH-* records would mint two live replacements for one
+            # retired class — quietly breaking the net-zero guarantee at the cap.
+            raise RegisterError(
+                f"more than one transition against class {t.class_id} in a single register"
+            )
+        seen_sources.add(t.class_id)
         _apply_transition(draft, t, round_no=round_no, minted=minted)
     for nc in register.new_classes:
         if len(draft.active()) >= MAX_ACTIVE_CLASSES:
@@ -425,6 +434,11 @@ def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> li
             )
         minted.append(_add(draft, nc.invariant, nc.severity, round_no,
                            nc.pattern, nc.pathspec, nc.procedure))
+    if len(draft.active()) > MAX_ACTIVE_CLASSES:
+        raise RegisterError(
+            f"register would leave {len(draft.active())} non-superseded classes, over the "
+            f"{MAX_ACTIVE_CLASSES} cap"
+        )
     lineage.classes = draft.classes
     lineage.next_seq = draft.next_seq
     lineage.exemptions = draft.exemptions
@@ -456,6 +470,14 @@ def _apply_transition(lineage: Lineage, t: Transition, *, round_no: int, minted:
     cls = lineage.classes.get(t.class_id)
     if cls is None:
         raise RegisterError(f"{t.kind} names unknown class id {t.class_id!r}")
+    if cls.status == SUPERSEDED:
+        # A superseded class is inert and uncounted against the cap. Letting CLOSED/REOPEN
+        # move it back to an active status would resurrect it, and superseding it again
+        # would mint a second replacement for one retirement.
+        raise RegisterError(
+            f"{t.kind} names class {t.class_id}, which is already superseded by "
+            f"{cls.superseded_by}"
+        )
 
     if t.kind in ("CLOSED", "REOPEN"):
         if cls.mechanized:
@@ -509,16 +531,39 @@ class GrepResult:
 GitGrep = Callable[[str, str], GrepResult]
 
 
+@dataclass
+class Budget:
+    """The round's closure budget, measured in GREP time only.
+
+    Deliberately not a wall-clock deadline: one round's two sweeps straddle the reviewer
+    call, which routinely runs for minutes, so an absolute deadline opened before the
+    review would always be spent by the time the post-register sweep ran — and every
+    newly registered class would be `unchecked` instead of evaluated, defeating both
+    same-round evaluation and the same-round false-closure warning.
+
+    A class is only started while budget remains, and each class can then run its two
+    passes, so the real ceiling is `total + 2 * PER_CLASS_TIMEOUT`.
+    """
+
+    total: float = ROUND_BUDGET
+    spent: float = 0.0
+
+    def exhausted(self) -> bool:
+        return self.spent >= self.total
+
+    def charge(self, seconds: float) -> None:
+        self.spent += max(0.0, seconds)
+
+
 def sweep(lineage: Lineage, grep: GitGrep, *, only: Iterable[str] | None = None,
-          deadline: float | None = None, clock: Callable[[], float] | None = None) -> None:
+          budget: Budget | None = None, clock: Callable[[], float] | None = None) -> None:
     """Re-run every non-superseded mechanized predicate and update its status in place.
 
     `closed` classes are swept too: a later fix can reintroduce a defect, and a class
     that never reopens would let the trailer report nothing unclosed while it lives.
 
-    `deadline` is an ABSOLUTE instant on `clock`, not a per-call budget, so the pre-review
-    and post-register sweeps of one round share the round's budget instead of each getting
-    a fresh one — two fresh 60s budgets is a 120s round.
+    Pass the SAME `Budget` to both of a round's sweeps so they share it rather than each
+    getting a fresh one.
     """
     ids = list(only) if only is not None else list(lineage.classes)
     now = clock or (lambda: 0.0)
@@ -526,14 +571,17 @@ def sweep(lineage: Lineage, grep: GitGrep, *, only: Iterable[str] | None = None,
         cls = lineage.classes.get(cid)
         if cls is None or cls.status == SUPERSEDED or not cls.mechanized:
             continue
-        if deadline is not None and now() >= deadline:
+        if budget is not None and budget.exhausted():
             lineage.classes[cid] = replace(
                 cls, status=UNCHECKED, matches=(),
                 detail="round closure budget exhausted before this class ran",
             )
             continue
-        lineage.classes[cid] = _evaluate(cls, grep(cls.pattern or "", cls.pathspec or "."),
-                                         lineage.exemptions)
+        started = now()
+        result = grep(cls.pattern or "", cls.pathspec or ".")
+        if budget is not None:
+            budget.charge(now() - started)
+        lineage.classes[cid] = _evaluate(cls, result, lineage.exemptions)
 
 
 def _evaluate(cls: TrackedClass, result: GrepResult, exemptions: Sequence[Exemption]) -> TrackedClass:
@@ -557,14 +605,18 @@ def _evaluate(cls: TrackedClass, result: GrepResult, exemptions: Sequence[Exempt
         m for m in result.matches
         if (m["path"], m["line"], fingerprint(m["text"])) not in exempt
     ]
-    exempt_paths = {e.path for e in exemptions if e.class_id == cls.class_id}
-    displayed_paths = {m["path"] for m in result.matches}
-    surviving_paths = [p for p in result.paths if p not in exempt_paths]
     # A path the verdict pass found but the display pass could not read is a binary match:
     # it must still block, and must still be visible, with no line to quote.
+    #
+    # It can NEVER be exempted. An exemption's identity is (path, line, text-fingerprint),
+    # and none of those can be established for a match no pass could read — so falling back
+    # to path-only matching here would silently turn one exact exemption into a path-wide
+    # one the moment a file went binary or the display pass timed out, and close the class
+    # over a live violation.
+    displayed_paths = {m["path"] for m in result.matches}
     binary = [
         {"path": p, "line": 0, "text": "", "binary": True}
-        for p in surviving_paths if p not in displayed_paths
+        for p in result.paths if p not in displayed_paths
     ]
     survivors = tuple(shown + binary)
     if not survivors:

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -124,9 +124,13 @@ class Exemption:
 
 
 def fingerprint(text: str) -> str:
-    """Normalized-whitespace hash of a matched line. An exemption is void once the
-    line's text changes, which fails toward blocking rather than toward clearance."""
-    return hashlib.sha256(" ".join(text.split()).encode("utf-8", "surrogateescape")).hexdigest()[:16]
+    """Exact-bytes hash of a matched line. An exemption is void the moment the line's text
+    changes at all, which fails toward blocking rather than toward clearance.
+
+    Deliberately NOT whitespace-normalized: in indentation-sensitive code a line that keeps
+    its tokens but changes its indentation has moved scope, and a stale exemption would let
+    the class close over a live violation."""
+    return hashlib.sha256(text.encode("utf-8", "surrogateescape")).hexdigest()[:16]
 
 
 # ── register parsing ──────────────────────────────────────────────────────────
@@ -401,20 +405,37 @@ def mint_id(lineage_id: str, seq: int, invariant: str) -> str:
 
 
 def apply_register(lineage: Lineage, register: Register, *, round_no: int) -> list[str]:
-    """Fold a parsed register into the lineage. Returns the ids of newly minted classes,
-    which the caller must then evaluate before computing a verdict (plan §2.6)."""
+    """Fold a parsed register into the lineage ATOMICALLY, returning the ids of newly minted
+    classes for the caller to evaluate before computing a verdict (plan §2.6).
+
+    A register is all-or-nothing. Applied record-by-record to the live lineage, a valid
+    `CLOSED: A` followed by an invalid record would leave A closed even though the register
+    was rejected — and once the debt was discharged the trailer could report `NOT-BLOCKED`
+    on the strength of a transition from a register that never parsed.
+    """
+    draft = _copy(lineage)
     minted: list[str] = []
     for t in register.transitions:
-        _apply_transition(lineage, t, round_no=round_no, minted=minted)
+        _apply_transition(draft, t, round_no=round_no, minted=minted)
     for nc in register.new_classes:
-        if len(lineage.active()) >= MAX_ACTIVE_CLASSES:
+        if len(draft.active()) >= MAX_ACTIVE_CLASSES:
             raise RegisterError(
                 f"registration refused: {MAX_ACTIVE_CLASSES} non-superseded classes already "
                 "tracked. Close or supersede one first."
             )
-        minted.append(_add(lineage, nc.invariant, nc.severity, round_no,
+        minted.append(_add(draft, nc.invariant, nc.severity, round_no,
                            nc.pattern, nc.pathspec, nc.procedure))
+    lineage.classes = draft.classes
+    lineage.next_seq = draft.next_seq
+    lineage.exemptions = draft.exemptions
     return minted
+
+
+def _copy(lineage: Lineage) -> Lineage:
+    return Lineage(
+        lineage_id=lineage.lineage_id, rounds=lineage.rounds, next_seq=lineage.next_seq,
+        classes=dict(lineage.classes), exemptions=list(lineage.exemptions), debt=lineage.debt,
+    )
 
 
 def _add(lineage: Lineage, invariant: str, severity: str, round_no: int,
@@ -489,22 +510,26 @@ GitGrep = Callable[[str, str], GrepResult]
 
 
 def sweep(lineage: Lineage, grep: GitGrep, *, only: Iterable[str] | None = None,
-          budget: float = ROUND_BUDGET, clock: Callable[[], float] | None = None) -> None:
+          deadline: float | None = None, clock: Callable[[], float] | None = None) -> None:
     """Re-run every non-superseded mechanized predicate and update its status in place.
 
     `closed` classes are swept too: a later fix can reintroduce a defect, and a class
     that never reopens would let the trailer report nothing unclosed while it lives.
+
+    `deadline` is an ABSOLUTE instant on `clock`, not a per-call budget, so the pre-review
+    and post-register sweeps of one round share the round's budget instead of each getting
+    a fresh one — two fresh 60s budgets is a 120s round.
     """
     ids = list(only) if only is not None else list(lineage.classes)
     now = clock or (lambda: 0.0)
-    started = now()
     for cid in ids:
         cls = lineage.classes.get(cid)
         if cls is None or cls.status == SUPERSEDED or not cls.mechanized:
             continue
-        if budget is not None and now() - started >= budget:
+        if deadline is not None and now() >= deadline:
             lineage.classes[cid] = replace(
-                cls, status=UNCHECKED, detail="round closure budget exhausted before this class ran"
+                cls, status=UNCHECKED, matches=(),
+                detail="round closure budget exhausted before this class ran",
             )
             continue
         lineage.classes[cid] = _evaluate(cls, grep(cls.pattern or "", cls.pathspec or "."),
@@ -516,11 +541,15 @@ def _evaluate(cls: TrackedClass, result: GrepResult, exemptions: Sequence[Exempt
         # A predicate that cannot run has not proved closure — but for an advisory class
         # that is no reason to stop the loop, so blocking still follows severity.
         return replace(cls, status=MALFORMED, detail=result.error, matches=())
-    if len(result.paths) > MAX_MATCHES:
+    # `-l` returns FILES, so counting it alone lets one file with thousands of violating
+    # lines pass as an ordinary open class and then be silently truncated in the block.
+    total = max(len(result.paths), len(result.matches))
+    if total > MAX_MATCHES:
+        unit = "matching lines" if len(result.matches) >= len(result.paths) else "matching files"
         return replace(
             cls, status=OVER_BROAD, matches=(),
-            detail=f"{len(result.paths)} matching paths exceeds the {MAX_MATCHES} cap — narrow "
-                   "the predicate with SUPERSEDE ... WITH-PATTERN",
+            detail=f"{total} {unit} exceeds the {MAX_MATCHES} cap — narrow the predicate "
+                   "with SUPERSEDE ... WITH-PATTERN",
         )
 
     exempt = {(e.path, e.line, e.fingerprint) for e in exemptions if e.class_id == cls.class_id}
@@ -596,19 +625,31 @@ def _strip_commit(paths: Sequence[str], commit: str) -> tuple[str, ...]:
 
 
 def _parse_matches(out: str) -> tuple[dict[str, Any], ...]:
-    """`-z -n` emits `<commit>:<path>\0<line>\0<text>\n` — paths are NUL-terminated, so a
-    path containing a newline or non-UTF-8 bytes still parses unambiguously."""
+    """`-z -n` emits `<commit>:<path>\0<line>\0<text>\n`.
+
+    Scanned NUL-first, never split on newlines first: git prints pathnames verbatim and
+    terminates them with NUL precisely so a path MAY contain a newline. Splitting on `\n`
+    would tear such a record in two and mint a wrong path — and therefore a wrong exemption
+    identity. The matched text itself is a single line, so its terminating `\n` is the only
+    newline that ends a record.
+    """
     found: list[dict[str, Any]] = []
-    for record in out.split("\n"):
-        if not record:
-            continue
-        parts = record.split("\0")
-        if len(parts) < 3:
-            continue
-        path, line, text = parts[0], parts[1], "\0".join(parts[2:])
+    pos = 0
+    while pos < len(out):
+        nul1 = out.find("\0", pos)
+        if nul1 < 0:
+            break
+        nul2 = out.find("\0", nul1 + 1)
+        if nul2 < 0:
+            break
+        path, raw_line = out[pos:nul1], out[nul1 + 1:nul2]
+        end = out.find("\n", nul2 + 1)
+        end = len(out) if end < 0 else end
+        text = out[nul2 + 1:end]
+        pos = end + 1
         path = path.split(":", 1)[1] if ":" in path else path
         try:
-            found.append({"path": path, "line": int(line), "text": text})
+            found.append({"path": path, "line": int(raw_line), "text": text})
         except ValueError:
             continue
     return tuple(found)
@@ -644,6 +685,9 @@ def render_unclosed(lineage: Lineage) -> str | None:
                 out.append(f"  {display(m['path'])}: binary match (line not shown)")
             else:
                 out.append(f"  {display(m['path'])}:{m['line']}: {display(m['text'])}")
+        if len(c.matches) > MAX_MATCHES:
+            # Never truncate silently: an operator reads this block as the match list.
+            out.append(f"  … {len(c.matches) - MAX_MATCHES} further match(es) not shown")
     return "\n".join(out)
 
 
@@ -694,6 +738,22 @@ def render_trailer(lineage: Lineage, *, register_status: str,
         f"CLASS-REGISTER: {register_status}",
         f"CLASS-CLOSURE: {counts}",
     ]
+    # A predicate can be wrong in the SAFE direction — too narrow, matching none of the
+    # violations it was written for, and closing in the very round it was registered. The
+    # mechanism cannot detect that, so it says so rather than presenting an ordinary close.
+    born_closed = [
+        lineage.classes[c] for c in minted
+        if c in lineage.classes and lineage.classes[c].status == CLOSED
+        and lineage.classes[c].mechanized
+    ]
+    if born_closed:
+        lines.append(
+            "CLASS-CLOSURE-WARNING: " + "; ".join(
+                f"{c.class_id} closed in the round it was registered — verify its predicate "
+                f"actually matches the violation it describes ({display(c.invariant)})"
+                for c in born_closed
+            )
+        )
     if lineage.debt:
         lines.append(
             f"CONVERGENCE: BLOCKED — register debt from round {lineage.debt.get('round')}: "

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -776,11 +776,27 @@ def render_unmechanized(lineage: Lineage) -> str | None:
 
 
 def render_exempt(lineage: Lineage) -> str | None:
+    """Each exemption is shown WITH its class's invariant and predicate.
+
+    A bare `class 3f2a91c4: a.py:17` is unchallengeable: once an exemption removes a
+    class's last survivor the class closes, so its unclosed block disappears too, and the
+    cold reviewer is left with a path and a line number and no idea what they are supposed
+    to be violating. The challenge this block exists for needs the claim attached.
+    """
     if not lineage.exemptions:
         return None
-    out = [EXEMPT_HEADER]
+    out = [EXEMPT_HEADER,
+           "Each line below was declared a FALSE POSITIVE of its class's predicate. Read "
+           "the line and say so if it is in fact a genuine violation.", ""]
     for e in lineage.exemptions:
-        out.append(f"- class {e.class_id}: {display(e.path)}:{e.line}")
+        cls = lineage.classes.get(e.class_id)
+        out.append(f"- {display(e.path)}:{e.line} — exempted from class {e.class_id}")
+        if cls is not None:
+            out.append(f"    invariant: {display(cls.invariant)}")
+            what = (f"pattern /{display(cls.pattern or '')}/ over {display(cls.pathspec or '.')}"
+                    if cls.mechanized else f"procedure: {display(cls.procedure or '')}")
+            out.append(f"    {what}")
+            out.append(f"    class status: {cls.status}")
     return "\n".join(out)
 
 

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -296,6 +296,20 @@ class StateUnavailable(RuntimeError):
     a storage fault must not become a false all-clear (plan §2.7)."""
 
 
+#: Where lineage state lives. Deliberately NOT derived from `log_dir`: `--log-dir` is
+#: documented as the audit-log directory, so a caller who moves their logs would silently
+#: get an empty state root and could be told NOT-BLOCKED with classes still open.
+DEFAULT_STATE_ROOT = Path.home() / ".paranoia"
+STATE_ROOT_ENV = "PARANOIA_STATE_ROOT"
+
+
+def default_state_root() -> Path:
+    """The env override exists so the test suite can isolate itself without every caller
+    threading a path — nothing may write lineages into the operator's real home."""
+    override = os.environ.get(STATE_ROOT_ENV)
+    return Path(override) if override else DEFAULT_STATE_ROOT
+
+
 def lineage_dir(root: Path) -> Path:
     return Path(root) / "lineages"
 

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -659,8 +659,12 @@ def make_grep(repo: Path, commit: str, *,
             return GrepResult(error=f"predicate timed out after {PER_CLASS_TIMEOUT}s")
         if code == 1:
             return GrepResult()               # no matches: closure, not failure
-        if code >= 2:
-            return GrepResult(error=_git_error(err))
+        if code != 0:
+            # Everything except 0 and 1 is a failure — INCLUDING negative codes, which is
+            # how Python reports a signal-terminated subprocess. A `-9` with empty output
+            # would otherwise read as "no matches" and falsely close the class: a predicate
+            # that never completed has not proved anything.
+            return GrepResult(error=_git_error(err) or f"git grep terminated with code {code}")
         paths = tuple(p for p in _decode(out).split("\0") if p)
 
         # Display pass. Its failure is not a verdict failure — the verdict already stands.
@@ -682,7 +686,7 @@ def _decode(raw: bytes) -> str:
 
 def _git_error(err: bytes) -> str:
     first = _decode(err).strip().splitlines()
-    return first[0] if first else "git grep failed"
+    return first[0] if first else ""
 
 
 def _strip_commit(paths: Sequence[str], commit: str) -> tuple[str, ...]:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -237,12 +237,10 @@ def _converge_branch_review(
         base_id = orientation.resolve_ref(repo, base_ref)
         head_id = orientation.resolve_ref(repo, head_ref or "HEAD")
 
-    # State root is derived from log_dir (~/.paranoia/logs -> ~/.paranoia) so an injected
-    # log_dir also isolates lineage state: tests must not write into the operator's home.
     closure = _ClassClosure(
         repo, head_id, args=closure_args or {}, round_no=review_round or 1,
         is_dirty=target.is_dirty, base_ref=base_ref, head_ref=head_ref,
-        state_root=state_root or Path(log_dir).parent, stamp=now(),
+        state_root=state_root or cc.default_state_root(), stamp=now(),
     ) if closure_on else None
     blocks = closure.prepare() if closure else []
 
@@ -282,8 +280,16 @@ def _converge_branch_review(
           # Recorded so a future incident IS replayable: the plan's own acceptance
           # replay was impossible because these were never written down.
           "base_id": base_id, "head_id": head_id,
-          "lineage": closure.lineage_id if closure else None})
+          "lineage": closure.lineage_id if closure else None,
+          # The retry's register is what actually changed durable state, so it belongs in
+          # the audit record; the original review only carries the malformed attempt.
+          "retry_register": closure.retry_register if closure else None})
     body = _footer(review, engine)
+    if closure and closure.retry_register:
+        # Same reason, for the operator: a CLOSED or a corrected predicate that the retry
+        # supplied would otherwise be invisible in everything they can see.
+        body += ("\n\n---\n_The register below was supplied on retry and is what this "
+                 f"round applied:_\n\n{closure.retry_register.strip()}")
     return f"{body}\n\n{trailer}" if trailer else body
 
 
@@ -464,6 +470,7 @@ class _ClassClosure:
         self.lineage: cc.Lineage | None = None
         self.unavailable: str | None = None
         self.budget = cc.Budget()
+        self.retry_register: str | None = None
         self._latched = False
         self._settled = False
 
@@ -559,6 +566,7 @@ class _ClassClosure:
             retry = engine.resume(
                 review.session_ref, prompts.REGISTER_RETRY, repo, model, effort, web_search,
                 **_progress_kwargs(on_progress))
+            self.retry_register = retry.text
             if retry.error:
                 # A failed CLI still returns text, and that text can contain a parseable
                 # NONE or CLOSED block. Trusting it would let a broken retry mutate durable

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -513,11 +513,10 @@ class _ClassClosure:
             return (f"CLASS-CLOSURE: not evaluated — the review failed "
                     f"(exit {review.returncode}); lineage state is unchanged.\n"
                     "CONVERGENCE: BLOCKED — no verdict can be computed from a failed review.")
-        status, minted = "parsed 0", []
+        status, minted = cc.NONE, []
         try:
-            register, status = self._register(review, engine, repo, model, effort,
-                                              web_search, on_progress)
-            minted = cc.apply_register(lineage, register, round_no=self.round_no)
+            minted, status = self._register(review, engine, repo, model, effort,
+                                            web_search, on_progress)
             # Round 10: a class registered by THIS review does not exist until now, so it
             # must be evaluated before the verdict — otherwise a new MAJOR class and
             # NOT-BLOCKED could ship in the same response.
@@ -564,10 +563,18 @@ class _ClassClosure:
         return cc.make_grep(self.repo, self.head_id, runner=_run_git)
 
     def _register(self, review: Review, engine: Engine, repo: Path, model: str, effort: str,
-                  web_search: bool, on_progress: Callable[[str], None] | None):
+                  web_search: bool, on_progress: Callable[[str], None] | None
+                  ) -> tuple[list[str], str]:
+        """Parse AND apply the register as one transaction, retried once as a whole.
+
+        Splitting them meant only *syntactic* failures earned the retry: an unknown class
+        id, a superseded source, two transitions against one class or a cap violation all
+        went straight to durable debt, costing the operator a whole extra review round for
+        what is usually a reviewer typo — the principal cost this feature has under these
+        stakes.
+        """
         try:
-            register = cc.parse_register(review.text)
-            return register, _count(register)
+            return self._attempt(review.text)
         except cc.RegisterError as first:
             if not review.session_ref or not hasattr(engine, "resume"):
                 # Claude's supported non-JSON fallback has no session to resume, and an
@@ -576,8 +583,8 @@ class _ClassClosure:
                 # an error — the one outcome this path must never produce.
                 raise first
             retry = engine.resume(
-                review.session_ref, prompts.REGISTER_RETRY, repo, model, effort, web_search,
-                **_progress_kwargs(on_progress))
+                review.session_ref, prompts.register_retry(str(first)), repo, model, effort,
+                web_search, **_progress_kwargs(on_progress))
             self._retry_candidate = retry.text
             if retry.error:
                 # A failed CLI still returns text, and that text can contain a parseable
@@ -586,8 +593,19 @@ class _ClassClosure:
                 raise cc.RegisterError(
                     f"the register retry itself failed (exit {retry.returncode})"
                 ) from first
-            register = cc.parse_register(retry.text)   # a second failure raises, and blocks
-            return register, f"parsed after retry: {_count(register)}"
+            minted, count = self._attempt(retry.text)   # a second failure raises, and blocks
+            return minted, f"parsed after retry: {count}"
+
+    def _attempt(self, text: str) -> tuple[list[str], str]:
+        """Apply `text`'s register to a draft, and adopt it only if the whole thing holds."""
+        assert self.lineage is not None
+        register = cc.parse_register(text)
+        draft = cc.copy_lineage(self.lineage)
+        minted = cc.apply_register(draft, register, round_no=self.round_no)
+        self.lineage.classes = draft.classes
+        self.lineage.next_seq = draft.next_seq
+        self.lineage.exemptions = draft.exemptions
+        return minted, _count(register)
 
     def _apply_exemption_args(self) -> None:
         assert self.lineage is not None

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -10,15 +10,21 @@ footer exposing the session reference for `rebut`.
 
 from __future__ import annotations
 
+import hashlib
+import subprocess
 import tempfile
+import time
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
+from . import class_closure as cc
 from . import logs, orientation, prompts
 from .config import load_repo_config, resolve
 from .engines import Engine, Review
 from .worktree import worktree_at
+
+CLASS_STATE_ROOT = logs.DEFAULT_LOG_DIR.parent  # ~/.paranoia
 
 Clock = Callable[[], str]
 
@@ -145,6 +151,7 @@ def critique_branch(
     calibration = _calibration(
         resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
     )
+    closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
 
     target = orientation.resolve_target(repo, base_ref, head_ref, include_unc)
 
@@ -155,6 +162,8 @@ def critique_branch(
             already=already, model=model, effort=effort, web_search=web_search,
             max_packet_chars=max_packet_chars, calibration=calibration,
             log_dir=log_dir, now=now, on_progress=on_progress,
+            closure_on=closure_on, closure_args=arguments,
+            review_round=arguments.get("round"), include_unc=include_unc,
         )
 
     packet = orientation.build_orientation(
@@ -194,6 +203,11 @@ def _converge_branch_review(
     log_dir: Path,
     now: Clock,
     on_progress: Callable[[str], None] | None,
+    closure_on: bool = False,
+    closure_args: dict[str, Any] | None = None,
+    review_round: int | None = None,
+    include_unc: bool = False,
+    state_root: Path | None = None,
 ) -> str:
     """Opt-in convergence path: pre-gather a deterministic packet so the reviewer skips
     the re-read/re-grep turns, and review it against an IMMUTABLE materialized worktree
@@ -212,21 +226,40 @@ def _converge_branch_review(
         base_id = orientation.resolve_ref(repo, base_ref)
         head_id = orientation.resolve_ref(repo, head_ref or "HEAD")
 
+    closure = _ClassClosure(
+        repo, head_id, args=closure_args or {}, round_no=review_round or 1,
+        is_dirty=target.is_dirty, base_ref=base_ref, head_ref=head_ref,
+        state_root=state_root or CLASS_STATE_ROOT, stamp=now(),
+    ) if closure_on else None
+    blocks = closure.prepare() if closure else []
+
     packet = orientation.build_packet(
         repo, base_id, head_id,
         project_summary=project_summary, diff_intent=diff_intent, focus=focus,
-        already_raised=already, max_chars=max_packet_chars,
+        already_raised=already, class_blocks=blocks, max_chars=max_packet_chars,
     )
-    prompt = prompts.compose(prompts.CODE_REVIEW_INSTRUCTIONS_PACKET, _prepend(calibration, packet))
+    instructions = prompts.CODE_REVIEW_INSTRUCTIONS_PACKET
+    if closure:
+        instructions += "\n\n" + prompts.CLASS_REGISTER_INSTRUCTIONS
+    prompt = prompts.compose(instructions, _prepend(calibration, packet))
 
     with worktree_at(repo, head_id) as wt:
         review = engine.run(prompt, wt, model, effort, web_search,
                             **_progress_kwargs(on_progress))
+        # Settle inside the worktree: a register retry resumes the same session and must
+        # see the same materialized snapshot the review did.
+        trailer = closure.settle(review, engine, wt, model, effort, web_search,
+                                 on_progress) if closure else None
 
     _log(log_dir, "critique_branch", engine, review, now,
          {"target": target.description, "model": model, "mode": "converge-packet",
-          "usage": review.usage, "duration_ms": review.duration_ms})
-    return _footer(review, engine)
+          "usage": review.usage, "duration_ms": review.duration_ms,
+          # Recorded so a future incident IS replayable: the plan's own acceptance
+          # replay was impossible because these were never written down.
+          "base_id": base_id, "head_id": head_id,
+          "lineage": closure.lineage_id if closure else None})
+    body = _footer(review, engine)
+    return f"{body}\n\n{trailer}" if trailer else body
 
 
 def _plan_body(
@@ -383,3 +416,140 @@ def rebut(
 
     _log(log_dir, "rebut", engine, review, now, {"session_ref": session_ref, "model": model})
     return _footer(review, engine)
+
+
+class _ClassClosure:
+    """Orchestration for one round of class closure: the impure half of `class_closure`.
+
+    Split from the pure core so the protocol stays testable without a repository, and
+    kept in one object so the round's two halves — the blocks handed to the reviewer,
+    and the verdict computed from its register — cannot drift apart.
+
+    Every failure path here BLOCKS and returns the review text. A paid review is never
+    discarded over a formatting miss, and a storage fault is never allowed to read as
+    an all-clear.
+    """
+
+    def __init__(self, repo: Path, head_id: str, *, args: dict[str, Any], round_no: int,
+                 is_dirty: bool, base_ref: str, head_ref: str | None,
+                 state_root: Path, stamp: str) -> None:
+        self.repo, self.head_id, self.round_no = repo, head_id, round_no
+        self.args, self.state_root, self.stamp = args, Path(state_root), stamp
+        self.lineage_id = _lineage_id(repo, base_ref, head_ref, is_dirty, args.get("lineage"))
+        self.lineage: cc.Lineage | None = None
+        self.unavailable: str | None = None
+
+    def prepare(self) -> list[str]:
+        """Load state, sweep what the lineage already holds, and render the reviewer blocks."""
+        try:
+            self.lineage = cc.load_lineage(self.state_root, self.lineage_id, stamp=self.stamp)
+        except cc.StateUnavailable as exc:
+            self.unavailable = str(exc)
+            return []
+        cc.open_latch(self.state_root, self.lineage_id)
+        self._apply_exemption_args()
+        cc.sweep(self.lineage, self._grep(), clock=time.monotonic)
+        return [b for b in (cc.render_unclosed(self.lineage),
+                            cc.render_unmechanized(self.lineage),
+                            cc.render_exempt(self.lineage)) if b]
+
+    def settle(self, review: Review, engine: Engine, repo: Path, model: str, effort: str,
+               web_search: bool, on_progress: Callable[[str], None] | None) -> str:
+        if self.unavailable or self.lineage is None:
+            return (f"CLASS-CLOSURE: STATE-UNAVAILABLE — {self.unavailable}\n"
+                    "CONVERGENCE: BLOCKED — lineage state could not be used this round.")
+        lineage = self.lineage
+        status, minted = "parsed 0", []
+        try:
+            register, status = self._register(review, engine, repo, model, effort,
+                                              web_search, on_progress)
+            minted = cc.apply_register(lineage, register, round_no=self.round_no)
+            # Round 10: a class registered by THIS review does not exist until now, so it
+            # must be evaluated before the verdict — otherwise a new MAJOR class and
+            # NOT-BLOCKED could ship in the same response.
+            cc.sweep(lineage, self._grep(), only=minted, clock=time.monotonic)
+            lineage.debt = None
+        except cc.RegisterError as exc:
+            lineage.debt = {"round": self.round_no, "reason": str(exc)}
+            status = f"malformed: {exc}"
+
+        lineage.rounds += 1
+        try:
+            cc.save_lineage(self.state_root, lineage)
+        except cc.StateUnavailable as exc:
+            # The latch stays: the next round blocks rather than starting empty.
+            return (f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
+                    "CONVERGENCE: BLOCKED — this round's classes were not persisted.")
+        cc.clear_latch(self.state_root, self.lineage_id)
+        return cc.render_trailer(lineage, register_status=status, minted=minted)
+
+    # ── internals ──
+
+    def _grep(self) -> cc.GitGrep:
+        return cc.make_grep(self.repo, self.head_id, runner=_run_git)
+
+    def _register(self, review: Review, engine: Engine, repo: Path, model: str, effort: str,
+                  web_search: bool, on_progress: Callable[[str], None] | None):
+        try:
+            return cc.parse_register(review.text), None or "parsed"
+        except cc.RegisterError as first:
+            if not review.session_ref or not hasattr(engine, "resume"):
+                # Claude's supported non-JSON fallback has no session to resume, and an
+                # injected engine may predate `resume` (the reason `_progress_kwargs`
+                # exists). Retrying either would raise and replace the paid review with
+                # an error — the one outcome this path must never produce.
+                raise first
+            retry = engine.resume(
+                review.session_ref, prompts.REGISTER_RETRY, repo, model, effort, web_search,
+                **_progress_kwargs(on_progress))
+            register = cc.parse_register(retry.text)   # a second failure raises, and blocks
+            return register, "parsed after retry"
+
+    def _apply_exemption_args(self) -> None:
+        assert self.lineage is not None
+        for e in self.args.get("exempt", []) or []:
+            self.lineage.exemptions.append(cc.Exemption(
+                class_id=e["class_id"], path=e["path"], line=int(e["line"]),
+                fingerprint=cc.fingerprint(e.get("line_text", "")),
+            ))
+        drop = {(e["class_id"], e["path"], int(e["line"]))
+                for e in (self.args.get("unexempt", []) or [])}
+        if drop:
+            self.lineage.exemptions = [
+                e for e in self.lineage.exemptions
+                if (e.class_id, e.path, e.line) not in drop
+            ]
+
+
+def _lineage_id(repo: Path, base_ref: str, head_ref: str | None, is_dirty: bool,
+                explicit: str | None) -> str:
+    if explicit:
+        return explicit
+    if is_dirty or not head_ref or head_ref == "HEAD":
+        # `symbolic-ref` reads the ref HEAD POINTS AT rather than resolving it to an
+        # object, so it works before the first commit — `rev-parse` exits 128 there and
+        # would break the supported unborn-repository first review.
+        name = _git_line(["git", "symbolic-ref", "-q", "HEAD"], repo)
+    else:
+        name = _git_line(["git", "rev-parse", "--symbolic-full-name", head_ref], repo)
+    if not name:
+        raise ValueError(
+            "class closure cannot derive a lineage: the reviewed ref is not a branch "
+            "(a detached HEAD or a raw commit). Pass `lineage` explicitly, or "
+            "`class_closure: false`."
+        )
+    key = "\0".join([str(repo.resolve()), base_ref, name])
+    return hashlib.sha256(key.encode()).hexdigest()[:12]
+
+
+def _git_line(argv: list[str], repo: Path) -> str:
+    proc = subprocess.run(argv, cwd=repo, capture_output=True, text=True)
+    return proc.stdout.strip() if proc.returncode == 0 else ""
+
+
+def _run_git(argv: list[str], cwd: Path, timeout: int) -> tuple[int, bytes, bytes]:
+    try:
+        proc = subprocess.run(argv, cwd=cwd, capture_output=True, timeout=timeout)
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError(str(exc)) from exc
+    return proc.returncode, proc.stdout, proc.stderr

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -24,7 +24,7 @@ from .config import load_repo_config, resolve
 from .engines import Engine, Review
 from .worktree import worktree_at
 
-CLASS_STATE_ROOT = logs.DEFAULT_LOG_DIR.parent  # ~/.paranoia
+
 
 Clock = Callable[[], str]
 
@@ -152,6 +152,14 @@ def critique_branch(
         resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
     )
     closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
+    if closure_on and include_unc and arguments.get("head_ref") not in (None, "HEAD"):
+        # resolve_target discards head_ref for a dirty review and snapshots the checkout, so
+        # accepting it would key this round's classes to a branch that was never reviewed.
+        raise ValueError(
+            "include_uncommitted reviews the current checkout, so head_ref="
+            f"{arguments['head_ref']!r} would not be the reviewed ref. Drop head_ref, or pass "
+            "an explicit `lineage`, or `class_closure: false`."
+        )
 
     target = orientation.resolve_target(repo, base_ref, head_ref, include_unc)
 
@@ -226,10 +234,12 @@ def _converge_branch_review(
         base_id = orientation.resolve_ref(repo, base_ref)
         head_id = orientation.resolve_ref(repo, head_ref or "HEAD")
 
+    # State root is derived from log_dir (~/.paranoia/logs -> ~/.paranoia) so an injected
+    # log_dir also isolates lineage state: tests must not write into the operator's home.
     closure = _ClassClosure(
         repo, head_id, args=closure_args or {}, round_no=review_round or 1,
         is_dirty=target.is_dirty, base_ref=base_ref, head_ref=head_ref,
-        state_root=state_root or CLASS_STATE_ROOT, stamp=now(),
+        state_root=state_root or Path(log_dir).parent, stamp=now(),
     ) if closure_on else None
     blocks = closure.prepare() if closure else []
 
@@ -248,8 +258,14 @@ def _converge_branch_review(
                             **_progress_kwargs(on_progress))
         # Settle inside the worktree: a register retry resumes the same session and must
         # see the same materialized snapshot the review did.
-        trailer = closure.settle(review, engine, wt, model, effort, web_search,
-                                 on_progress) if closure else None
+        try:
+            trailer = closure.settle(review, engine, wt, model, effort, web_search,
+                                     on_progress) if closure else None
+        finally:
+            # Whatever happened, the round must not strand its own pending latch and block
+            # every future round on a fault that has already been reported.
+            if closure:
+                closure.release()
 
     _log(log_dir, "critique_branch", engine, review, now,
          {"target": target.description, "model": model, "mode": "converge-packet",
@@ -438,6 +454,9 @@ class _ClassClosure:
         self.lineage_id = _lineage_id(repo, base_ref, head_ref, is_dirty, args.get("lineage"))
         self.lineage: cc.Lineage | None = None
         self.unavailable: str | None = None
+        self.deadline: float | None = None
+        self._latched = False
+        self._settled = False
 
     def prepare(self) -> list[str]:
         """Load state, sweep what the lineage already holds, and render the reviewer blocks."""
@@ -447,8 +466,10 @@ class _ClassClosure:
             self.unavailable = str(exc)
             return []
         cc.open_latch(self.state_root, self.lineage_id)
+        self._latched = True
+        self.deadline = time.monotonic() + cc.ROUND_BUDGET
         self._apply_exemption_args()
-        cc.sweep(self.lineage, self._grep(), clock=time.monotonic)
+        cc.sweep(self.lineage, self._grep(), deadline=self.deadline, clock=time.monotonic)
         return [b for b in (cc.render_unclosed(self.lineage),
                             cc.render_unmechanized(self.lineage),
                             cc.render_exempt(self.lineage)) if b]
@@ -459,6 +480,14 @@ class _ClassClosure:
             return (f"CLASS-CLOSURE: STATE-UNAVAILABLE — {self.unavailable}\n"
                     "CONVERGENCE: BLOCKED — lineage state could not be used this round.")
         lineage = self.lineage
+        if review.error:
+            # A CLI failure or timeout is not a review. Recording debt or applying whatever
+            # text came back would let a broken run mutate durable state — and the plan
+            # requires a failed engine call to leave the lineage byte-identical.
+            self._settled = True
+            return (f"CLASS-CLOSURE: not evaluated — the review failed "
+                    f"(exit {review.returncode}); lineage state is unchanged.\n"
+                    "CONVERGENCE: BLOCKED — no verdict can be computed from a failed review.")
         status, minted = "parsed 0", []
         try:
             register, status = self._register(review, engine, repo, model, effort,
@@ -467,7 +496,8 @@ class _ClassClosure:
             # Round 10: a class registered by THIS review does not exist until now, so it
             # must be evaluated before the verdict — otherwise a new MAJOR class and
             # NOT-BLOCKED could ship in the same response.
-            cc.sweep(lineage, self._grep(), only=minted, clock=time.monotonic)
+            cc.sweep(lineage, self._grep(), only=minted, deadline=self.deadline,
+                     clock=time.monotonic)
             lineage.debt = None
         except cc.RegisterError as exc:
             lineage.debt = {"round": self.round_no, "reason": str(exc)}
@@ -477,11 +507,23 @@ class _ClassClosure:
         try:
             cc.save_lineage(self.state_root, lineage)
         except cc.StateUnavailable as exc:
-            # The latch stays: the next round blocks rather than starting empty.
+            # The latch deliberately STAYS: a write that may have half-happened must block
+            # the next round rather than let it start from an empty lineage.
             return (f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
                     "CONVERGENCE: BLOCKED — this round's classes were not persisted.")
-        cc.clear_latch(self.state_root, self.lineage_id)
+        self._settled = True
         return cc.render_trailer(lineage, register_status=status, minted=minted)
+
+    def release(self) -> None:
+        """Clear the pending latch once the round is over WITHOUT an unresolved write.
+
+        Called from a `finally`, so a crash between `prepare()` and `settle()` cannot strand
+        the latch and block every later round on a fault that already surfaced. A failed
+        *write* does not release: that is the one case the latch exists for.
+        """
+        if self._latched and self._settled:
+            cc.clear_latch(self.state_root, self.lineage_id)
+            self._latched = False
 
     # ── internals ──
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -486,7 +486,12 @@ class _ClassClosure:
         except cc.StateUnavailable as exc:
             self.unavailable = str(exc)
             return []
-        cc.open_latch(self.state_root, self.lineage_id)
+        try:
+            cc.open_latch(self.state_root, self.lineage_id)
+        except cc.StateUnavailable as exc:
+            # The review still runs and is still returned; it simply cannot be settled.
+            self.unavailable = str(exc)
+            return []
         self._latched = True
         self._apply_exemption_args()
         cc.sweep(self.lineage, self._grep(), budget=self.budget, clock=time.monotonic)

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -152,13 +152,16 @@ def critique_branch(
         resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
     )
     closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
-    if closure_on and include_unc and arguments.get("head_ref") not in (None, "HEAD"):
+    if (closure_on and include_unc and arguments.get("head_ref") not in (None, "HEAD")
+            and not arguments.get("lineage")):
         # resolve_target discards head_ref for a dirty review and snapshots the checkout, so
         # accepting it would key this round's classes to a branch that was never reviewed.
+        # An explicit `lineage` says the caller has chosen the key deliberately, so it is
+        # honoured rather than rejected — an error whose remedy it also refuses is no remedy.
         raise ValueError(
             "include_uncommitted reviews the current checkout, so head_ref="
             f"{arguments['head_ref']!r} would not be the reviewed ref. Drop head_ref, or pass "
-            "an explicit `lineage`, or `class_closure: false`."
+            "an explicit `lineage` to choose the key yourself, or `class_closure: false`."
         )
 
     target = orientation.resolve_target(repo, base_ref, head_ref, include_unc)
@@ -243,29 +246,35 @@ def _converge_branch_review(
     ) if closure_on else None
     blocks = closure.prepare() if closure else []
 
-    packet = orientation.build_packet(
-        repo, base_id, head_id,
-        project_summary=project_summary, diff_intent=diff_intent, focus=focus,
-        already_raised=already, class_blocks=blocks, max_chars=max_packet_chars,
-    )
-    instructions = prompts.CODE_REVIEW_INSTRUCTIONS_PACKET
-    if closure:
-        instructions += "\n\n" + prompts.CLASS_REGISTER_INSTRUCTIONS
-    prompt = prompts.compose(instructions, _prepend(calibration, packet))
+    # EVERYTHING after prepare() is inside the latch's cleanup: packet building, worktree
+    # entry and the engine call can all raise, and a latch stranded there would make every
+    # later round STATE-UNAVAILABLE over a fault that already surfaced to the caller. A
+    # failed *write* is the one case that deliberately keeps the latch (see `release`).
+    try:
+        packet = orientation.build_packet(
+            repo, base_id, head_id,
+            project_summary=project_summary, diff_intent=diff_intent, focus=focus,
+            already_raised=already, class_blocks=blocks, max_chars=max_packet_chars,
+        )
+        instructions = prompts.CODE_REVIEW_INSTRUCTIONS_PACKET
+        if closure:
+            instructions += "\n\n" + prompts.CLASS_REGISTER_INSTRUCTIONS
+        prompt = prompts.compose(instructions, _prepend(calibration, packet))
 
-    with worktree_at(repo, head_id) as wt:
-        review = engine.run(prompt, wt, model, effort, web_search,
-                            **_progress_kwargs(on_progress))
-        # Settle inside the worktree: a register retry resumes the same session and must
-        # see the same materialized snapshot the review did.
-        try:
+        with worktree_at(repo, head_id) as wt:
+            review = engine.run(prompt, wt, model, effort, web_search,
+                                **_progress_kwargs(on_progress))
+            # Settle inside the worktree: a register retry resumes the same session and
+            # must see the same materialized snapshot the review did.
             trailer = closure.settle(review, engine, wt, model, effort, web_search,
                                      on_progress) if closure else None
-        finally:
-            # Whatever happened, the round must not strand its own pending latch and block
-            # every future round on a fault that has already been reported.
-            if closure:
-                closure.release()
+    except BaseException:
+        if closure:
+            closure.abandon()
+        raise
+    finally:
+        if closure:
+            closure.release()
 
     _log(log_dir, "critique_branch", engine, review, now,
          {"target": target.description, "model": model, "mode": "converge-packet",
@@ -454,7 +463,7 @@ class _ClassClosure:
         self.lineage_id = _lineage_id(repo, base_ref, head_ref, is_dirty, args.get("lineage"))
         self.lineage: cc.Lineage | None = None
         self.unavailable: str | None = None
-        self.deadline: float | None = None
+        self.budget = cc.Budget()
         self._latched = False
         self._settled = False
 
@@ -467,9 +476,8 @@ class _ClassClosure:
             return []
         cc.open_latch(self.state_root, self.lineage_id)
         self._latched = True
-        self.deadline = time.monotonic() + cc.ROUND_BUDGET
         self._apply_exemption_args()
-        cc.sweep(self.lineage, self._grep(), deadline=self.deadline, clock=time.monotonic)
+        cc.sweep(self.lineage, self._grep(), budget=self.budget, clock=time.monotonic)
         return [b for b in (cc.render_unclosed(self.lineage),
                             cc.render_unmechanized(self.lineage),
                             cc.render_exempt(self.lineage)) if b]
@@ -496,7 +504,7 @@ class _ClassClosure:
             # Round 10: a class registered by THIS review does not exist until now, so it
             # must be evaluated before the verdict — otherwise a new MAJOR class and
             # NOT-BLOCKED could ship in the same response.
-            cc.sweep(lineage, self._grep(), only=minted, deadline=self.deadline,
+            cc.sweep(lineage, self._grep(), only=minted, budget=self.budget,
                      clock=time.monotonic)
             lineage.debt = None
         except cc.RegisterError as exc:
@@ -514,12 +522,18 @@ class _ClassClosure:
         self._settled = True
         return cc.render_trailer(lineage, register_status=status, minted=minted)
 
+    def abandon(self) -> None:
+        """The round died before it could settle. Nothing was written, so the latch has
+        nothing to protect and must not outlive the exception that is already propagating."""
+        self._settled = True
+
     def release(self) -> None:
         """Clear the pending latch once the round is over WITHOUT an unresolved write.
 
-        Called from a `finally`, so a crash between `prepare()` and `settle()` cannot strand
-        the latch and block every later round on a fault that already surfaced. A failed
-        *write* does not release: that is the one case the latch exists for.
+        Called from a `finally` covering everything after `prepare()`, so no failure between
+        the two can strand the latch and block every later round on a fault the caller has
+        already been told about. A failed *write* does not release: that is the one
+        genuinely ambiguous case, and the one the latch exists for.
         """
         if self._latched and self._settled:
             cc.clear_latch(self.state_root, self.lineage_id)
@@ -533,7 +547,8 @@ class _ClassClosure:
     def _register(self, review: Review, engine: Engine, repo: Path, model: str, effort: str,
                   web_search: bool, on_progress: Callable[[str], None] | None):
         try:
-            return cc.parse_register(review.text), None or "parsed"
+            register = cc.parse_register(review.text)
+            return register, _count(register)
         except cc.RegisterError as first:
             if not review.session_ref or not hasattr(engine, "resume"):
                 # Claude's supported non-JSON fallback has no session to resume, and an
@@ -544,8 +559,15 @@ class _ClassClosure:
             retry = engine.resume(
                 review.session_ref, prompts.REGISTER_RETRY, repo, model, effort, web_search,
                 **_progress_kwargs(on_progress))
+            if retry.error:
+                # A failed CLI still returns text, and that text can contain a parseable
+                # NONE or CLOSED block. Trusting it would let a broken retry mutate durable
+                # state — the same reason `settle` refuses a failed review outright.
+                raise cc.RegisterError(
+                    f"the register retry itself failed (exit {retry.returncode})"
+                ) from first
             register = cc.parse_register(retry.text)   # a second failure raises, and blocks
-            return register, "parsed after retry"
+            return register, f"parsed after retry: {_count(register)}"
 
     def _apply_exemption_args(self) -> None:
         assert self.lineage is not None
@@ -595,3 +617,10 @@ def _run_git(argv: list[str], cwd: Path, timeout: int) -> tuple[int, bytes, byte
     except subprocess.TimeoutExpired as exc:
         raise TimeoutError(str(exc)) from exc
     return proc.returncode, proc.stdout, proc.stderr
+
+
+def _count(register: cc.Register) -> str:
+    """`NONE` and `parsed 0` are different facts about a review, and an operator reading
+    the trailer needs to tell an empty register from one whose records were all accepted."""
+    total = len(register.new_classes) + len(register.transitions)
+    return cc.NONE if total == 0 else f"parsed {total}"

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -152,7 +152,8 @@ def critique_branch(
         resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
     )
     closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
-    if (closure_on and include_unc and arguments.get("head_ref") not in (None, "HEAD")
+    if (converge and closure_on and include_unc
+            and arguments.get("head_ref") not in (None, "HEAD")
             and not arguments.get("lineage")):
         # resolve_target discards head_ref for a dirty review and snapshots the checkout, so
         # accepting it would key this round's classes to a branch that was never reviewed.
@@ -470,6 +471,10 @@ class _ClassClosure:
         self.lineage: cc.Lineage | None = None
         self.unavailable: str | None = None
         self.budget = cc.Budget()
+        #: The retry text, held back until the round has actually applied AND persisted it.
+        #: A failed, malformed or transition-invalid retry must never be reported as what
+        #: the round applied while durable state says otherwise.
+        self._retry_candidate: str | None = None
         self.retry_register: str | None = None
         self._latched = False
         self._settled = False
@@ -527,6 +532,8 @@ class _ClassClosure:
             return (f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
                     "CONVERGENCE: BLOCKED — this round's classes were not persisted.")
         self._settled = True
+        if lineage.debt is None:
+            self.retry_register = self._retry_candidate
         return cc.render_trailer(lineage, register_status=status, minted=minted)
 
     def abandon(self) -> None:
@@ -566,7 +573,7 @@ class _ClassClosure:
             retry = engine.resume(
                 review.session_ref, prompts.REGISTER_RETRY, repo, model, effort, web_search,
                 **_progress_kwargs(on_progress))
-            self.retry_register = retry.text
+            self._retry_candidate = retry.text
             if retry.error:
                 # A failed CLI still returns text, and that text can contain a parseable
                 # NONE or CLOSED block. Trusting it would let a broken retry mutate durable

--- a/src/paranoia_local/orientation.py
+++ b/src/paranoia_local/orientation.py
@@ -16,6 +16,8 @@ import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 
+from .textsafe import display
+
 # Above this, we stop embedding the raw diff and tell the reviewer to run
 # `git diff` itself. The reviewer has repo access, so nothing is lost — this
 # only keeps the prompt from ballooning on large branches.
@@ -122,14 +124,9 @@ class ChangeEntry:
     old_path: str | None = None
 
 
-def _display(name: str) -> str:
-    """A display-safe, INJECTIVE rendering of a possibly `surrogateescape`-decoded path.
-    Valid Unicode (e.g. `café.py`) is kept; a literal backslash is doubled first so it can't
-    be confused with an escape introducer, then non-UTF-8 bytes carried as surrogates become
-    `\\u….` escapes. The result therefore can't (a) collide two distinct paths onto one label
-    (a real `a\\udcff` vs a `0xff`-byte path stay distinct), or (b) inject lone surrogates that
-    crash JSON/UTF-8 encoding of the packet or the reviewer prompt stdin."""
-    return name.replace("\\", "\\\\").encode("utf-8", "backslashreplace").decode("utf-8")
+#: Shared with `class_closure`, which renders grep matches into the same packet and must
+#: apply the identical injective escaping. See `textsafe.display` for the contract.
+_display = display
 
 
 def changed_files(repo: Path, from_ref: str, to_ref: str) -> list[ChangeEntry]:
@@ -390,6 +387,7 @@ def build_packet(
     diff_intent: str | None = None,
     focus: str | None = None,
     already_raised: list[str] | None = None,
+    class_blocks: list[str] | None = None,
     max_chars: int = MAX_PACKET_CHARS,
     max_file_chars: int = MAX_FILE_CHARS,
 ) -> str:
@@ -398,11 +396,16 @@ def build_packet(
 
     Layout: mandatory header (context/intent/focus/diffstat) + budgeted evidence (diff, then
     each touched file's content) + mandatory `already_raised` block. `max_chars` bounds the
-    packet whenever it exceeds the mandatory header + `already_raised`; those two are ALWAYS
-    included (the firewall list is never dropped) even if they alone exceed `max_chars`. When
+    packet whenever it exceeds the mandatory header + `already_raised` + `class_blocks`; those
+    are ALWAYS included (the firewall list is never dropped) even if they alone exceed
+    `max_chars`. `class_blocks` render AFTER `already_raised`, deliberately: the two carry
+    opposite instructions ("do NOT restate" vs "re-verify these"), and a reviewer obeying the
+    nearer one must land on the class blocks, which is why they also state their own
+    precedence. When
     evidence is trimmed a marker is emitted, and the marker's own size is reserved so the
     final packet stays within `max_chars` in the normal case."""
     already_raised = already_raised or []
+    class_blocks = class_blocks or []
     entries = changed_files(repo, base_id, head_id)
 
     head_parts = [
@@ -425,11 +428,14 @@ def build_packet(
         head_parts.append(f"=== DIFFSTAT ===\n{stat}")
     header = "\n\n".join(head_parts)
 
-    reserved = ""
+    reserved_parts: list[str] = []
     if already_raised:
-        reserved = "=== Already-raised — do NOT restate these; hunt for what they missed ===\n" + "\n".join(
-            f"- {c}" for c in already_raised
+        reserved_parts.append(
+            "=== Already-raised — do NOT restate these; hunt for what they missed ===\n"
+            + "\n".join(f"- {c}" for c in already_raised)
         )
+    reserved_parts.extend(class_blocks)
+    reserved = "\n\n".join(reserved_parts) if reserved_parts else ""
 
     evidence: list[str] = [
         f"=== DIFF (git diff {base_id[:12]}..{head_id[:12]}) ===\n{_safe_diff(repo, base_id, head_id)}"

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -294,7 +294,15 @@ begin with `:` (pathspec magic); an unknown class id is rejected. Do NOT list re
 — the server computes those from your predicate and does not read your prose for them."""
 
 
-REGISTER_RETRY = """Your reply did not end with a parseable === CLASS REGISTER === block.
+def register_retry(reason: str) -> str:
+    """Naming the actual fault matters: most retries are a typo'd class id or a repeated
+    transition, and a reviewer told only "unparseable" will resend the same block."""
+    return _REGISTER_RETRY.replace("<REASON>", reason)
+
+
+_REGISTER_RETRY = """Your reply's === CLASS REGISTER === block was not accepted.
+
+Reason: <REASON>
 
 Reply with ONLY that block and nothing else — no preamble, no review text. Records are
 separated by blank lines, one field per line. If you registered no class and are changing
@@ -302,3 +310,5 @@ no state, the entire body is the single word NONE:
 
 === CLASS REGISTER ===
 NONE"""
+
+REGISTER_RETRY = _REGISTER_RETRY.replace("<REASON>", "the block was absent or unparseable")

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -33,6 +33,7 @@ The TASK INPUT may include a `=== REVIEW CALIBRATION ===` block with STAKES (the
 
 - STAKES bounds legitimate concern. A finding that assumes adversaries, scale, data volumes, multi-tenancy, concurrency, or failure modes BEYOND the stated stakes is out of scope: drop it, or if it is real-but-beyond-scope tag it [OUT-OF-SCOPE] — never as a blocker or a must-fix. Do NOT propose hardening, defensive code, or generality against threats the stakes do not include; that is over-engineering, itself a defect.
 - If NO stakes are stated, assume a MODEST single-team internal tool: trusted operators, no hostile input, ordinary scale. Do NOT default to the most adversarial, multi-tenant, or high-scale reading — that default is the main cause of review scope-creep.
+- The ROUND severity floor NEVER applies to a recurrence of a class listed in an `=== UNCLOSED CLASSES ===` block. Those were reported in an earlier round and are still open; report every one whatever its individual severity, and do NOT write `CONVERGED` while that block is non-empty — a computed trailer below your review will contradict you, and the trailer governs.
 - ROUND sets the severity floor. Round 1: report everything in scope. Round 3 or higher: the design has already survived earlier rounds — report ONLY in-scope findings of merge-blocking severity ([MAJOR] or higher for this review mode); withhold [MINOR] and anything [OUT-OF-SCOPE]. If no merge-blocking findings remain, write `CONVERGED — no blocking findings at this round` as the entire content of the "What doesn't work" section and set the other four sections to "Nothing notable." — this signals convergence WITHOUT breaking the five-section format. Late-round marginal, stylistic, or hardening findings are noise that prevents convergence — withhold them."""
 
 _SHARED_RULES = """### Rules across all sections
@@ -236,3 +237,68 @@ def compose(instructions: str, body: str) -> str:
     """Combine a system instruction block with the task body into the single
     prompt string the engines feed to the CLI over stdin."""
     return f"{instructions}\n\n===== TASK INPUT =====\n\n{body}"
+
+
+# ── class closure ─────────────────────────────────────────────────────────────
+# The register is the ONLY channel by which a defect class becomes durable. Nothing in
+# the five prose sections is parsed: nine review rounds established that policing free
+# text for undeclared classes is unachievable, so the contract asks plainly instead and
+# `docs/class_closure_plan.md` §1 scopes the guarantee to a class you register.
+
+CLASS_REGISTER_INSTRUCTIONS = """## Register the defect CLASSES you found — mandatory terminal block
+
+A finding is a **class** when the reasoning that condemned this site would condemn
+another site if one existed: a violated invariant, not a one-off. A genuine off-by-one is
+not a class, and inventing class machinery for one is over-engineering.
+
+Registering a class is how it survives past this round. The server re-runs your predicate
+every future round, reports every surviving match as a recurrence, and refuses to report
+the loop unblocked while a BLOCKER or MAJOR class of yours is still open. A class you do
+not register is simply not tracked — nothing detects that, so it is on you.
+
+**A mechanized predicate matches VIOLATIONS ONLY.** Closure is defined as zero matches,
+so a pattern that also matches conforming code can never close and is worse than useless.
+If no line-level regex can express the violation, use PROCEDURE instead and say so — an
+honest unmechanized class is worth far more than a regex that quietly matches nothing.
+
+End your reply with EXACTLY this block, after everything else, records separated by blank
+lines. If you registered no class and changed no state, the whole body is `NONE`.
+
+=== CLASS REGISTER ===
+CLASS: <the invariant, one line, stated WITHOUT reference to any particular site>
+SEVERITY: BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE
+PATTERN: <POSIX-extended regex matching violations only>
+PATHSPEC: <git pathspec bounding the search, or . for the whole tree>
+
+For an invariant no regex can express, replace PATTERN and PATHSPEC with:
+PROCEDURE: <what a reviewer must do to find every violation>
+
+State changes against classes already shown to you, each its own record:
+CLOSED: <class-id>                 (unmechanized only — you judge it genuinely closed)
+REOPEN: <class-id>                 (unmechanized only — a closed one is violated again)
+RECLASSIFY: <class-id> <severity>  (correct a severity you judge wrong)
+SUPERSEDE: <old-id>
+BY: <existing-class-id>            (must be a different, live class)
+   — or —
+SUPERSEDE: <old-id>
+WITH-PATTERN: <corrected regex>
+PATHSPEC: <pathspec>
+CLASS: <restated invariant>        (optional)
+   — or —
+SUPERSEDE: <old-id>
+WITH-PROCEDURE: <procedure>        (the invariant turned out to be inexpressible)
+CLASS: <restated invariant>        (optional)
+
+Rules: one field per line; SEVERITY here is the class's ONLY severity; a pathspec may not
+begin with `:` (pathspec magic); an unknown class id is rejected. Do NOT list recurrences
+— the server computes those from your predicate and does not read your prose for them."""
+
+
+REGISTER_RETRY = """Your reply did not end with a parseable === CLASS REGISTER === block.
+
+Reply with ONLY that block and nothing else — no preamble, no review text. Records are
+separated by blank lines, one field per line. If you registered no class and are changing
+no state, the entire body is the single word NONE:
+
+=== CLASS REGISTER ===
+NONE"""

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -130,6 +130,57 @@ TOOLS: list[Tool] = [
                 "already_raised": _ALREADY_RAISED,
                 "stakes": _STAKES,
                 "round": _ROUND,
+                "class_closure": {
+                    "type": "boolean",
+                    "description": (
+                        "Track defect CLASSES across rounds (default true). The reviewer registers "
+                        "each class with a regex matching violations only; every later round re-runs "
+                        "it and a computed CONVERGENCE trailer reports BLOCKED while any BLOCKER/MAJOR "
+                        "class still matches. This is what stops a loop fixing one spelling of a "
+                        "defect per round. Set false to restore the pre-closure behaviour exactly."
+                    ),
+                },
+                "lineage": {
+                    "type": "string",
+                    "description": (
+                        "Explicit class-closure lineage key. Defaults to repo + base_ref + the "
+                        "reviewed branch. Required when the reviewed ref is not a branch (detached "
+                        "HEAD or a raw commit), where there is no stable key to derive."
+                    ),
+                },
+                "exempt": {
+                    "type": "array",
+                    "description": (
+                        "Mark specific matches as false positives of a class's regex. Each is shown "
+                        "to every later reviewer for challenge, and can be revoked with `unexempt`."
+                    ),
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "class_id": {"type": "string"},
+                            "path": {"type": "string"},
+                            "line": {"type": "integer"},
+                            "line_text": {
+                                "type": "string",
+                                "description": "The matched line verbatim; the exemption is void once it changes.",
+                            },
+                        },
+                        "required": ["class_id", "path", "line", "line_text"],
+                    },
+                },
+                "unexempt": {
+                    "type": "array",
+                    "description": "Revoke exemptions previously granted (a successful challenge).",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "class_id": {"type": "string"},
+                            "path": {"type": "string"},
+                            "line": {"type": "integer"},
+                        },
+                        "required": ["class_id", "path", "line"],
+                    },
+                },
                 **_COMMON,
             },
             "required": ["repo_path"],

--- a/src/paranoia_local/textsafe.py
+++ b/src/paranoia_local/textsafe.py
@@ -1,0 +1,23 @@
+"""Display-safe rendering of `surrogateescape`-decoded text.
+
+`git` paths and file contents are bytes, not Unicode. We decode them with
+`surrogateescape` so the exact bytes round-trip back to git, which means the
+resulting `str` can carry lone surrogates. Those crash UTF-8/JSON encoding — and
+both reviewer runners write stdin in text mode — so nothing decoded that way may
+be rendered into a packet, footer or trailer directly.
+"""
+
+from __future__ import annotations
+
+
+def display(name: str) -> str:
+    """A display-safe, INJECTIVE rendering of possibly `surrogateescape`-decoded text.
+
+    Valid Unicode (e.g. `café.py`) is kept; a literal backslash is doubled first so it
+    can't be confused with an escape introducer, then non-UTF-8 bytes carried as
+    surrogates become `\\u….` escapes. The result therefore can't (a) collide two
+    distinct inputs onto one label (a real `a\\udcff` vs a `0xff`-byte path stay
+    distinct), or (b) inject lone surrogates that crash UTF-8 encoding of the packet
+    or the reviewer prompt stdin.
+    """
+    return name.replace("\\", "\\\\").encode("utf-8", "backslashreplace").decode("utf-8")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,15 @@ from pathlib import Path
 
 import pytest
 
+from paranoia_local import class_closure as cc
+
+
+@pytest.fixture(autouse=True)
+def _isolate_class_closure_state(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Class closure is on by default, so without this every test that reviews a branch
+    would write a lineage into the operator's real ~/.paranoia."""
+    monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
+
 _GIT_ENV = {
     "GIT_AUTHOR_NAME": "test",
     "GIT_AUTHOR_EMAIL": "test@example.com",

--- a/tests/test_class_closure.py
+++ b/tests/test_class_closure.py
@@ -225,6 +225,32 @@ class TestIdentityAndTransitions:
             transitions=(cc.Transition("REOPEN", cid),)), round_no=3)
         assert lin.classes[cid].blocking
 
+    def test_a_superseded_source_is_rejected(self) -> None:
+        """A superseded class is inert and uncounted against the cap; CLOSED or REOPEN
+        against it would resurrect it, and superseding it again would mint a second
+        replacement for one retirement."""
+        lin = lineage_with(("a", cc.MAJOR, None), ("b", cc.MAJOR, None))
+        a, b = [c.class_id for c in lin.active()]
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("SUPERSEDE", a, target=b),)), round_no=2)
+        for t in (cc.Transition("REOPEN", a), cc.Transition("CLOSED", a),
+                  cc.Transition("SUPERSEDE", a, procedure="again")):
+            with pytest.raises(cc.RegisterError, match="already superseded"):
+                cc.apply_register(lin, cc.Register(transitions=(t,)), round_no=3)
+        assert lin.classes[a].status == cc.SUPERSEDED
+
+    def test_two_transitions_against_one_class_in_a_register_are_rejected(self) -> None:
+        """Two SUPERSEDE ... WITH-* records for one source would mint two live replacements
+        for one retirement, quietly breaking the net-zero guarantee at the cap."""
+        lin = lineage_with(("a", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        with pytest.raises(cc.RegisterError, match="more than one transition"):
+            cc.apply_register(lin, cc.Register(transitions=(
+                cc.Transition("SUPERSEDE", cid, pattern="Y", pathspec="."),
+                cc.Transition("SUPERSEDE", cid, pattern="Z", pathspec="."),
+            )), round_no=2)
+        assert len(lin.active()) == 1, "a rejected register applies none of its records"
+
     def test_transition_naming_an_unknown_id_is_rejected(self) -> None:
         with pytest.raises(cc.RegisterError, match="unknown class id"):
             cc.apply_register(cc.Lineage("t"), cc.Register(
@@ -313,22 +339,38 @@ class TestClosure:
 
     def test_budget_exhaustion_leaves_the_class_unchecked_and_blocking(self) -> None:
         lin = lineage_with(("inv", cc.MAJOR, "X"))
-        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=0.0, clock=lambda: 1.0)
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=cc.Budget(total=0.0))
         cls = lin.active()[0]
         assert cls.status == cc.UNCHECKED and cls.blocking
 
-    def test_both_sweeps_of_a_round_share_one_deadline(self) -> None:
+    def test_both_sweeps_of_a_round_share_one_budget(self) -> None:
         """A per-call budget would give the pre-review and post-register sweeps a fresh
         60s each, making a 60s round budget a 120s one in practice."""
         lin = lineage_with(("first", cc.MAJOR, "X"))
         ticks = iter([0.0, 61.0])
         clock = lambda: next(ticks)  # noqa: E731
-        deadline = 60.0
-        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=deadline, clock=clock)
-        assert lin.active()[0].status == cc.CLOSED
-        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=deadline, clock=clock)
+        budget = cc.Budget(total=60.0)
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=budget, clock=clock)
+        assert lin.active()[0].status == cc.CLOSED and budget.spent == 61.0
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=budget, clock=clock)
         assert lin.active()[0].status == cc.UNCHECKED, (
             "the second sweep must inherit the round's spent budget, not restart it"
+        )
+
+    def test_the_budget_measures_grep_time_not_wall_clock(self) -> None:
+        """The two sweeps of a round straddle the reviewer call, which runs for minutes. A
+        wall-clock deadline opened before the review would always be spent by the time the
+        post-register sweep ran, so every newly registered class would be `unchecked`."""
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        budget = cc.Budget(total=60.0)
+        # grep itself takes 1s; 600s of reviewer time elapses between the two readings.
+        ticks = iter([0.0, 1.0, 600.0, 601.0])
+        clock = lambda: next(ticks)  # noqa: E731
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=budget, clock=clock)
+        assert budget.spent == 1.0, "only the grep call may be charged"
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("a.py",)), budget=budget, clock=clock)
+        assert lin.active()[0].status == cc.OPEN, (
+            "the reviewer's own runtime must not exhaust the closure budget"
         )
 
     def test_a_new_mechanized_class_starts_unchecked_and_blocking(self) -> None:
@@ -373,6 +415,25 @@ class TestBinaryMatches:
         cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("blob.dat",), matches=()))
         assert lin.classes[cid].status == cc.OPEN
         assert lin.classes[cid].matches[0]["binary"] is True
+
+    def test_a_binary_match_cannot_be_exempted_away(self) -> None:
+        """Round 2's MAJOR: falling back to path-only matching for an undisplayable match
+        turns one exact exemption into a path-wide one the moment a file goes binary, and
+        closes the class over a live violation."""
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        lin.exemptions.append(cc.Exemption(cid, "blob.dat", 4, cc.fingerprint("X was here")))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("blob.dat",), matches=()))
+        assert lin.classes[cid].status == cc.OPEN
+        assert lin.classes[cid].matches[0]["binary"] is True
+
+    def test_a_display_pass_timeout_does_not_let_an_exemption_close_the_class(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        lin.exemptions.append(cc.Exemption(cid, "a.py", 1, cc.fingerprint("X")))
+        # verdict pass found it; display pass returned nothing (timeout)
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("a.py",), matches=()))
+        assert lin.classes[cid].status == cc.OPEN
 
     def test_the_binary_match_is_visible_in_the_block(self) -> None:
         lin = lineage_with(("inv", cc.MAJOR, "X"))

--- a/tests/test_class_closure.py
+++ b/tests/test_class_closure.py
@@ -1,0 +1,509 @@
+"""Behavioural tests for class closure.
+
+Each block names the review round whose finding it pins, so a later change that
+re-opens one of them fails with the history attached.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paranoia_local import class_closure as cc
+
+
+def git(args: list[str], cwd: Path) -> None:
+    subprocess.run(["git", *args], cwd=cwd, check=True, capture_output=True)
+
+
+def runner(argv: list[str], cwd: Path, timeout: int) -> tuple[int, bytes, bytes]:
+    p = subprocess.run(argv, cwd=cwd, capture_output=True, timeout=timeout)
+    return p.returncode, p.stdout, p.stderr
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "r"
+    r.mkdir()
+    git(["init", "-q", "-b", "main"], r)
+    git(["config", "user.email", "t@t"], r)
+    git(["config", "user.name", "t"], r)
+    return r
+
+
+def commit(repo: Path, files: dict[str, str | bytes], message: str = "c") -> str:
+    for name, body in files.items():
+        p = repo / name
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_bytes(body if isinstance(body, bytes) else body.encode())
+    git(["add", "-A"], repo)
+    git(["commit", "-qm", message], repo)
+    return subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                          capture_output=True, text=True).stdout.strip()
+
+
+MECH = """
+=== CLASS REGISTER ===
+CLASS: every open state must be in the v2 open set
+SEVERITY: MAJOR
+PATTERN: BAD_CALL\\(
+PATHSPEC: .
+"""
+
+
+# ── register parsing ──────────────────────────────────────────────────────────
+
+
+class TestRegisterParsing:
+    def test_none_parses_as_an_empty_register(self) -> None:
+        assert cc.parse_register("prose\n\n=== CLASS REGISTER ===\nNONE\n") == cc.Register()
+
+    def test_absent_block_is_an_error(self) -> None:
+        with pytest.raises(cc.RegisterError, match="no === CLASS REGISTER ==="):
+            cc.parse_register("a review with no register at all")
+
+    def test_two_records_parse(self) -> None:
+        reg = cc.parse_register(
+            "=== CLASS REGISTER ===\n"
+            "CLASS: one\nSEVERITY: MAJOR\nPATTERN: a\nPATHSPEC: src\n\n"
+            "CLASS: two\nSEVERITY: MINOR\nPROCEDURE: read every caller\n"
+        )
+        assert [c.invariant for c in reg.new_classes] == ["one", "two"]
+        assert reg.new_classes[0].mechanized and not reg.new_classes[1].mechanized
+
+    def test_duplicate_field_within_a_record_is_rejected(self) -> None:
+        with pytest.raises(cc.RegisterError, match="duplicate register key"):
+            cc.parse_register("=== CLASS REGISTER ===\nCLASS: a\nCLASS: b\nSEVERITY: MAJOR\n")
+
+    def test_missing_required_field_is_rejected(self) -> None:
+        with pytest.raises(cc.RegisterError):
+            cc.parse_register("=== CLASS REGISTER ===\nCLASS: a\nSEVERITY: MAJOR\nPATTERN: x\n")
+
+    def test_unknown_severity_is_rejected(self) -> None:
+        with pytest.raises(cc.RegisterError, match="unknown severity"):
+            cc.parse_register("=== CLASS REGISTER ===\nCLASS: a\nSEVERITY: URGENT\nPROCEDURE: p\n")
+
+    def test_unknown_key_is_rejected(self) -> None:
+        with pytest.raises(cc.RegisterError, match="unknown register key"):
+            cc.parse_register("=== CLASS REGISTER ===\nCLASS: a\nSEVERITY: MAJOR\nSITES: x\n")
+
+    def test_a_field_name_in_earlier_prose_does_not_confuse_the_parser(self) -> None:
+        text = ("## What doesn't work\nThe code writes CLASS: nonsense into the log.\n\n"
+                "=== CLASS REGISTER ===\nNONE\n")
+        assert cc.parse_register(text) == cc.Register()
+
+    def test_pathspec_magic_is_rejected_before_any_git_call(self) -> None:
+        with pytest.raises(cc.RegisterError, match="pathspec magic"):
+            cc.parse_register(
+                "=== CLASS REGISTER ===\nCLASS: a\nSEVERITY: MAJOR\nPATTERN: x\n"
+                "PATHSPEC: :(exclude)src\n"
+            )
+
+
+class TestNothingOutsideTheRegisterIsParsed:
+    """Round 9's FATAL: policing the prose was impossible, so revision 10 stopped.
+    These tests pin the *concession* — the opposite behaviour is unachievable and §1
+    scopes the guarantee to a registered class."""
+
+    def test_prose_describing_a_class_with_a_none_register_parses_and_records_nothing(self) -> None:
+        text = ("## What doesn't work\n[MAJOR] This is a whole class of defect, it recurs "
+                "everywhere.\n\n=== CLASS REGISTER ===\nNONE\n")
+        assert cc.parse_register(text).new_classes == ()
+
+    def test_a_clean_late_round_converged_body_still_parses(self) -> None:
+        text = ("## What doesn't work\nCONVERGED — no blocking findings at this round\n\n"
+                "=== CLASS REGISTER ===\nNONE\n")
+        assert cc.parse_register(text) == cc.Register()
+
+    def test_a_prose_severity_tag_disagreeing_with_the_register_is_not_an_error(self) -> None:
+        text = ("## What doesn't work\n[MAJOR] something\n\n=== CLASS REGISTER ===\n"
+                "CLASS: a\nSEVERITY: MINOR\nPROCEDURE: p\n")
+        assert cc.parse_register(text).new_classes[0].severity == cc.MINOR
+
+
+class TestSupersessionGrammar:
+    """Round 9's MAJOR: the single-line form had no unique parse, because PATHSPEC: and
+    CLASS: are legal content inside a regex, a pathspec and an invariant alike."""
+
+    def test_fields_containing_the_literal_tokens_still_parse_correctly(self) -> None:
+        reg = cc.parse_register(
+            "=== CLASS REGISTER ===\n"
+            "SUPERSEDE: abc12345\nWITH-PATTERN: PATHSPEC: [a-z]+\nPATHSPEC: src\n"
+            "CLASS: an invariant mentioning CLASS: verbatim\n"
+        )
+        t = reg.transitions[0]
+        assert t.pattern == "PATHSPEC: [a-z]+"
+        assert t.pathspec == "src"
+        assert t.invariant == "an invariant mentioning CLASS: verbatim"
+
+    def test_with_procedure_is_available(self) -> None:
+        reg = cc.parse_register(
+            "=== CLASS REGISTER ===\nSUPERSEDE: abc12345\nWITH-PROCEDURE: read every caller\n"
+        )
+        assert reg.transitions[0].procedure == "read every caller"
+
+
+# ── state transitions ─────────────────────────────────────────────────────────
+
+
+def lineage_with(*specs: tuple[str, str, str | None]) -> cc.Lineage:
+    """specs: (invariant, severity, pattern-or-None)."""
+    lin = cc.Lineage("test")
+    for invariant, severity, pattern in specs:
+        cc.apply_register(
+            lin,
+            cc.Register(new_classes=(cc.NewClass(
+                invariant, severity,
+                pattern=pattern, pathspec="." if pattern else None,
+                procedure=None if pattern else "read it",
+            ),)),
+            round_no=1,
+        )
+    return lin
+
+
+class TestIdentityAndTransitions:
+    def test_two_records_sharing_a_predicate_get_independent_state(self) -> None:
+        """Round 4's FATAL: dedup on (pattern, pathspec) collapsed distinct invariants."""
+        lin = lineage_with(("first invariant", cc.MAJOR, "X"), ("second invariant", cc.MINOR, "X"))
+        a, b = lin.active()
+        assert a.class_id != b.class_id
+        cc.apply_register(lin, cc.Register(transitions=(
+            cc.Transition("RECLASSIFY", a.class_id, severity=cc.MINOR),)), round_no=2)
+        assert lin.classes[b.class_id].severity == cc.MINOR   # untouched, was already MINOR
+        assert lin.classes[a.class_id].severity == cc.MINOR
+
+    def test_supersede_by_rejects_self_target(self) -> None:
+        """Round 6's FATAL: A BY A retired the only blocker and left nothing active."""
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        with pytest.raises(cc.RegisterError, match="cannot name the class it supersedes"):
+            cc.apply_register(lin, cc.Register(
+                transitions=(cc.Transition("SUPERSEDE", cid, target=cid),)), round_no=2)
+
+    def test_supersede_by_rejects_an_already_superseded_target(self) -> None:
+        lin = lineage_with(("a", cc.MAJOR, "X"), ("b", cc.MAJOR, "Y"), ("c", cc.MAJOR, "Z"))
+        a, b, c = [x.class_id for x in lin.active()]
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("SUPERSEDE", a, target=b),)), round_no=2)
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("SUPERSEDE", b, target=c),)), round_no=2)
+        with pytest.raises(cc.RegisterError, match="already-superseded"):
+            cc.apply_register(lin, cc.Register(
+                transitions=(cc.Transition("SUPERSEDE", c, target=b),)), round_no=3)
+
+    def test_supersede_with_pattern_inherits_severity_and_first_round(self) -> None:
+        lin = cc.Lineage("test")
+        cc.apply_register(lin, cc.Register(new_classes=(
+            cc.NewClass("inv", cc.MAJOR, pattern="X", pathspec="."),)), round_no=7)
+        old = lin.active()[0].class_id
+        minted = cc.apply_register(lin, cc.Register(transitions=(
+            cc.Transition("SUPERSEDE", old, pattern="Y", pathspec="."),)), round_no=9)
+        new = lin.classes[minted[0]]
+        assert new.severity == cc.MAJOR and new.first_round == 7
+        assert lin.classes[old].status == cc.SUPERSEDED and not lin.classes[old].blocking
+
+    def test_reopen_is_rejected_for_a_mechanized_class(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        with pytest.raises(cc.RegisterError, match="unmechanized classes only"):
+            cc.apply_register(lin, cc.Register(
+                transitions=(cc.Transition("REOPEN", cid),)), round_no=2)
+
+    def test_unmechanized_closes_and_reopens(self) -> None:
+        """Round 6's MAJOR: CLOSED had no counterpart, so a recurrence could not be recorded."""
+        lin = lineage_with(("semantic invariant", cc.MAJOR, None))
+        cid = lin.active()[0].class_id
+        assert lin.classes[cid].blocking
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("CLOSED", cid),)), round_no=2)
+        assert not lin.classes[cid].blocking
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("REOPEN", cid),)), round_no=3)
+        assert lin.classes[cid].blocking
+
+    def test_transition_naming_an_unknown_id_is_rejected(self) -> None:
+        with pytest.raises(cc.RegisterError, match="unknown class id"):
+            cc.apply_register(cc.Lineage("t"), cc.Register(
+                transitions=(cc.Transition("CLOSED", "deadbeef"),)), round_no=1)
+
+
+class TestCapBoundary:
+    """Round 11's MAJOR: counting superseded classes removed the recovery path at exactly
+    the boundary the cap establishes."""
+
+    def _full(self) -> cc.Lineage:
+        lin = cc.Lineage("test")
+        for i in range(cc.MAX_ACTIVE_CLASSES):
+            cc.apply_register(lin, cc.Register(new_classes=(
+                cc.NewClass(f"inv {i}", cc.MINOR, pattern=f"P{i}", pathspec="."),)), round_no=1)
+        return lin
+
+    def test_registration_is_refused_at_the_cap(self) -> None:
+        lin = self._full()
+        with pytest.raises(cc.RegisterError, match="registration refused"):
+            cc.apply_register(lin, cc.Register(new_classes=(
+                cc.NewClass("one too many", cc.MAJOR, pattern="Z", pathspec="."),)), round_no=2)
+
+    def test_supersede_with_pattern_still_succeeds_at_the_cap(self) -> None:
+        lin = self._full()
+        victim = lin.active()[0].class_id
+        minted = cc.apply_register(lin, cc.Register(transitions=(
+            cc.Transition("SUPERSEDE", victim, pattern="NARROWER", pathspec="."),)), round_no=2)
+        assert len(lin.active()) == cc.MAX_ACTIVE_CLASSES
+        assert lin.classes[minted[0]].pattern == "NARROWER"
+
+    def test_supersede_with_procedure_still_succeeds_at_the_cap(self) -> None:
+        """Round 13's MAJOR: an inexpressible invariant needs a route to PROCEDURE."""
+        lin = self._full()
+        victim = lin.active()[0].class_id
+        minted = cc.apply_register(lin, cc.Register(transitions=(
+            cc.Transition("SUPERSEDE", victim, procedure="read every caller"),)), round_no=2)
+        assert not lin.classes[minted[0]].mechanized
+
+
+# ── closure semantics ─────────────────────────────────────────────────────────
+
+
+class TestClosure:
+    def test_zero_matches_closes_and_any_match_reopens(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("a.py",),
+                                                 matches=({"path": "a.py", "line": 3, "text": "X"},)))
+        assert lin.classes[cid].status == cc.OPEN and lin.classes[cid].blocking
+        cc.sweep(lin, lambda p, s: cc.GrepResult())
+        assert lin.classes[cid].status == cc.CLOSED and not lin.classes[cid].blocking
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("b.py",),
+                                                 matches=({"path": "b.py", "line": 1, "text": "X"},)))
+        assert lin.classes[cid].status == cc.OPEN, "a closed class must reopen on a new match"
+
+    def test_a_superseded_class_is_not_swept(self) -> None:
+        lin = lineage_with(("a", cc.MAJOR, "X"), ("b", cc.MAJOR, "Y"))
+        a, b = [c.class_id for c in lin.active()]
+        cc.apply_register(lin, cc.Register(
+            transitions=(cc.Transition("SUPERSEDE", a, target=b),)), round_no=2)
+        seen: list[str] = []
+
+        def grep(pattern: str, pathspec: str) -> cc.GrepResult:
+            seen.append(pattern)
+            return cc.GrepResult()
+
+        cc.sweep(lin, grep)
+        assert seen == ["Y"]
+
+    def test_a_predicate_error_is_malformed_and_blocks_by_severity(self) -> None:
+        lin = lineage_with(("major", cc.MAJOR, "a["), ("minor", cc.MINOR, "a["))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(error="Invalid regular expression"))
+        major, minor = lin.active()
+        assert major.status == cc.MALFORMED and major.blocking
+        assert minor.status == cc.MALFORMED and not minor.blocking, (
+            "round 2: an advisory class must never block, including on execution failure"
+        )
+
+    def test_over_the_match_cap_is_over_broad_and_says_to_narrow(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "."))
+        paths = tuple(f"f{i}.py" for i in range(cc.MAX_MATCHES + 1))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=paths))
+        cls = lin.active()[0]
+        assert cls.status == cc.OVER_BROAD and "narrow" in (cls.detail or "")
+
+    def test_budget_exhaustion_leaves_the_class_unchecked_and_blocking(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=0, clock=lambda: 1.0)
+        cls = lin.active()[0]
+        assert cls.status == cc.UNCHECKED and cls.blocking
+
+    def test_a_new_mechanized_class_starts_unchecked_and_blocking(self) -> None:
+        """Round 10's FATAL: a class registered this round was never evaluated in it."""
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cls = lin.active()[0]
+        assert cls.status == cc.UNCHECKED and cls.blocking
+
+
+class TestExemptions:
+    def _open(self) -> tuple[cc.Lineage, str]:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        return lin, lin.active()[0].class_id
+
+    def test_an_exempt_match_is_subtracted_but_an_identical_line_elsewhere_is_not(self) -> None:
+        """Round 2's MAJOR: a fingerprint alone collided across duplicate lines."""
+        lin, cid = self._open()
+        text = "  BAD_CALL(x)"
+        lin.exemptions.append(cc.Exemption(cid, "a.py", 10, cc.fingerprint(text)))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(
+            paths=("a.py",),
+            matches=({"path": "a.py", "line": 10, "text": text},
+                     {"path": "a.py", "line": 20, "text": text}),
+        ))
+        surviving = lin.classes[cid].matches
+        assert [m["line"] for m in surviving] == [20]
+
+    def test_an_exemption_is_void_once_the_line_text_changes(self) -> None:
+        lin, cid = self._open()
+        lin.exemptions.append(cc.Exemption(cid, "a.py", 10, cc.fingerprint("BAD_CALL(x)")))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(
+            paths=("a.py",), matches=({"path": "a.py", "line": 10, "text": "BAD_CALL(y)"},)))
+        assert lin.classes[cid].status == cc.OPEN, "drift must fail toward blocking"
+
+
+class TestBinaryMatches:
+    """Round 15's MAJOR: -I suppresses binary matches, so a violation there read as closed."""
+
+    def test_a_verdict_path_absent_from_the_display_pass_still_blocks(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("blob.dat",), matches=()))
+        assert lin.classes[cid].status == cc.OPEN
+        assert lin.classes[cid].matches[0]["binary"] is True
+
+    def test_the_binary_match_is_visible_in_the_block(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("blob.dat",), matches=()))
+        assert "binary match (line not shown)" in (cc.render_unclosed(lin) or "")
+
+    def test_against_a_real_repo_a_binary_violation_is_not_reported_closed(self, repo: Path) -> None:
+        head = commit(repo, {"blob.dat": b"VIOLATION\x00 and VIOLATION again\n"})
+        grep = cc.make_grep(repo, head, runner=runner)
+        result = grep("VIOLATION", ".")
+        assert result.paths == ("blob.dat",), "the -l verdict pass must see the binary blob"
+        assert result.matches == (), "the -I display pass cannot read it, and that is fine"
+
+
+class TestGitEdge:
+    def test_no_match_is_closure_not_failure(self, repo: Path) -> None:
+        head = commit(repo, {"a.py": "clean = 1\n"})
+        assert cc.make_grep(repo, head, runner=runner)("NOTHING_HERE", ".") == cc.GrepResult()
+
+    def test_an_invalid_regex_is_an_error_not_a_closure(self, repo: Path) -> None:
+        head = commit(repo, {"a.py": "x = 1\n"})
+        result = cc.make_grep(repo, head, runner=runner)("a[", ".")
+        assert result.error and result.paths == ()
+
+    def test_a_non_utf8_path_parses_and_renders_safely(self, repo: Path) -> None:
+        """Round 14's MAJOR: parsed with surrogateescape, then rendered verbatim, a lone
+        surrogate crashes the prompt encoding or hangs stdin until the timeout."""
+        odd = b"od\xffd.py"
+        (repo / odd.decode("utf-8", "surrogateescape")).write_bytes(b"BAD_CALL(1)\n")
+        git(["add", "-A"], repo)
+        git(["commit", "-qm", "odd"], repo)
+        head = subprocess.run(["git", "rev-parse", "HEAD"], cwd=repo,
+                              capture_output=True, text=True).stdout.strip()
+        result = cc.make_grep(repo, head, runner=runner)("BAD_CALL", ".")
+        assert result.paths, "the odd-byte path must be found"
+
+        lin = lineage_with(("inv", cc.MAJOR, "BAD_CALL"))
+        cc.sweep(lin, lambda p, s: result)
+        rendered = (cc.render_unclosed(lin) or "") + cc.render_trailer(lin, register_status="parsed 1")
+        rendered.encode("utf-8")  # must not raise
+
+    def test_two_paths_differing_only_by_a_non_utf8_byte_render_distinctly(self) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(
+            paths=("a\udcffb.py", "a\\udcffb.py"),
+            matches=({"path": "a\udcffb.py", "line": 1, "text": "X"},
+                     {"path": "a\\udcffb.py", "line": 1, "text": "X"}),
+        ))
+        block = cc.render_unclosed(lin) or ""
+        assert block.count("a\\udcffb.py") == 1 and block.count("a\\\\udcffb.py") == 1
+
+
+# ── lineage state ─────────────────────────────────────────────────────────────
+
+
+class TestLineageState:
+    def test_state_round_trips(self, tmp_path: Path) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        lin.rounds = 3
+        cc.save_lineage(tmp_path, lin)
+        again = cc.load_lineage(tmp_path, "test", stamp="s")
+        assert again.rounds == 3 and len(again.active()) == 1
+
+    def test_unparseable_state_blocks_and_is_quarantined(self, tmp_path: Path) -> None:
+        d = cc.lineage_dir(tmp_path)
+        d.mkdir(parents=True)
+        (d / "test.json").write_text("{not json", encoding="utf-8")
+        with pytest.raises(cc.StateUnavailable, match="quarantined"):
+            cc.load_lineage(tmp_path, "test", stamp="20260728T000000")
+        assert list(d.glob("test.corrupt-*.json")), "the corrupt file must be moved aside"
+
+    def test_rerunning_after_quarantine_does_not_start_a_fresh_lineage(self, tmp_path: Path) -> None:
+        """Round 4's FATAL: quarantine alone created the empty-lineage path it closed."""
+        d = cc.lineage_dir(tmp_path)
+        d.mkdir(parents=True)
+        (d / "test.json").write_text("{not json", encoding="utf-8")
+        with pytest.raises(cc.StateUnavailable):
+            cc.load_lineage(tmp_path, "test", stamp="s1")
+        with pytest.raises(cc.StateUnavailable, match="repair or delete"):
+            cc.load_lineage(tmp_path, "test", stamp="s2")
+
+    def test_a_pending_latch_blocks_even_with_no_state_file(self, tmp_path: Path) -> None:
+        """Round 8's FATAL: a failed *write* left no marker, so the next round started empty."""
+        cc.open_latch(tmp_path, "test")
+        with pytest.raises(cc.StateUnavailable, match="pending write latch"):
+            cc.load_lineage(tmp_path, "test", stamp="s")
+        cc.clear_latch(tmp_path, "test")
+        assert cc.load_lineage(tmp_path, "test", stamp="s").rounds == 0
+
+    def test_state_is_replaced_atomically(self, tmp_path: Path) -> None:
+        lin = lineage_with(("inv", cc.MAJOR, "X"))
+        cc.save_lineage(tmp_path, lin)
+        lin.rounds = 9
+        cc.save_lineage(tmp_path, lin)
+        state = json.loads((cc.lineage_dir(tmp_path) / "test.json").read_text())
+        assert state["rounds"] == 9
+        assert not list(cc.lineage_dir(tmp_path).glob("*.tmp")), "no temp file may survive"
+
+
+# ── the trailer ───────────────────────────────────────────────────────────────
+
+
+class TestTrailer:
+    def test_blocked_names_the_ids_and_voids_a_reviewer_converged(self) -> None:
+        lin = lineage_with(("the invariant", cc.MAJOR, "X"))
+        cid = lin.active()[0].class_id
+        out = cc.render_trailer(lin, register_status="parsed 1")
+        assert "CONVERGENCE: BLOCKED" in out and cid in out
+        assert "VOID" in out
+
+    def test_not_blocked_never_says_converged_and_does_not_overclaim(self) -> None:
+        lin = lineage_with(("advisory", cc.MINOR, "X"))
+        cc.sweep(lin, lambda p, s: cc.GrepResult(paths=("a.py",),
+                                                 matches=({"path": "a.py", "line": 1, "text": "X"},)))
+        out = cc.render_trailer(lin, register_status="parsed 1")
+        assert "NOT-BLOCKED" in out
+        assert "converged" not in out.lower(), "a mechanical check must never read as approval"
+        assert "advisory classes may remain open" in out, (
+            "round 7: an open MINOR class means 'no unclosed class' would be a false claim"
+        )
+
+    def test_an_open_unmechanized_major_blocks(self) -> None:
+        """Round 3's MAJOR: 'nothing to run' is not 'does not block'."""
+        lin = lineage_with(("semantic", cc.MAJOR, None))
+        out = cc.render_trailer(lin, register_status="parsed 1")
+        assert "CONVERGENCE: BLOCKED" in out and "awaiting reviewer CLOSED" in out
+
+    def test_register_debt_blocks(self) -> None:
+        lin = cc.Lineage("test")
+        lin.debt = {"round": 4, "reason": "no === CLASS REGISTER === block"}
+        assert "BLOCKED — register debt from round 4" in cc.render_trailer(
+            lin, register_status="absent")
+
+    def test_the_lineage_id_and_round_count_are_always_visible(self) -> None:
+        lin = cc.Lineage("abc123")
+        lin.rounds = 7
+        assert "LINEAGE: abc123 (rounds recorded: 7)" in cc.render_trailer(
+            lin, register_status="NONE")
+
+
+class TestUnmechanizedBlock:
+    def test_a_closed_unmechanized_class_is_still_listed_with_its_id(self) -> None:
+        """Round 7's MAJOR: without this, REOPEN is unreachable for a later reviewer."""
+        lin = lineage_with(("semantic", cc.MAJOR, None))
+        cid = lin.active()[0].class_id
+        cc.apply_register(lin, cc.Register(transitions=(cc.Transition("CLOSED", cid),)), round_no=2)
+        block = cc.render_unmechanized(lin) or ""
+        assert cid in block and "closed" in block and "REOPEN" in block

--- a/tests/test_class_closure.py
+++ b/tests/test_class_closure.py
@@ -458,6 +458,22 @@ class TestGitEdge:
         result = cc.make_grep(repo, head, runner=runner)("a[", ".")
         assert result.error and result.paths == ()
 
+    def test_a_signal_killed_grep_is_an_error_not_a_closure(self, repo: Path) -> None:
+        """Python reports a signal-terminated subprocess with a NEGATIVE return code. Only
+        0 and 1 are meaningful; anything else means the predicate never proved closure."""
+        head = commit(repo, {"a.py": "x = 1\n"})
+
+        def killed(argv: list[str], cwd: Path, timeout: int) -> tuple[int, bytes, bytes]:
+            return -9, b"", b""
+
+        result = cc.make_grep(repo, head, runner=killed)("anything", ".")
+        assert result.error and "-9" in result.error
+        assert result.paths == ()
+
+        lin = lineage_with(("inv", cc.MAJOR, "anything"))
+        cc.sweep(lin, lambda p, s: result)
+        assert lin.active()[0].status == cc.MALFORMED and lin.active()[0].blocking
+
     def test_a_non_utf8_path_parses_and_renders_safely(self, repo: Path) -> None:
         """Round 14's MAJOR: parsed with surrogateescape, then rendered verbatim, a lone
         surrogate crashes the prompt encoding or hangs stdin until the timeout."""

--- a/tests/test_class_closure.py
+++ b/tests/test_class_closure.py
@@ -313,9 +313,23 @@ class TestClosure:
 
     def test_budget_exhaustion_leaves_the_class_unchecked_and_blocking(self) -> None:
         lin = lineage_with(("inv", cc.MAJOR, "X"))
-        cc.sweep(lin, lambda p, s: cc.GrepResult(), budget=0, clock=lambda: 1.0)
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=0.0, clock=lambda: 1.0)
         cls = lin.active()[0]
         assert cls.status == cc.UNCHECKED and cls.blocking
+
+    def test_both_sweeps_of_a_round_share_one_deadline(self) -> None:
+        """A per-call budget would give the pre-review and post-register sweeps a fresh
+        60s each, making a 60s round budget a 120s one in practice."""
+        lin = lineage_with(("first", cc.MAJOR, "X"))
+        ticks = iter([0.0, 61.0])
+        clock = lambda: next(ticks)  # noqa: E731
+        deadline = 60.0
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=deadline, clock=clock)
+        assert lin.active()[0].status == cc.CLOSED
+        cc.sweep(lin, lambda p, s: cc.GrepResult(), deadline=deadline, clock=clock)
+        assert lin.active()[0].status == cc.UNCHECKED, (
+            "the second sweep must inherit the round's spent budget, not restart it"
+        )
 
     def test_a_new_mechanized_class_starts_unchecked_and_blocking(self) -> None:
         """Round 10's FATAL: a class registered this round was never evaluated in it."""

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -1,0 +1,338 @@
+"""Orchestration tests for class closure: `_ClassClosure` driven through real rounds.
+
+`test_class_closure.py` covers the pure protocol. These cover the half that actually
+failed review — retry, durable debt, post-register sweeping, failed-engine state
+identity, latch lifecycle, dirty `head_ref` rejection and trailer integration — plus the
+known-positive the whole design was built to reproduce.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import pytest
+
+from paranoia_local import class_closure as cc
+from paranoia_local import handlers
+
+
+def git(args: list[str], cwd: Path) -> str:
+    return subprocess.run(["git", *args], cwd=cwd, check=True,
+                          capture_output=True, text=True).stdout.strip()
+
+
+@pytest.fixture
+def repo(tmp_path: Path) -> Path:
+    r = tmp_path / "repo"
+    r.mkdir()
+    git(["init", "-q", "-b", "main"], r)
+    git(["config", "user.email", "t@t"], r)
+    git(["config", "user.name", "t"], r)
+    (r / "seed.py").write_text("seed = 1\n")
+    git(["add", "-A"], r)
+    git(["commit", "-qm", "seed"], r)
+    git(["branch", "-q", "feature"], r)
+    git(["checkout", "-q", "feature"], r)
+    return r
+
+
+def commit(repo: Path, files: dict[str, str], message: str) -> None:
+    for name, body in files.items():
+        (repo / name).write_text(body)
+    git(["add", "-A"], repo)
+    git(["commit", "-qm", message], repo)
+
+
+class FakeEngine:
+    """Returns a scripted review per call, and records resume() invocations."""
+
+    name = "fake"
+    default_model = "fake-model"
+
+    def __init__(self, *reviews: str, session_ref: str | None = "sess") -> None:
+        self.reviews = list(reviews)
+        self.session_ref = session_ref
+        self.resumed: list[str] = []
+        self.calls: list[str] = []
+
+    def run(self, prompt: str, cwd: Path, model: str, effort: str, web: bool, **kw):
+        self.calls.append(prompt)
+        return self._review(self.reviews.pop(0) if self.reviews else "## What works\nok")
+
+    def resume(self, session_ref: str, prompt: str, cwd: Path, model: str, effort: str,
+               web: bool, **kw):
+        self.resumed.append(prompt)
+        return self._review(self.reviews.pop(0) if self.reviews else "no register here either")
+
+    def _review(self, text: str):
+        from paranoia_local.engines import Review
+        return Review(text=text, session_ref=self.session_ref, raw="{}")
+
+
+def review_with(register: str) -> str:
+    return f"## What works\nNothing notable.\n\n=== CLASS REGISTER ===\n{register}"
+
+
+MECHANIZED = (
+    "CLASS: every open state must be in the v2 open set\n"
+    "SEVERITY: MAJOR\n"
+    "PATTERN: NOT_IN_OPEN_SET\n"
+    "PATHSPEC: .\n"
+)
+
+
+def run_round(repo: Path, engine: FakeEngine, tmp_path: Path, **extra) -> str:
+    args = {"repo_path": str(repo), "base_ref": "main", "converge": True, **extra}
+    return handlers.critique_branch(args, engine=engine, log_dir=tmp_path / "logs")
+
+
+def state_root(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+# ── the known-positive this whole design exists to reproduce ──────────────────
+
+
+class TestThreeSiteIncident:
+    """A real three-site invariant across three commits, mirroring the observed loop:
+    round 7 finds site A, the fix closes A and leaves B and C, and so on. The mechanism
+    must register the class once and keep BLOCKING under the SAME id at every round."""
+
+    def test_one_class_id_blocks_across_all_three_rounds(self, repo: Path, tmp_path: Path) -> None:
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET_escalation\n",
+                      "b.py": "NOT_IN_OPEN_SET_progress\n",
+                      "c.py": "NOT_IN_OPEN_SET_unresolved\n"}, "three sites")
+
+        engine = FakeEngine(review_with(MECHANIZED))
+        first = run_round(repo, engine, tmp_path, round=7)
+        assert "CONVERGENCE: BLOCKED" in first
+        lineage = cc.load_lineage(state_root(tmp_path), _only_lineage(tmp_path), stamp="s")
+        cid = lineage.active()[0].class_id
+
+        # Round 8: the operator fixed only the site that was named.
+        commit(repo, {"a.py": "fixed = 1\n"}, "fix site A only")
+        second = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=8)
+        assert "CONVERGENCE: BLOCKED" in second and cid in second, (
+            "the class must survive under its original id, not be re-derived"
+        )
+
+        # Round 9: still one site left.
+        commit(repo, {"b.py": "fixed = 1\n"}, "fix site B only")
+        third = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=9)
+        assert "CONVERGENCE: BLOCKED" in third and cid in third
+
+        # Only when the last site goes does the class close.
+        commit(repo, {"c.py": "fixed = 1\n"}, "fix site C")
+        fourth = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=10)
+        assert "CONVERGENCE: NOT-BLOCKED" in fourth
+        assert "converged" not in fourth.lower()
+
+    def test_the_reviewer_is_shown_the_surviving_matches_next_round(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET here\n", "b.py": "NOT_IN_OPEN_SET too\n"}, "two")
+        run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
+        engine = FakeEngine(review_with("NONE"))
+        run_round(repo, engine, tmp_path, round=2)
+        prompt = engine.calls[0]
+        assert cc.UNCLOSED_HEADER in prompt
+        assert "a.py" in prompt and "b.py" in prompt
+        assert prompt.index("Already-raised") < prompt.index(cc.UNCLOSED_HEADER) \
+            if "Already-raised" in prompt else True
+
+
+def _only_lineage(tmp_path: Path) -> str:
+    files = list(cc.lineage_dir(tmp_path).glob("*.json"))
+    assert len(files) == 1, f"expected one lineage, got {files}"
+    return files[0].stem
+
+
+# ── register handling at the orchestration layer ──────────────────────────────
+
+
+class TestRegisterHandling:
+    def test_a_missing_register_is_retried_once_then_becomes_durable_debt(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        engine = FakeEngine("no register at all", "still no register")
+        out = run_round(repo, engine, tmp_path, round=1)
+        assert len(engine.resumed) == 1, "exactly one retry"
+        assert "register debt from round 1" in out
+
+        # Debt is durable: it survives into the next round's state, and clears on a good one.
+        lineage = cc.load_lineage(tmp_path, _only_lineage(tmp_path), stamp="s")
+        assert lineage.debt and lineage.debt["round"] == 1
+        out2 = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
+        assert "NOT-BLOCKED" in out2 and "register debt" not in out2
+
+    def test_a_successful_retry_is_used(self, repo: Path, tmp_path: Path) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        engine = FakeEngine("no register", review_with(MECHANIZED))
+        out = run_round(repo, engine, tmp_path, round=1)
+        assert "parsed after retry" in out
+
+    def test_no_session_ref_skips_the_retry_and_keeps_the_review(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """Claude's supported non-JSON fallback has no session; retrying would raise and
+        replace the paid review with an error."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        engine = FakeEngine("no register", session_ref=None)
+        out = run_round(repo, engine, tmp_path, round=1)
+        assert engine.resumed == []
+        assert "no register" in out, "the paid review text must still be returned"
+        assert "CONVERGENCE: BLOCKED" in out
+
+    def test_a_rejected_register_applies_none_of_its_records(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """A valid CLOSED followed by an invalid record must not leave the CLOSED applied."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with(
+            "CLASS: a semantic invariant\nSEVERITY: MAJOR\nPROCEDURE: read every caller\n"
+        )), tmp_path, round=1)
+        lin_id = _only_lineage(tmp_path)
+        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+
+        out = run_round(repo, FakeEngine(
+            review_with(f"CLOSED: {cid}\n\nCLOSED: deadbeef\n"),
+            review_with(f"CLOSED: {cid}\n\nCLOSED: deadbeef\n"),
+        ), tmp_path, round=2)
+        assert "CONVERGENCE: BLOCKED" in out
+        after = cc.load_lineage(tmp_path, lin_id, stamp="s")
+        assert after.classes[cid].status == cc.OPEN, (
+            "the valid CLOSED rode in on a register that was rejected"
+        )
+
+
+# ── failure paths ─────────────────────────────────────────────────────────────
+
+
+class TestFailurePaths:
+    def test_a_failed_review_leaves_lineage_state_byte_identical(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET\n"}, "c")
+        run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
+        path = cc.lineage_dir(tmp_path) / f"{_only_lineage(tmp_path)}.json"
+        before = path.read_bytes()
+
+        class Failing(FakeEngine):
+            def run(self, *a, **kw):
+                from paranoia_local.engines import Review
+                return Review(text="boom", session_ref=None, raw="", returncode=1, error=True)
+
+        out = run_round(repo, Failing(), tmp_path, round=2)
+        assert path.read_bytes() == before, "a failed review must not mutate durable state"
+        assert "CONVERGENCE: BLOCKED" in out and "review failed" in out
+
+    def test_the_pending_latch_is_released_on_a_normal_round(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        assert not list(cc.lineage_dir(tmp_path).glob("*.pending"))
+
+    def test_a_stranded_latch_blocks_the_next_round_rather_than_starting_empty(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        cc.open_latch(tmp_path, _only_lineage(tmp_path))
+        out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
+        assert "STATE-UNAVAILABLE" in out and "CONVERGENCE: BLOCKED" in out
+
+    def test_state_is_written_under_the_injected_log_dir_not_the_real_home(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        assert list(cc.lineage_dir(tmp_path).glob("*.json")), (
+            "tests must not write lineages into the operator's ~/.paranoia"
+        )
+
+
+# ── argument handling ─────────────────────────────────────────────────────────
+
+
+class TestArguments:
+    def test_a_dirty_review_rejects_an_explicit_head_ref(self, repo: Path, tmp_path: Path) -> None:
+        """resolve_target discards head_ref for a dirty review, so accepting it would key
+        this round's classes to a branch that was never reviewed."""
+        (repo / "dirty.py").write_text("x = 1\n")
+        with pytest.raises(ValueError, match="would not be the reviewed ref"):
+            run_round(repo, FakeEngine(review_with("NONE")), tmp_path,
+                      include_uncommitted=True, head_ref="feature")
+
+    def test_a_dirty_review_without_head_ref_works_and_keys_on_the_checkout(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        (repo / "dirty.py").write_text("x = 1\n")
+        out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, include_uncommitted=True)
+        assert "LINEAGE:" in out
+
+    def test_two_branches_off_one_base_get_different_lineages(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "on feature")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        git(["checkout", "-q", "-b", "other", "main"], repo)
+        commit(repo, {"b.py": "y = 1\n"}, "on other")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        assert len(list(cc.lineage_dir(tmp_path).glob("*.json"))) == 2
+
+    def test_class_closure_false_emits_no_trailer_at_all(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        out = run_round(repo, FakeEngine("## What works\nok"), tmp_path, class_closure=False)
+        assert "CONVERGENCE:" not in out and "LINEAGE:" not in out
+        assert not cc.lineage_dir(tmp_path).exists()
+
+    def test_an_exemption_subtracts_a_match_and_is_shown_for_challenge(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET here\n"}, "c")
+        run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
+        lin_id = _only_lineage(tmp_path)
+        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+
+        engine = FakeEngine(review_with("NONE"))
+        out = run_round(repo, engine, tmp_path, round=2, exempt=[
+            {"class_id": cid, "path": "a.py", "line": 1, "line_text": "NOT_IN_OPEN_SET here"},
+        ])
+        assert "CONVERGENCE: NOT-BLOCKED" in out
+        assert cc.EXEMPT_HEADER in engine.calls[0], "exemptions must be shown for challenge"
+
+
+class TestTrailerIntegration:
+    def test_a_class_registered_this_round_is_swept_before_the_verdict(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """Round 10's FATAL: a new MAJOR class and NOT-BLOCKED could ship together."""
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET\n"}, "c")
+        out = run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
+        assert "CONVERGENCE: BLOCKED" in out
+        assert "unchecked" not in out, "the new class must be evaluated, not left unchecked"
+
+    def test_a_predicate_that_closes_in_its_own_round_is_flagged(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """A too-narrow regex is the one predicate failure nothing can detect, so the
+        trailer says so rather than presenting an ordinary closed class."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        out = run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
+        assert "CLASS-CLOSURE-WARNING" in out and "closed in the round it was registered" in out
+
+    def test_base_id_and_head_id_are_recorded_in_the_audit_log(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """The plan's own acceptance replay was impossible because these were never logged."""
+        import json
+
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        record = json.loads(next((tmp_path / "logs").glob("*.json")).read_text())
+        assert len(record["base_id"]) == 40 and len(record["head_id"]) == 40

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -184,6 +184,43 @@ class TestRegisterHandling:
         record = json.loads(next((tmp_path / "logs").glob("*.json")).read_text())
         assert "NOT_IN_OPEN_SET" in (record.get("retry_register") or "")
 
+    def test_a_semantic_register_error_also_earns_the_retry(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """Round 7's MAJOR: only syntactic failures earned a retry, so an unknown class id
+        or a repeated transition — usually a reviewer typo — cost a whole extra round."""
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET\n"}, "c")
+        engine = FakeEngine(
+            review_with("CLOSED: deadbeef\n"),   # semantically invalid: unknown id
+            review_with(MECHANIZED),              # the retry gets it right
+        )
+        out = run_round(repo, engine, tmp_path, round=1)
+        assert len(engine.resumed) == 1, "a semantic error must be retried, not banked as debt"
+        assert "unknown class id" in engine.resumed[0], (
+            "the retry must say what was actually wrong, or the reviewer resends the same block"
+        )
+        assert "parsed after retry" in out and "register debt" not in out
+
+    def test_a_semantic_error_applies_none_of_the_register_before_retrying(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with(
+            "CLASS: a semantic invariant\nSEVERITY: MAJOR\nPROCEDURE: read every caller\n"
+        )), tmp_path, round=1)
+        lin_id = _only_lineage(tmp_path)
+        cid = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s").active()[0].class_id
+
+        # A valid CLOSED followed by an unknown id: the whole register is rejected, retried,
+        # and the retry's NONE must leave the class open.
+        engine = FakeEngine(
+            review_with(f"CLOSED: {cid}\n\nCLOSED: deadbeef\n"),
+            review_with("NONE"),
+        )
+        run_round(repo, engine, tmp_path, round=2)
+        after = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s")
+        assert after.classes[cid].status == cc.OPEN
+
     def test_no_session_ref_skips_the_retry_and_keeps_the_review(
         self, repo: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -286,6 +286,45 @@ class TestFailurePaths:
         out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
         assert "CONVERGENCE: NOT-BLOCKED" in out
 
+    def test_an_unwritable_latch_blocks_but_still_returns_the_review(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """A storage fault must never prevent the review running or discard its text."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        d = cc.lineage_dir(state_root(tmp_path))
+        d.mkdir(parents=True)
+        d.chmod(0o500)  # readable, not writable
+        try:
+            out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+        finally:
+            d.chmod(0o700)
+        assert "STATE-UNAVAILABLE" in out and "CONVERGENCE: BLOCKED" in out
+        assert "Nothing notable" in out, "the paid review text must survive"
+
+    def test_an_unremovable_latch_does_not_destroy_the_review(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """An un-removable latch leaves the next round STATE-UNAVAILABLE, which is the
+        fail-closed outcome it exists for — but it must not cost this round's review."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        real_clear = cc.clear_latch
+        calls: list[str] = []
+
+        def boom(root: Path, lineage_id: str) -> None:
+            calls.append(lineage_id)
+            raise OSError("read-only filesystem")
+
+        try:
+            cc.clear_latch = lambda *a, **kw: real_clear(*a, **kw)
+            out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+            assert "CONVERGENCE: NOT-BLOCKED" in out
+        finally:
+            cc.clear_latch = real_clear
+        # And the unlink failure itself is swallowed rather than raised:
+        latch = cc.lineage_dir(state_root(tmp_path)) / "nonexistent.pending"
+        cc.clear_latch(state_root(tmp_path), "nonexistent")  # must not raise
+        assert not latch.exists()
+
     def test_the_pending_latch_is_released_on_a_normal_round(
         self, repo: Path, tmp_path: Path
     ) -> None:

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -265,6 +265,9 @@ class TestFailurePaths:
             "a failed retry's parseable CLOSED must not be applied"
         )
         assert after.debt, "the round is register debt, not a silent success"
+        assert "supplied on retry" not in out, (
+            "a retry that was rejected must not be presented as what the round applied"
+        )
 
     def test_an_exception_after_prepare_does_not_strand_the_latch(
         self, repo: Path, tmp_path: Path
@@ -332,6 +335,16 @@ class TestFailurePaths:
 
 
 class TestArguments:
+    def test_the_legacy_non_converge_path_still_accepts_a_dirty_head_ref(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """Class closure never runs on the legacy path, so its argument rule must not
+        reach back and break a review that was valid before this feature existed."""
+        (repo / "dirty.py").write_text("x = 1\n")
+        out = run_round(repo, FakeEngine("## What works\nok"), tmp_path,
+                        converge=False, include_uncommitted=True, head_ref="feature")
+        assert "CONVERGENCE:" not in out
+
     def test_a_dirty_review_rejects_an_explicit_head_ref(self, repo: Path, tmp_path: Path) -> None:
         """resolve_target discards head_ref for a dirty review, so accepting it would key
         this round's classes to a branch that was never reviewed."""
@@ -378,7 +391,13 @@ class TestArguments:
             {"class_id": cid, "path": "a.py", "line": 1, "line_text": "NOT_IN_OPEN_SET here"},
         ])
         assert "CONVERGENCE: NOT-BLOCKED" in out
-        assert cc.EXEMPT_HEADER in engine.calls[0], "exemptions must be shown for challenge"
+        block = engine.calls[0]
+        assert cc.EXEMPT_HEADER in block, "exemptions must be shown for challenge"
+        # Once an exemption removes the last survivor the class closes and its unclosed
+        # block disappears, so this block is the ONLY place the reviewer can learn what the
+        # exempted line is alleged to violate. A bare path:line is unchallengeable.
+        assert "every open state must be in the v2 open set" in block
+        assert "NOT_IN_OPEN_SET" in block, "the predicate must travel with the exemption"
 
 
 class TestTrailerIntegration:

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -88,7 +88,9 @@ def run_round(repo: Path, engine: FakeEngine, tmp_path: Path, **extra) -> str:
 
 
 def state_root(tmp_path: Path) -> Path:
-    return tmp_path
+    """Matches the autouse isolation fixture in conftest: lineage state deliberately does
+    NOT follow log_dir, so tests must look where the env override actually points."""
+    return tmp_path / "state"
 
 
 # ── the known-positive this whole design exists to reproduce ──────────────────
@@ -143,7 +145,7 @@ class TestThreeSiteIncident:
 
 
 def _only_lineage(tmp_path: Path) -> str:
-    files = list(cc.lineage_dir(tmp_path).glob("*.json"))
+    files = list(cc.lineage_dir(state_root(tmp_path)).glob("*.json"))
     assert len(files) == 1, f"expected one lineage, got {files}"
     return files[0].stem
 
@@ -162,16 +164,25 @@ class TestRegisterHandling:
         assert "register debt from round 1" in out
 
         # Debt is durable: it survives into the next round's state, and clears on a good one.
-        lineage = cc.load_lineage(tmp_path, _only_lineage(tmp_path), stamp="s")
+        lineage = cc.load_lineage(state_root(tmp_path), _only_lineage(tmp_path), stamp="s")
         assert lineage.debt and lineage.debt["round"] == 1
         out2 = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
         assert "NOT-BLOCKED" in out2 and "register debt" not in out2
 
-    def test_a_successful_retry_is_used(self, repo: Path, tmp_path: Path) -> None:
+    def test_a_successful_retry_is_used_and_is_visible_to_the_operator(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """The retry's register is what actually changed durable state; showing only the
+        malformed original would hide the transition that took effect."""
+        import json
+
         commit(repo, {"a.py": "x = 1\n"}, "c")
         engine = FakeEngine("no register", review_with(MECHANIZED))
         out = run_round(repo, engine, tmp_path, round=1)
         assert "parsed after retry" in out
+        assert "supplied on retry" in out and "NOT_IN_OPEN_SET" in out
+        record = json.loads(next((tmp_path / "logs").glob("*.json")).read_text())
+        assert "NOT_IN_OPEN_SET" in (record.get("retry_register") or "")
 
     def test_no_session_ref_skips_the_retry_and_keeps_the_review(
         self, repo: Path, tmp_path: Path
@@ -194,14 +205,14 @@ class TestRegisterHandling:
             "CLASS: a semantic invariant\nSEVERITY: MAJOR\nPROCEDURE: read every caller\n"
         )), tmp_path, round=1)
         lin_id = _only_lineage(tmp_path)
-        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+        cid = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s").active()[0].class_id
 
         out = run_round(repo, FakeEngine(
             review_with(f"CLOSED: {cid}\n\nCLOSED: deadbeef\n"),
             review_with(f"CLOSED: {cid}\n\nCLOSED: deadbeef\n"),
         ), tmp_path, round=2)
         assert "CONVERGENCE: BLOCKED" in out
-        after = cc.load_lineage(tmp_path, lin_id, stamp="s")
+        after = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s")
         assert after.classes[cid].status == cc.OPEN, (
             "the valid CLOSED rode in on a register that was rejected"
         )
@@ -216,7 +227,7 @@ class TestFailurePaths:
     ) -> None:
         commit(repo, {"a.py": "NOT_IN_OPEN_SET\n"}, "c")
         run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
-        path = cc.lineage_dir(tmp_path) / f"{_only_lineage(tmp_path)}.json"
+        path = cc.lineage_dir(state_root(tmp_path)) / f"{_only_lineage(tmp_path)}.json"
         before = path.read_bytes()
 
         class Failing(FakeEngine):
@@ -238,7 +249,7 @@ class TestFailurePaths:
             "CLASS: a semantic invariant\nSEVERITY: MAJOR\nPROCEDURE: read every caller\n"
         )), tmp_path, round=1)
         lin_id = _only_lineage(tmp_path)
-        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+        cid = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s").active()[0].class_id
 
         class FailingRetry(FakeEngine):
             def resume(self, *a, **kw):
@@ -249,7 +260,7 @@ class TestFailurePaths:
 
         out = run_round(repo, FailingRetry("no register"), tmp_path, round=2)
         assert "CONVERGENCE: BLOCKED" in out
-        after = cc.load_lineage(tmp_path, lin_id, stamp="s")
+        after = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s")
         assert after.classes[cid].status == cc.OPEN, (
             "a failed retry's parseable CLOSED must not be applied"
         )
@@ -268,7 +279,7 @@ class TestFailurePaths:
 
         with pytest.raises(RuntimeError, match="engine blew up"):
             run_round(repo, Exploding(), tmp_path, round=1)
-        assert not list(cc.lineage_dir(tmp_path).glob("*.pending"))
+        assert not list(cc.lineage_dir(state_root(tmp_path)).glob("*.pending"))
         out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
         assert "CONVERGENCE: NOT-BLOCKED" in out
 
@@ -277,25 +288,44 @@ class TestFailurePaths:
     ) -> None:
         commit(repo, {"a.py": "x = 1\n"}, "c")
         run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
-        assert not list(cc.lineage_dir(tmp_path).glob("*.pending"))
+        assert not list(cc.lineage_dir(state_root(tmp_path)).glob("*.pending"))
 
     def test_a_stranded_latch_blocks_the_next_round_rather_than_starting_empty(
         self, repo: Path, tmp_path: Path
     ) -> None:
         commit(repo, {"a.py": "x = 1\n"}, "c")
         run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
-        cc.open_latch(tmp_path, _only_lineage(tmp_path))
+        cc.open_latch(state_root(tmp_path), _only_lineage(tmp_path))
         out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
         assert "STATE-UNAVAILABLE" in out and "CONVERGENCE: BLOCKED" in out
 
-    def test_state_is_written_under_the_injected_log_dir_not_the_real_home(
+    def test_state_is_written_under_the_state_root_not_the_real_home(
         self, repo: Path, tmp_path: Path
     ) -> None:
         commit(repo, {"a.py": "x = 1\n"}, "c")
         run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
-        assert list(cc.lineage_dir(tmp_path).glob("*.json")), (
+        assert list(cc.lineage_dir(state_root(tmp_path)).glob("*.json")), (
             "tests must not write lineages into the operator's ~/.paranoia"
         )
+
+    def test_moving_the_audit_log_dir_does_not_start_a_fresh_lineage(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """`--log-dir` is documented as the AUDIT-LOG directory. Deriving state from it
+        meant an operator who moved their logs silently got an empty lineage and could be
+        told NOT-BLOCKED with classes still open."""
+        commit(repo, {"a.py": "NOT_IN_OPEN_SET\n"}, "c")
+        first = handlers.critique_branch(
+            {"repo_path": str(repo), "base_ref": "main", "converge": True, "round": 1},
+            engine=FakeEngine(review_with(MECHANIZED)), log_dir=tmp_path / "logs-a")
+        assert "CONVERGENCE: BLOCKED" in first
+        second = handlers.critique_branch(
+            {"repo_path": str(repo), "base_ref": "main", "converge": True, "round": 2},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs-b")
+        assert "CONVERGENCE: BLOCKED" in second, (
+            "the class must survive a change of audit-log directory"
+        )
+        assert len(list(cc.lineage_dir(state_root(tmp_path)).glob("*.json"))) == 1
 
 
 # ── argument handling ─────────────────────────────────────────────────────────
@@ -325,7 +355,7 @@ class TestArguments:
         git(["checkout", "-q", "-b", "other", "main"], repo)
         commit(repo, {"b.py": "y = 1\n"}, "on other")
         run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
-        assert len(list(cc.lineage_dir(tmp_path).glob("*.json"))) == 2
+        assert len(list(cc.lineage_dir(state_root(tmp_path)).glob("*.json"))) == 2
 
     def test_class_closure_false_emits_no_trailer_at_all(
         self, repo: Path, tmp_path: Path
@@ -333,7 +363,7 @@ class TestArguments:
         commit(repo, {"a.py": "x = 1\n"}, "c")
         out = run_round(repo, FakeEngine("## What works\nok"), tmp_path, class_closure=False)
         assert "CONVERGENCE:" not in out and "LINEAGE:" not in out
-        assert not cc.lineage_dir(tmp_path).exists()
+        assert not cc.lineage_dir(state_root(tmp_path)).exists()
 
     def test_an_exemption_subtracts_a_match_and_is_shown_for_challenge(
         self, repo: Path, tmp_path: Path
@@ -341,7 +371,7 @@ class TestArguments:
         commit(repo, {"a.py": "NOT_IN_OPEN_SET here\n"}, "c")
         run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
         lin_id = _only_lineage(tmp_path)
-        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+        cid = cc.load_lineage(state_root(tmp_path), lin_id, stamp="s").active()[0].class_id
 
         engine = FakeEngine(review_with("NONE"))
         out = run_round(repo, engine, tmp_path, round=2, exempt=[

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -228,6 +228,50 @@ class TestFailurePaths:
         assert path.read_bytes() == before, "a failed review must not mutate durable state"
         assert "CONVERGENCE: BLOCKED" in out and "review failed" in out
 
+    def test_a_failed_retry_is_not_trusted_and_leaves_state_unchanged(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """Round 2's BLOCKER: a failed CLI still returns text, and that text can contain a
+        parseable NONE or CLOSED block."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        run_round(repo, FakeEngine(review_with(
+            "CLASS: a semantic invariant\nSEVERITY: MAJOR\nPROCEDURE: read every caller\n"
+        )), tmp_path, round=1)
+        lin_id = _only_lineage(tmp_path)
+        cid = cc.load_lineage(tmp_path, lin_id, stamp="s").active()[0].class_id
+
+        class FailingRetry(FakeEngine):
+            def resume(self, *a, **kw):
+                from paranoia_local.engines import Review
+                self.resumed.append("x")
+                return Review(text=f"=== CLASS REGISTER ===\nCLOSED: {cid}\n",
+                              session_ref="sess", raw="", returncode=1, error=True)
+
+        out = run_round(repo, FailingRetry("no register"), tmp_path, round=2)
+        assert "CONVERGENCE: BLOCKED" in out
+        after = cc.load_lineage(tmp_path, lin_id, stamp="s")
+        assert after.classes[cid].status == cc.OPEN, (
+            "a failed retry's parseable CLOSED must not be applied"
+        )
+        assert after.debt, "the round is register debt, not a silent success"
+
+    def test_an_exception_after_prepare_does_not_strand_the_latch(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        """A stranded latch would make every later round STATE-UNAVAILABLE over a fault the
+        caller has already been told about."""
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+
+        class Exploding(FakeEngine):
+            def run(self, *a, **kw):
+                raise RuntimeError("engine blew up")
+
+        with pytest.raises(RuntimeError, match="engine blew up"):
+            run_round(repo, Exploding(), tmp_path, round=1)
+        assert not list(cc.lineage_dir(tmp_path).glob("*.pending"))
+        out = run_round(repo, FakeEngine(review_with("NONE")), tmp_path, round=2)
+        assert "CONVERGENCE: NOT-BLOCKED" in out
+
     def test_the_pending_latch_is_released_on_a_normal_round(
         self, repo: Path, tmp_path: Path
     ) -> None:
@@ -325,6 +369,20 @@ class TestTrailerIntegration:
         commit(repo, {"a.py": "x = 1\n"}, "c")
         out = run_round(repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
         assert "CLASS-CLOSURE-WARNING" in out and "closed in the round it was registered" in out
+
+    def test_an_empty_register_reads_as_NONE_not_parsed_zero(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        assert "CLASS-REGISTER: NONE" in run_round(
+            repo, FakeEngine(review_with("NONE")), tmp_path, round=1)
+
+    def test_an_accepted_register_reports_its_record_count(
+        self, repo: Path, tmp_path: Path
+    ) -> None:
+        commit(repo, {"a.py": "x = 1\n"}, "c")
+        assert "CLASS-REGISTER: parsed 1" in run_round(
+            repo, FakeEngine(review_with(MECHANIZED)), tmp_path, round=1)
 
     def test_base_id_and_head_id_are_recorded_in_the_audit_log(
         self, repo: Path, tmp_path: Path


### PR DESCRIPTION
## The defect

A real ten-round `critique_branch` loop against Parallax produced findings per round of
7 → 9 → 5 → 2 → 2 → 2 → 3 → 2 → 1. Rounds 7, 8 and 9 were **the same defect three times** —
one incomplete predicate, found at three different sites, fixed three times instance-shaped.

The operator wasn't being careless. The protocol gave the class nowhere to live: findings are
`file:line` shaped, `already_raised` tells the reviewer not to look there again, and the
round-3 severity floor meters the leak to one instance per round. Nothing linked round 9 to
round 7.

## The mechanism

The reviewer ends its review with a **class register**: per defect class, the invariant, a
severity, and a **regex matching violations only** (or a `PROCEDURE` when no regex can express
it). The server then re-runs every registered predicate itself each round, injects surviving
matches into the next packet *after* `already_raised` and with precedence over it, and computes
the verdict in Python:

```
LINEAGE: 9f2c1a4b0e77 (rounds recorded: 8)
CLASS-REGISTER: parsed 1
CLASS-CLOSURE: 1 open, 2 closed, 3 surviving matches, 0 exempt, 1 unmechanized
CONVERGENCE: BLOCKED — 1 class(es) unclosed:
  3f2a91c4 every open state must be in the v2 open set (mechanized: 3 match(es))
```

Closure is exactly zero matches; a closed class reopens the moment it matches again. Only
`BLOCKER`/`MAJOR` classes block, so the mechanism can't trap the operator on a marginal finding.

## What it deliberately does not do

It guarantees durability for a class the reviewer **registers**. Nine plan-review rounds were
spent trying to make the prose provably account for every class it described, and round 9
established the goal is unreachable in principle — a reviewer that finds a class and doesn't
register it is indistinguishable from one that never found it. So nothing in the review's prose
is parsed at all, and `NOT-BLOCKED` says only "no blocking class is unclosed", never that the
change is correct.

## Review

Sixteen `critique_plan` rounds (14 FATALs) then eight `critique_branch` rounds against the
implementation (2 BLOCKER, 20 MAJOR, 6 MINOR, 6 gaps), all codex, converged at round 8. Every
finding accepted.

Two things worth recording. **Eleven of the fourteen plan FATALs were introduced by fixes to
earlier findings**, and two mechanisms each accounted for three of them in three different
spellings — the exact failure this feature exists to catch, occurring inside its own brief.
And **every fix that finally held removed mechanism rather than adding it**: the adjudication
layer, dedup, the recurrence grammar, and finally prose parsing entirely.

The most consequential code-review finding: the closure budget was a wall-clock deadline opened
before the multi-minute reviewer call, so the post-register sweep always found it spent and
every newly registered class would have been left `unchecked` — defeating same-round evaluation
outright. It now charges git-grep time only.

## Tests

490 pass. 68 new, each naming the review round whose finding it pins, including a three-commit
fixture reproducing the original round-7/8/9 incident: one class id must block at rounds 8 and 9
and only close when the last site goes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)