### PR TITLE
Make the convergence machinery mandatory, with one explicit one-shot escape

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ agent reviewer is:
 | Tool | What it does |
 |---|---|
 | `critique_branch` | Adversarial review of a git branch/diff or the dirty working tree. Five-section critique (What works / doesn't / Risks / Gaps / Improvements) with `[BLOCKER]`/`[MAJOR]`/`[MINOR]`/`[OUT-OF-SCOPE]` tags. |
-| `critique_plan` | Adversarial review of a plan or design doc. With `repo_path`, the reviewer reads the real code to test the plan's premises about current behaviour — a plan built on an inverted premise is the most dangerous kind. |
+| `critique_plan` | Adversarial review of a plan or design doc. `repo_path` is **required**: the reviewer reads the real code to test the plan's premises about current behaviour — a plan built on an inverted premise is the most dangerous kind, and an ungrounded review cannot catch one. |
 | `query` | A quick double-check of a single fact or point. Not a full review — lower reasoning effort, a direct answer with citations and a stated confidence level. |
 | `rebut` | Dispute a specific finding. Resumes the **same** reviewer session with your counter-evidence; it concedes or holds with fresh citations. Cheaper and higher-resolution than a cold re-round. |
 | `arbitrate` | Decide between 2–4 options. **Both** engines choose independently and cold over one pinned snapshot; Python computes the verdict. See below. |

--- a/README.md
+++ b/README.md
@@ -187,7 +187,16 @@ maximum paranoia and manufactures marginal/hardening findings for 20+ rounds):
   internal tool*, not a hostile/high-scale service. Set it **once per project in
   `.paranoia.toml`**; override per-call to tighten. This is the single highest-
   leverage lever against hardening scope-creep.
-- **`round`** — the 1-based loop round. **Increment it each cold round.** At
+
+  It stays **optional and never blocks** — the fallback is the safe reading, so a
+  gate here would refuse valid work to prevent a miscalibration you can simply be
+  shown. Instead, a review that resolved no stakes from either the call or
+  `.paranoia.toml` ends with a `STAKES: unstated` line. Pass `stakes: "unstated"`
+  to accept that reading deliberately, which calibrates the reviewer to one fixed
+  sentence and silences the line.
+- **`round`** — the 1-based loop round. **Required** whenever class closure is
+  tracking a loop, i.e. by default; the one escape is `class_closure: false`,
+  which is the explicit one-shot mode. **Increment it each cold round.** At
   `round >= 3` the reviewer reports only merge-blocking in-scope findings
   (`[MAJOR]` or higher for the review mode) and says `CONVERGED` — inside the
   five-section format — when none remain, which is how you *stop* the loop
@@ -319,10 +328,10 @@ The reviewer is told the exact grammar; you do not need to quote it.
 would discard every tracked class and then report `NOT-BLOCKED`, turning a storage
 fault into a false all-clear.
 
-#### Class closure for `critique_plan` — opt-in, and a weaker guarantee
+#### Class closure for `critique_plan` — on by default, and a weaker guarantee
 
-`critique_plan` takes `class_closure` too, but it is **off by default** and it is a
-**different, weaker mechanism**. Read this before relying on it.
+`critique_plan` takes `class_closure` too, **on by default** as for `critique_branch`,
+but it is a **different, weaker mechanism**. Read this before relying on it.
 
 There are **no regex predicates for a plan**, deliberately. Over source, editing the
 code until the pattern stops matching *is* the fix. Over a plan, editing the prose
@@ -345,10 +354,20 @@ and closed ones never block, so the mechanism cannot trap you.
 
 ```jsonc
 {
-  "plan_text": "…", "repo_path": "/path/to/repo", "round": 3,
-  "class_closure": true,
-  "lineage": "myproject-42-plan"   // REQUIRED, and mode-qualified
+  "plan_text": "…",
+  "repo_path": "/path/to/repo",     // REQUIRED — an ungrounded plan review
+                                    // cannot test the plan's premises
+  "round": 3,                       // REQUIRED while closure tracks the loop
+  "lineage": "myproject-42-plan"    // REQUIRED, and mode-qualified
 }
+```
+
+**One-shot reviews.** A design sketch with no convergence loop behind it takes
+`class_closure: false`. That is the single explicit escape, and it also drops the
+`round` requirement — there is no next round to apply a severity floor to:
+
+```jsonc
+{ "plan_text": "…", "repo_path": "/path/to/repo", "class_closure": false }
 ```
 
 **`lineage` is required and nothing is derived.** A plan has no branch to key state to,

--- a/README.md
+++ b/README.md
@@ -218,7 +218,7 @@ rather than growing the design to fix them.
   The stakes are wrong, not the code. Tighten `stakes` and re-run that round
   rather than folding what it raised.
 
-### Class closure (`class_closure`, **on by default** for `critique_branch`; opt-in and weaker for `critique_plan`)
+### Class closure (`class_closure`, **on by default** for both critiques; weaker for `critique_plan`)
 
 A convergence loop that reports one instance of a defect per round can run for ten
 rounds while a single invariant stays violated — each round the operator fixes the
@@ -260,9 +260,14 @@ says only "no blocking class is unclosed", never that the change is correct.
 
 #### Working the loop
 
-**You do nothing to turn this on for `critique_branch`.** (For `critique_plan` it is
-opt-in and needs an explicit `lineage` — see *Class closure for `critique_plan`*
-below.) Run `critique_branch` as before, incrementing
+**You do nothing to turn this on** — on either critique. What you must supply is
+`round` (1-based, incremented each cold round) and, for `critique_plan`, an explicit
+`lineage`; both are refused rather than defaulted, because a loop without a round has
+no severity floor and a plan without a lineage has no state to carry. The one escape
+is `class_closure: false`, the explicit one-shot mode, which also drops the `round`
+requirement. `converge: false` is NOT an escape: closure only runs on the converge
+path, so asking for both is refused rather than silently ungating the review. Run
+`critique_branch` as before, incrementing
 `round`. The only new thing you must do is *read the trailer instead of the review's
 own `CONVERGED`* — when the two disagree, the trailer governs and says so.
 

--- a/README.md
+++ b/README.md
@@ -414,8 +414,10 @@ rounds against the implementation:
 Each cold round otherwise re-gathers the same orientation — re-reading the touched
 files and re-running `git`, which measurements show dominates the per-round cost.
 `critique_branch` therefore runs in **convergence mode by default** (pass
-`converge: false`, or set it in `.paranoia.toml`, to fall back to the legacy in-place
-review). In convergence mode the server **pre-gathers a
+`converge: false` **together with** `class_closure: false`, or set both in
+`.paranoia.toml`, to fall back to the legacy in-place review — closure runs only on
+the converge path, so asking for one without the other is refused rather than
+silently ungating the review). In convergence mode the server **pre-gathers a
 deterministic evidence packet** (the contents of every touched file in the reviewed
 snapshot — binary/large files are marked rather than embedded — plus the diff) and
 hands it to the reviewer with a packet-aware prompt, so it verifies rather than
@@ -521,10 +523,15 @@ The agent calls:
     "repo_path": "/Users/you/Work/my-project",
     "base_ref": "main",
     "head_ref": "HEAD",
+    "round": 1,
     "diff_intent": "Add overdraft protection to withdraw()."
   }
 }
 ```
+
+`round` is required — class closure is on by default, and a loop without a round
+never reaches the severity floor that lets it stop. Pass `class_closure: false`
+for a genuine one-shot review, which is the one escape and drops the requirement.
 
 ## Per-repo defaults — `.paranoia.toml`
 

--- a/docs/class_closure_plan.md
+++ b/docs/class_closure_plan.md
@@ -731,8 +731,16 @@ converge is the default path, it already resolves an explicit snapshot id, and i
 is where the packet block is rendered. Extending to the legacy path is deferred,
 not impossible.
 
-**Out:** `critique_plan` (a plan has no code sites to enumerate), `query`,
+**Out:** `query`,
 `rebut`, and legacy non-converge `critique_branch`.
+
+*Superseded 2026-08-04: `critique_plan` is no longer out of scope. It gained
+UNMECHANIZED-ONLY class closure, on by default, with an explicit `lineage` — a regex
+over plan prose closes the moment the wording changes, which is a false closure rather
+than a fix, so the mechanized half deliberately did NOT transfer. Design:
+[`plan_class_closure_proposal.md`](plan_class_closure_proposal.md). The reason given
+here — "a plan has no code sites to enumerate" — was right about predicates and wrong
+about the register.*
 
 **Kill switch:** `class_closure` call arg / `.paranoia.toml` key, default `true`.
 It is the escape of last resort, not the escape of first resort — §2.3, §2.8 and

--- a/docs/plan_class_closure_proposal.md
+++ b/docs/plan_class_closure_proposal.md
@@ -313,7 +313,7 @@ rather than firing on the prescribed convention, which is what a fail-closed che
 is for. This is a documentation obligation and an acceptance fixture, not a
 mechanism.
 
-**This is also why plan closure must default OFF (§2.2)**, and the reason is now
+**This is also why plan closure defaulted OFF (§2.2 — superseded 2026-08-04; it now defaults ON and refuses a call with no lineage)**, and the reason is now
 stronger than revision 1's: with no derivable key at all, defaulting on would
 hard-error *every* existing plan call, not merely the `plan_text` ones. The
 dominant consumer passes `plan_text` regardless — in the incident session's
@@ -768,8 +768,8 @@ null placeholders or implement part of §2.1 out of order.* Split it:
    trailer rather than an exception; `FATAL` registering, blocking, and being
    `RECLASSIFY`-ed down to `MINOR` into `NOT-BLOCKED`; an open `MINOR` class at
    round ≥3 permitting prose `CONVERGED` **and** trailer `NOT-BLOCKED` together
-   (§2.3's second FATAL); `CLOSED` then `REOPEN`; `class_closure` default-off
-   writing no state at all; `.paranoia.toml` carrying `class_closure = true` having
+   (§2.3's second FATAL); `CLOSED` then `REOPEN`; `class_closure: false` (the one-shot mode,
+   superseding the default-off contract) writing no state at all, and needing no `round`; `.paranoia.toml` carrying `class_closure = true` having
    **no** effect on `critique_plan` (§2.2); a failed review leaving the lineage
    byte-identical (the branch rule at `handlers.py:509-515`); both directions of the
    §2.7 cross-mode refusal; and the never-reaches-`make_grep` contract from item 1.

--- a/docs/plan_class_closure_proposal.md
+++ b/docs/plan_class_closure_proposal.md
@@ -820,13 +820,18 @@ the §5 over-claim this proposal exists to prevent. The README section and the
 `critique_plan` schema descriptions in `server.py` are deliverables of this change,
 not documentation debt after it.
 
-**The consumer's operator rules.** *Round 1 [MAJOR] gap: because closure defaults
-off (§2.2), nothing makes a later seam turn it on — and
-`COMPLEX_DELIVERY_RUNBOOK.md:889-896` still tells the operator that on
-`critique_plan` the stop condition is "the triage half alone, since it has no
-trailer".* Shipping without changing that sentence ships a mechanism the documented
-procedure tells its only user to ignore. The runbook and `CLAUDE.md` must be
-updated in the same rollout to prescribe `class_closure: true`; one explicit
+**The consumer's operator rules.** *Round 1 [MAJOR] gap: `COMPLEX_DELIVERY_RUNBOOK.md:889-896`
+still tells the operator that on `critique_plan` the stop condition is "the triage half
+alone, since it has no trailer".* Shipping without changing that sentence ships a
+mechanism the documented procedure tells its only user to ignore.
+
+*Superseded in one respect 2026-08-04: this gap originally read "because closure
+defaults off, nothing makes a later seam turn it on". Closure now defaults ON, so
+nothing needs to turn it on — but the runbook edit is MORE urgent, not less, because a
+seam that omits `lineage` or `round` is now REFUSED rather than quietly ungated. The
+fourth recurrence of this documentation class was this very sentence.* The runbook and
+`CLAUDE.md` must be updated in the same rollout to state that plan closure is on by
+default and that a seam must supply `repo_path`, `round`, and one explicit
 `lineage` held across both vendor stages, named by the **mode-qualified** extension
 of the globally-unique convention the runbook already mandates
 (`parallax-<issue>-<card>-plan`, against the frozen seam's

--- a/docs/plan_class_closure_proposal.md
+++ b/docs/plan_class_closure_proposal.md
@@ -46,8 +46,11 @@ left a stale sentence in §2.7 asserting a derived plan key that §1.4 had just
 deleted.*
 
 **The short answer.** The unmechanized half of `class_closure` transfers to
-`critique_plan` essentially intact, and I verified it runs with no repository and
-no `git` call at all. The mechanized half must **not** transfer, and the argument
+`critique_plan` essentially intact, and I verified the mechanism itself needs no
+repository and makes no `git` call at all. *(Superseded 2026-08-04 in one respect:
+`critique_plan` now REQUIRES `repo_path` — not because closure needs it, but because
+an ungrounded plan review cannot test the plan's premises against the code, which is
+the reviewer's highest-value job. The closure mechanism remains repository-free.)* The mechanized half must **not** transfer, and the argument
 against it is not "a regex over prose false-positives" — it is worse than that: a
 predicate over plan prose **closes on a rewording**, and a rewording is precisely
 the failure mode this mechanism exists to catch. Evidence in §1.1.

--- a/docs/plan_class_closure_proposal.md
+++ b/docs/plan_class_closure_proposal.md
@@ -346,9 +346,20 @@ byte-identical (`handlers.py:509-515`).
 
 ### 2.2 Default **off**, and a call argument only — `.paranoia.toml` is not consulted
 
+> **SUPERSEDED 2026-08-04 by operator decision.** `class_closure` now defaults **true**
+> on `critique_plan`, and `round` is required on both critiques while closure tracks a
+> loop. The reasoning below for *why default-off was defensible* still stands; what
+> changed is the operator's judgement of the trade — the friction of one extra argument
+> is preferred to a convergence gate nobody remembers to switch on. `class_closure:
+> false` is now the single explicit one-shot mode, and it is also what drops the `round`
+> requirement. The call-argument-only rule below is UNCHANGED and now runs in both
+> directions: `.paranoia.toml` can neither enable nor disable the plan gate.
+
 Justified narrowly: the branch default was earned by a derivable key, and plans
 have none at all (§1.4). `class_closure: true` without a `lineage` is an error,
 never a silent skip — a mode that degrades quietly is how a gate stops existing.
+*(That last sentence is why the supersession above is coherent rather than a
+reversal: the error was always the design, and only the default moved.)*
 
 *Round 2 [MAJOR] risk: revision 2 left the interaction with repo configuration
 undefined, and both readings are wrong. `resolve()` is explicit arg → repo config →

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -18,7 +18,7 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
 
-from . import class_closure as cc
+from . import arbitration, class_closure as cc
 from . import logs, orientation, prompts
 from .config import load_repo_config, resolve
 from .engines import Engine, Review
@@ -72,6 +72,51 @@ def _footer(review: Review, engine: Engine) -> str:
 def _progress_kwargs(on_progress: Callable[[str], None] | None) -> dict[str, Any]:
     """Pass on_progress only when set — injected engines may predate the kwarg."""
     return {"on_progress": on_progress} if on_progress is not None else {}
+
+
+ONE_SHOT_HINT = "pass `class_closure: false` for a one-shot review"
+
+
+def _require_round(review_round: Any, closure_on: bool, tool: str) -> None:
+    """`round` is what makes a loop terminate: `_CALIBRATION`'s severity floor only exists
+    from round 3, so a loop driven without it reports at round-1 severity forever and has
+    no mechanical stopping pressure. Required whenever class closure is tracking a loop,
+    and deliberately NOT required in the one-shot mode, which has no next round to floor.
+    """
+    if closure_on and review_round is None:
+        raise ValueError(
+            f"{tool} needs `round` (1-based, incremented each cold round): without it the "
+            "reviewer never reaches the round-3 severity floor, so the loop has no "
+            f"terminating pressure. Pass round: 1 for a first round, or {ONE_SHOT_HINT}."
+        )
+
+
+STAKES_NOTICE = ("STAKES: unstated — the reviewer assumed a modest internal tool. Set "
+                 "`stakes` per call, or once for the project in .paranoia.toml; pass "
+                 "`stakes: \"unstated\"` to accept that reading deliberately and silence "
+                 "this line.")
+
+
+def _resolve_stakes(stakes: object) -> tuple[str | None, bool]:
+    """`arbitrate`'s trick, minus its requirement: the literal `unstated` is an EXPLICIT
+    acceptance of one fixed reading (`arbitration.STAKES_DEFAULT`, byte-identical on every
+    call) rather than an accidental omission, so it calibrates the reviewer AND silences
+    the notice. Returns (stakes_text, notice_needed).
+
+    Stakes stay optional here, unlike `arbitrate` where they gate a decision: the fallback
+    is the SAFE reading, so a gate would refuse valid work to prevent a miscalibration the
+    caller can simply be shown. Surfacing beats blocking (plan proposal §1.3).
+    """
+    text = str(stakes).strip() if stakes is not None else ""
+    if not text:
+        return None, True
+    if text.lower() == arbitration.STAKES_UNSTATED:
+        return arbitration.STAKES_DEFAULT, False
+    return text, False
+
+
+def _stakes_notice(needed: bool) -> str:
+    return f"\n\n{STAKES_NOTICE}" if needed else ""
 
 
 def _calibration(stakes: str | None, review_round: int | None) -> str | None:
@@ -148,10 +193,10 @@ def critique_branch(
     )
     # Calibration: STAKES (project-level, so also honoured from .paranoia.toml) bounds
     # scope; ROUND (per-call, raised each convergence round) sets the severity floor.
-    calibration = _calibration(
-        resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
-    )
+    stakes, no_stakes = _resolve_stakes(resolve("stakes", arguments.get("stakes"), cfg, None))
+    calibration = _calibration(stakes, arguments.get("round"))
     closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
+    _require_round(arguments.get("round"), closure_on, "critique_branch")
     if (converge and closure_on and include_unc
             and arguments.get("head_ref") not in (None, "HEAD")
             and not arguments.get("lineage")):
@@ -176,7 +221,7 @@ def critique_branch(
             log_dir=log_dir, now=now, on_progress=on_progress,
             closure_on=closure_on, closure_args=arguments,
             review_round=arguments.get("round"), include_unc=include_unc,
-        )
+        ) + _stakes_notice(no_stakes)
 
     packet = orientation.build_orientation(
         repo, target, project_summary, diff_intent, focus, already
@@ -194,7 +239,7 @@ def critique_branch(
     _log(log_dir, "critique_branch", engine, review, now,
          {"target": target.description, "model": model,
           "round": arguments.get("round"), "already_raised": already})
-    return _footer(review, engine)
+    return _footer(review, engine) + _stakes_notice(no_stakes)
 
 
 def _converge_branch_review(
@@ -352,23 +397,24 @@ def critique_plan(
     context = arguments.get("context")
     focus = arguments.get("focus")
     already = list(arguments.get("already_raised", []))
-    repo_path = arguments.get("repo_path")
-    repo = _require_repo(arguments) if repo_path else None
-    cwd = repo if repo else _no_repo_cwd()
-    cfg = load_repo_config(repo) if repo else {}
+    # Required, not "strongly recommended": PLAN_REVIEW_INSTRUCTIONS calls testing the
+    # plan's premises against the code the reviewer's single most valuable job, and an
+    # ungrounded plan review cannot do it. Every one of the 225 logged plan reviews
+    # passed a repo, so this refuses nothing anyone actually does.
+    repo = _require_repo(arguments)
+    cwd = repo
+    cfg = load_repo_config(repo)
 
     model = resolve("model", arguments.get("model"), cfg, engine.default_model)
     effort = resolve("effort", arguments.get("effort"), cfg, "high")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
 
-    calibration = _calibration(
-        resolve("stakes", arguments.get("stakes"), cfg, None), arguments.get("round")
-    )
-    # Call argument ONLY — `.paranoia.toml` is deliberately not consulted. A project that
-    # set `class_closure = true` for its branch reviews would otherwise turn plan closure
-    # on and hard-error every plan call that has no `lineage`; and a per-project setting
-    # could never suffice anyway, since the lineage is inherently per-seam.
-    closure_on = bool(arguments.get("class_closure", False))
+    stakes, no_stakes = _resolve_stakes(resolve("stakes", arguments.get("stakes"), cfg, None))
+    calibration = _calibration(stakes, arguments.get("round"))
+    # Call argument ONLY — `.paranoia.toml` is deliberately not consulted. A per-project
+    # setting could never suffice anyway, since the lineage is inherently per-seam, and
+    # sharing the branch key would give one name two meanings across two tools.
+    closure_on = bool(arguments.get("class_closure", True))
     lineage_id = arguments.get("lineage")
     if closure_on and not lineage_id:
         raise ValueError(
@@ -376,8 +422,9 @@ def critique_plan(
             "branch to key state to, and deriving one from the plan's text or path would "
             "mint a fresh empty lineage whenever either changed — reporting NOT-BLOCKED "
             "with every tracked class silently dropped. Pass a globally unique, "
-            "mode-qualified key (e.g. 'myproject-42-plan'), or class_closure: false."
+            f"mode-qualified key (e.g. 'myproject-42-plan'), or {ONE_SHOT_HINT}."
         )
+    _require_round(arguments.get("round"), closure_on, "critique_plan")
 
     closure = _PlanClassClosure(
         lineage_id, round_no=arguments.get("round") or 1,
@@ -419,7 +466,7 @@ def critique_plan(
         # (rejected) block alone would misreport the round.
         "retry_register": closure.retry_register if closure else None,
     })
-    body_text = _footer(review, engine)
+    body_text = _footer(review, engine) + _stakes_notice(no_stakes)
     if closure and closure.retry_register:
         body_text += ("\n\n---\n_The register below was supplied on retry and is what this "
                       f"round applied:_\n\n{closure.retry_register.strip()}")

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -86,8 +86,10 @@ def _require_converge(converge: bool, closure_on: bool) -> None:
     if closure_on and not converge:
         raise ValueError(
             "class closure runs only on the converge path, so `converge: false` would "
-            "silently disable it and return no CONVERGENCE trailer. Drop `converge: false` "
-            f"to keep the gate, or {ONE_SHOT_HINT} to review without one."
+            "silently disable it and return no CONVERGENCE trailer. Pass `converge: true` "
+            "to keep the gate — note `converge` also resolves from .paranoia.toml, so "
+            "removing a call argument may not be enough — or "
+            f"{ONE_SHOT_HINT} to review without one."
         )
 
 
@@ -97,16 +99,23 @@ def _require_round(review_round: Any, closure_on: bool, tool: str) -> None:
     no mechanical stopping pressure. Required whenever class closure is tracking a loop,
     and deliberately NOT required in the one-shot mode, which has no next round to floor.
     """
-    if not closure_on:
-        return
-    # `_calibration` renders ROUND only for an int >= 1, so 0, "3" and None are all the
-    # same thing to the reviewer — no floor — while only None looked like an omission.
+    if review_round is None:
+        # Omission is the one-shot mode's privilege: there is no next round to floor.
+        if not closure_on:
+            return
+    # A SUPPLIED round is checked in BOTH modes. `_calibration` renders ROUND only for an
+    # int >= 1, so 0 and "3" are the same thing to the reviewer as omitting it — no floor —
+    # and silently ignoring one the caller took the trouble to pass is how a loop believes
+    # it has a floor it never had.
     if not isinstance(review_round, int) or isinstance(review_round, bool) or review_round < 1:
+        # Only suggest the escape when it is not already taken — an error whose remedy the
+        # caller has already applied reads as a bug in the tool.
+        escape = f", or {ONE_SHOT_HINT}" if closure_on else ""
         raise ValueError(
             f"{tool} needs `round` as an integer >= 1 (incremented each cold round), got "
             f"{review_round!r}: any other value produces no ROUND line, so the reviewer "
             "never reaches the round-3 severity floor and the loop has no terminating "
-            f"pressure. Pass round: 1 for a first round, or {ONE_SHOT_HINT}."
+            f"pressure. Pass round: 1 for a first round{escape}."
         )
 
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -77,17 +77,36 @@ def _progress_kwargs(on_progress: Callable[[str], None] | None) -> dict[str, Any
 ONE_SHOT_HINT = "pass `class_closure: false` for a one-shot review"
 
 
+def _require_converge(converge: bool, closure_on: bool) -> None:
+    """Class closure runs ONLY on the converge path (`class_closure_plan.md` §3), so
+    `converge: false` silently disabled it while `round` was still demanded — a call that
+    looked gated, emitted no trailer, and let a reviewer's own `CONVERGED` end a loop with
+    a blocking class live. There must be exactly ONE escape, and it must be explicit.
+    """
+    if closure_on and not converge:
+        raise ValueError(
+            "class closure runs only on the converge path, so `converge: false` would "
+            "silently disable it and return no CONVERGENCE trailer. Drop `converge: false` "
+            f"to keep the gate, or {ONE_SHOT_HINT} to review without one."
+        )
+
+
 def _require_round(review_round: Any, closure_on: bool, tool: str) -> None:
     """`round` is what makes a loop terminate: `_CALIBRATION`'s severity floor only exists
     from round 3, so a loop driven without it reports at round-1 severity forever and has
     no mechanical stopping pressure. Required whenever class closure is tracking a loop,
     and deliberately NOT required in the one-shot mode, which has no next round to floor.
     """
-    if closure_on and review_round is None:
+    if not closure_on:
+        return
+    # `_calibration` renders ROUND only for an int >= 1, so 0, "3" and None are all the
+    # same thing to the reviewer — no floor — while only None looked like an omission.
+    if not isinstance(review_round, int) or isinstance(review_round, bool) or review_round < 1:
         raise ValueError(
-            f"{tool} needs `round` (1-based, incremented each cold round): without it the "
-            "reviewer never reaches the round-3 severity floor, so the loop has no "
-            f"terminating pressure. Pass round: 1 for a first round, or {ONE_SHOT_HINT}."
+            f"{tool} needs `round` as an integer >= 1 (incremented each cold round), got "
+            f"{review_round!r}: any other value produces no ROUND line, so the reviewer "
+            "never reaches the round-3 severity floor and the loop has no terminating "
+            f"pressure. Pass round: 1 for a first round, or {ONE_SHOT_HINT}."
         )
 
 
@@ -128,7 +147,7 @@ def _calibration(stakes: str | None, review_round: int | None) -> str | None:
     lines: list[str] = []
     if stakes:
         lines.append(f"STAKES: {stakes}")
-    if review_round is not None and review_round >= 1:
+    if isinstance(review_round, int) and not isinstance(review_round, bool) and review_round >= 1:
         lines.append(f"ROUND: {review_round}")
     if not lines:
         return None
@@ -193,10 +212,11 @@ def critique_branch(
     )
     # Calibration: STAKES (project-level, so also honoured from .paranoia.toml) bounds
     # scope; ROUND (per-call, raised each convergence round) sets the severity floor.
+    closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
+    _require_converge(converge, closure_on)
+    _require_round(arguments.get("round"), closure_on, "critique_branch")
     stakes, no_stakes = _resolve_stakes(resolve("stakes", arguments.get("stakes"), cfg, None))
     calibration = _calibration(stakes, arguments.get("round"))
-    closure_on = bool(resolve("class_closure", arguments.get("class_closure"), cfg, True))
-    _require_round(arguments.get("round"), closure_on, "critique_branch")
     if (converge and closure_on and include_unc
             and arguments.get("head_ref") not in (None, "HEAD")
             and not arguments.get("lineage")):
@@ -409,8 +429,6 @@ def critique_plan(
     effort = resolve("effort", arguments.get("effort"), cfg, "high")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
 
-    stakes, no_stakes = _resolve_stakes(resolve("stakes", arguments.get("stakes"), cfg, None))
-    calibration = _calibration(stakes, arguments.get("round"))
     # Call argument ONLY — `.paranoia.toml` is deliberately not consulted. A per-project
     # setting could never suffice anyway, since the lineage is inherently per-seam, and
     # sharing the branch key would give one name two meanings across two tools.
@@ -425,6 +443,8 @@ def critique_plan(
             f"mode-qualified key (e.g. 'myproject-42-plan'), or {ONE_SHOT_HINT}."
         )
     _require_round(arguments.get("round"), closure_on, "critique_plan")
+    stakes, no_stakes = _resolve_stakes(resolve("stakes", arguments.get("stakes"), cfg, None))
+    calibration = _calibration(stakes, arguments.get("round"))
 
     closure = _PlanClassClosure(
         lineage_id, round_no=arguments.get("round") or 1,

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -73,13 +73,15 @@ _ROUND = {
     "type": "integer",
     "minimum": 1,
     "description": (
+        "REQUIRED unless you pass class_closure: false (the one-shot mode). "
         "Convergence-loop round number (1-based). Increment it on each cold review round you run. "
         "At round >=3 the reviewer restricts itself to merge-blocking in-scope findings — MAJOR "
         "or higher ([BLOCKER]/[MAJOR] for code review, [FATAL]/[MAJOR] for plan review) — and "
         "withholds [MINOR] and [OUT-OF-SCOPE], declaring 'CONVERGED' when none remain. This is "
         "the lever to STOP a loop instead of chasing marginal/hardening findings across many "
-        "rounds. Start at 1 and raise as the design stabilises; omit to report at all severities "
-        "(round-1 behaviour)."
+        "rounds. Start at 1 and raise as the design stabilises. It is required while class "
+        "closure is tracking a loop because without it the reviewer never reaches the "
+        "round-3 floor, so the loop has no terminating pressure at all."
     ),
 }
 
@@ -196,10 +198,10 @@ TOOLS: list[Tool] = [
         inputSchema={
             "type": "object",
             "properties": {
-                "plan_text": {"type": "string", "description": "The plan as markdown. Provide this OR plan_path."},
-                "plan_path": {"type": "string", "description": "Absolute path to a markdown plan file. Provide this OR plan_text."},
+                "plan_text": {"type": "string", "description": "The plan as markdown. Provide this OR plan_path, never both."},
+                "plan_path": {"type": "string", "description": "Absolute path to a markdown plan file. Provide this OR plan_text, never both."},
                 "context": {"type": "string", "description": "Background the reviewer needs to judge the plan fairly."},
-                "repo_path": {"type": "string", "description": "Repo the plan concerns — enables grounding the critique in real code (strongly recommended)."},
+                "repo_path": {"type": "string", "description": "REQUIRED. The repo the plan concerns. Testing the plan's premises against the real code is the reviewer's highest-value job — a plan that asserts 'X currently does Y' when the code shows otherwise is the most dangerous kind — and an ungrounded review cannot do it."},
                 "focus": {"type": "string", "description": "Narrow the review to a specific concern."},
                 "already_raised": _ALREADY_RAISED,
                 "stakes": _STAKES,
@@ -207,8 +209,11 @@ TOOLS: list[Tool] = [
                 "class_closure": {
                     "type": "boolean",
                     "description": (
-                        "Track defect CLASSES across plan rounds (default FALSE — opt in, "
-                        "unlike critique_branch). Requires `lineage`. The reviewer registers "
+                        "Track defect CLASSES across plan rounds (default TRUE, as for "
+                        "critique_branch). Requires `lineage` and `round`. Pass FALSE for a "
+                        "ONE-SHOT review — a design sketch with no convergence loop behind "
+                        "it — which is the single explicit escape and also drops the `round` "
+                        "requirement. The reviewer registers "
                         "each class with a PROCEDURE (never a regex: over prose a predicate "
                         "would close the moment the wording changed, which is what a rewrite "
                         "that keeps the defect looks like). Every later round is shown the "
@@ -218,13 +223,15 @@ TOOLS: list[Tool] = [
                         "OUT-OF-SCOPE ones are tracked, advisory, and never block. The "
                         "guarantee is non-forgetting plus explicit closure — NOT the "
                         "git-backed recurrence detection critique_branch gets. This is a "
-                        "call argument only; .paranoia.toml is not consulted for it."
+                        "call argument only; .paranoia.toml is not consulted for it, in "
+                        "either direction, so a project's branch-review setting can neither "
+                        "enable nor disable the plan gate."
                     ),
                 },
                 "lineage": {
                     "type": "string",
                     "description": (
-                        "REQUIRED when class_closure is true. A plan has no branch to key "
+                        "REQUIRED unless class_closure is false. A plan has no branch to key "
                         "state to, and nothing is derived from the plan's text or path — "
                         "either would mint a fresh empty lineage whenever it changed and "
                         "report NOT-BLOCKED with every tracked class silently dropped. The "
@@ -236,6 +243,10 @@ TOOLS: list[Tool] = [
                 },
                 **_COMMON,
             },
+            "required": ["repo_path"],
+            # The handler has always enforced exactly-one-of; the schema never said so, so
+            # a client could not catch it before spending a call.
+            "oneOf": [{"required": ["plan_text"]}, {"required": ["plan_path"]}],
         },
     ),
     Tool(

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -120,7 +120,7 @@ TOOLS: list[Tool] = [
                 },
                 "converge": {
                     "type": "boolean",
-                    "description": "Convergence mode (default TRUE): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate). Pass false to fall back to the legacy in-place review.",
+                    "description": "Convergence mode (default TRUE): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate). Pass false (with class_closure: false) to fall back to the legacy in-place review. Class closure runs ONLY on this path, so `converge: false` is REFUSED unless you also pass `class_closure: false` — otherwise the review would look gated and emit no CONVERGENCE trailer.",
                 },
                 "max_packet_chars": {
                     "type": "integer",

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -191,7 +191,7 @@ TOOLS: list[Tool] = [
     Tool(
         name="critique_plan",
         description=(
-            "Adversarially review a plan or design doc. With repo_path the reviewer reads the actual "
+            "Adversarially review a plan or design doc. The reviewer reads the actual "
             "code to test the plan's premises about current behaviour — a plan built on an inverted "
             "premise is the most dangerous kind. Returns the five-section critique with FATAL/MAJOR/MINOR tags."
         ),

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -83,7 +83,7 @@ MECHANIZED = (
 
 
 def run_round(repo: Path, engine: FakeEngine, tmp_path: Path, **extra) -> str:
-    args = {"repo_path": str(repo), "base_ref": "main", "converge": True, **extra, "round": 1}
+    args = {"repo_path": str(repo), "base_ref": "main", "converge": True, "round": 1, **extra}
     return handlers.critique_branch(args, engine=engine, log_dir=tmp_path / "logs")
 
 
@@ -418,7 +418,7 @@ class TestArguments:
         reach back and break a review that was valid before this feature existed."""
         (repo / "dirty.py").write_text("x = 1\n")
         out = run_round(repo, FakeEngine("## What works\nok"), tmp_path,
-                        converge=False, include_uncommitted=True, head_ref="feature")
+                        converge=False, class_closure=False, include_uncommitted=True, head_ref="feature")
         assert "CONVERGENCE:" not in out
 
     def test_a_dirty_review_rejects_an_explicit_head_ref(self, repo: Path, tmp_path: Path) -> None:

--- a/tests/test_class_closure_integration.py
+++ b/tests/test_class_closure_integration.py
@@ -83,7 +83,7 @@ MECHANIZED = (
 
 
 def run_round(repo: Path, engine: FakeEngine, tmp_path: Path, **extra) -> str:
-    args = {"repo_path": str(repo), "base_ref": "main", "converge": True, **extra}
+    args = {"repo_path": str(repo), "base_ref": "main", "converge": True, **extra, "round": 1}
     return handlers.critique_branch(args, engine=engine, log_dir=tmp_path / "logs")
 
 

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -31,7 +31,7 @@ def _dirty(repo: Path) -> None:
 
 
 def _args(repo: Path, **extra) -> dict:
-    return {"repo_path": str(repo), "include_uncommitted": True, **extra}
+    return {"repo_path": str(repo), "include_uncommitted": True, **extra, "round": 1}
 
 
 class TestConvergeBranch:
@@ -86,7 +86,7 @@ class TestConvergeBranch:
         (repo / "a.py").write_text("UNBORN_MARKER = 1\n")
         fake = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo), "include_uncommitted": True, "converge": True},
+            {"repo_path": str(repo), "include_uncommitted": True, "converge": True, "round": 1},
             engine=fake, log_dir=tmp_path / "logs",
         )
         assert "UNBORN_MARKER = 1" in fake.calls[0]["prompt"]  # new file's content packaged

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -31,7 +31,7 @@ def _dirty(repo: Path) -> None:
 
 
 def _args(repo: Path, **extra) -> dict:
-    return {"repo_path": str(repo), "include_uncommitted": True, **extra, "round": 1}
+    return {"repo_path": str(repo), "include_uncommitted": True, "round": 1, **extra}
 
 
 class TestConvergeBranch:
@@ -75,7 +75,8 @@ class TestConvergeBranch:
     def test_explicit_converge_false_restores_live_repo(self, repo: Path, tmp_path: Path) -> None:
         _dirty(repo)
         fake = FakeEngine()
-        handlers.critique_branch(_args(repo, converge=False), engine=fake, log_dir=tmp_path)
+        handlers.critique_branch(_args(repo, converge=False, class_closure=False),
+                                 engine=fake, log_dir=tmp_path)
         assert fake.calls[0]["cwd"] == repo  # escape hatch: legacy in-place review
 
     def test_converge_on_unborn_repo(self, tmp_path: Path) -> None:

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -109,19 +109,21 @@ class TestCritiqueBranch:
         )
         assert "CFGSTAKES" in eng.calls[0]["prompt"]
 
-    def test_round_below_one_is_ignored(self, repo_with_branch: Path, tmp_path: Path) -> None:
-        # dogfood finding: schema is 1-based; a non-positive round must not emit a ROUND
-        # line. While closure tracks a loop such a round is now REFUSED outright (a value
-        # that renders no floor is the same as omitting it); this pins the one-shot mode,
-        # where there is no next round to floor and the value is merely inert.
-        eng = FakeEngine()
-        handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "round": 0, "class_closure": False},
-            engine=eng, log_dir=tmp_path, now=fixed_clock,
-        )
-        body = eng.calls[0]["prompt"].split("===== TASK INPUT =====", 1)[1]
-        assert "ROUND:" not in body
+    def test_round_below_one_is_refused_in_both_modes(
+        self, repo_with_branch: Path, tmp_path: Path
+    ) -> None:
+        # dogfood finding: the schema is 1-based and a non-positive round emits no ROUND
+        # line. It used to be silently ignored; silently ignoring a round the caller took
+        # the trouble to pass is how a loop believes it has a floor it never had. A
+        # SUPPLIED round is now checked in both modes — only OMITTING it is the one-shot
+        # mode's privilege.
+        for extra in ({}, {"class_closure": False}):
+            with pytest.raises(ValueError, match="integer >= 1"):
+                handlers.critique_branch(
+                    {"repo_path": str(repo_with_branch), "base_ref": "main",
+                     "head_ref": "feature", "round": 0, **extra},
+                    engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
+                )
 
     def test_no_calibration_block_in_body_when_absent(self, repo_with_branch: Path, tmp_path: Path) -> None:
         # The instructions always DESCRIBE the calibration block; assert it isn't

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -64,7 +64,7 @@ class TestCritiqueBranch:
         (repo / "app.py").write_text("# uncommitted edit\n")
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo), "include_uncommitted": True, "converge": False, "round": 1},
+            {"repo_path": str(repo), "include_uncommitted": True, "converge": False, "class_closure": False, "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo
@@ -75,7 +75,7 @@ class TestCritiqueBranch:
         eng = FakeEngine()
         handlers.critique_branch(
             {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "isolate": False, "converge": False, "round": 1},
+             "isolate": False, "class_closure": False, "converge": False, "class_closure": False, "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo_with_branch
@@ -110,10 +110,14 @@ class TestCritiqueBranch:
         assert "CFGSTAKES" in eng.calls[0]["prompt"]
 
     def test_round_below_one_is_ignored(self, repo_with_branch: Path, tmp_path: Path) -> None:
-        # dogfood finding: schema is 1-based; a non-positive round must not emit a ROUND line.
+        # dogfood finding: schema is 1-based; a non-positive round must not emit a ROUND
+        # line. While closure tracks a loop such a round is now REFUSED outright (a value
+        # that renders no floor is the same as omitting it); this pins the one-shot mode,
+        # where there is no next round to floor and the value is merely inert.
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 0},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
+             "round": 0, "class_closure": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         body = eng.calls[0]["prompt"].split("===== TASK INPUT =====", 1)[1]

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -39,7 +39,7 @@ class TestCritiqueBranch:
         eng = FakeEngine()
         out = handlers.critique_branch(
             {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "diff_intent": "friendlier greeting"},
+             "diff_intent": "friendlier greeting", "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "REVIEW BODY" in out
@@ -53,7 +53,7 @@ class TestCritiqueBranch:
 
     def test_footer_exposes_session_for_rebut(self, repo_with_branch: Path, tmp_path: Path) -> None:
         out = handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 1},
             engine=FakeEngine(session_ref="abc-999"), log_dir=tmp_path, now=fixed_clock,
         )
         assert "abc-999" in out
@@ -64,7 +64,7 @@ class TestCritiqueBranch:
         (repo / "app.py").write_text("# uncommitted edit\n")
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo), "include_uncommitted": True, "converge": False},
+            {"repo_path": str(repo), "include_uncommitted": True, "converge": False, "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo
@@ -75,7 +75,7 @@ class TestCritiqueBranch:
         eng = FakeEngine()
         handlers.critique_branch(
             {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "isolate": False, "converge": False},
+             "isolate": False, "converge": False, "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo_with_branch
@@ -84,7 +84,7 @@ class TestCritiqueBranch:
         eng = FakeEngine()
         handlers.critique_branch(
             {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
-             "already_raised": ["app.py:5 — greeting not escaped"]},
+             "already_raised": ["app.py:5 — greeting not escaped"], "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "greeting not escaped" in eng.calls[0]["prompt"]
@@ -104,7 +104,7 @@ class TestCritiqueBranch:
         (repo_with_branch / ".paranoia.toml").write_text('stakes = "CFGSTAKES"\n')
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "CFGSTAKES" in eng.calls[0]["prompt"]
@@ -122,9 +122,12 @@ class TestCritiqueBranch:
     def test_no_calibration_block_in_body_when_absent(self, repo_with_branch: Path, tmp_path: Path) -> None:
         # The instructions always DESCRIBE the calibration block; assert it isn't
         # INJECTED into the task-input body when neither stakes nor round is given.
+        # `round` is required once class closure is tracking a loop, so the only shape
+        # with neither is the explicit one-shot mode.
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
+             "class_closure": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         body = eng.calls[0]["prompt"].split("===== TASK INPUT =====", 1)[1]
@@ -132,7 +135,7 @@ class TestCritiqueBranch:
 
     def test_writes_audit_log(self, repo_with_branch: Path, tmp_path: Path) -> None:
         handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 1},
             engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
         )
         logs = list(tmp_path.glob("*.json"))
@@ -145,7 +148,7 @@ class TestCritiqueBranch:
         git(["add", "-A"], repo_with_branch)
         eng = FakeEngine()
         handlers.critique_branch(
-            {"repo_path": str(repo_with_branch), "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "head_ref": "feature", "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         # a diff was computed against main (feature's change is visible)
@@ -163,37 +166,41 @@ class TestCritiquePlan:
     def test_rejects_both_text_and_path(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="not both"):
             handlers.critique_plan(
-                {"plan_text": "x", "plan_path": "/tmp/y.md"},
+                {"plan_text": "x", "plan_path": "/tmp/y.md", "repo_path": str(tmp_path)},
                 engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
             )
 
     def test_rejects_neither(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError, match="plan_text or plan_path"):
             handlers.critique_plan(
-                {}, engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
+                {"repo_path": str(tmp_path)}, engine=FakeEngine(), log_dir=tmp_path,
+                now=fixed_clock,
             )
 
-    def test_plan_text_reaches_reviewer(self, tmp_path: Path) -> None:
+    def test_plan_text_reaches_reviewer(self, repo: Path, tmp_path: Path) -> None:
         eng = FakeEngine()
         handlers.critique_plan(
-            {"plan_text": "Step 1: rewrite the auth layer."},
+            {"plan_text": "Step 1: rewrite the auth layer.", "repo_path": str(repo),
+             "class_closure": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "rewrite the auth layer" in eng.calls[0]["prompt"]
 
-    def test_plan_path_is_read(self, tmp_path: Path) -> None:
+    def test_plan_path_is_read(self, repo: Path, tmp_path: Path) -> None:
         plan = tmp_path / "plan.md"
         plan.write_text("# Plan\nDo the risky thing.\n")
         eng = FakeEngine()
         handlers.critique_plan(
-            {"plan_path": str(plan)}, engine=eng, log_dir=tmp_path, now=fixed_clock,
+            {"plan_path": str(plan), "repo_path": str(repo), "class_closure": False},
+            engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "risky thing" in eng.calls[0]["prompt"]
 
-    def test_stakes_and_round_reach_plan_reviewer(self, tmp_path: Path) -> None:
+    def test_stakes_and_round_reach_plan_reviewer(self, repo: Path, tmp_path: Path) -> None:
         eng = FakeEngine()
         handlers.critique_plan(
-            {"plan_text": "do a thing", "stakes": "PLANSTAKESMARK", "round": 5},
+            {"plan_text": "do a thing", "stakes": "PLANSTAKESMARK", "round": 5,
+             "repo_path": str(repo), "class_closure": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         p = eng.calls[0]["prompt"]
@@ -203,7 +210,7 @@ class TestCritiquePlan:
     def test_repo_grounding_runs_in_repo(self, repo: Path, tmp_path: Path) -> None:
         eng = FakeEngine()
         handlers.critique_plan(
-            {"plan_text": "change greet()", "repo_path": str(repo)},
+            {"plan_text": "change greet()", "repo_path": str(repo), "class_closure": False},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert eng.calls[0]["cwd"] == repo
@@ -232,7 +239,7 @@ class TestRebut:
         eng = FakeEngine()
         out = handlers.rebut(
             {"repo_path": str(repo), "session_ref": "sess-1",
-             "rebuttal": "That line is unreachable because X."},
+             "rebuttal": "That line is unreachable because X.", "round": 1},
             engine=eng, log_dir=tmp_path, now=fixed_clock,
         )
         assert "REBUTTAL VERDICT" in out
@@ -244,6 +251,6 @@ class TestRebut:
     def test_requires_session_and_rebuttal(self, repo: Path, tmp_path: Path) -> None:
         with pytest.raises(ValueError):
             handlers.rebut(
-                {"repo_path": str(repo), "rebuttal": "x"},
+                {"repo_path": str(repo), "rebuttal": "x", "round": 1},
                 engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
             )

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,7 +80,7 @@ class TestDispatchEndToEnd:
     def test_critique_branch_runs_in_worktree(self, repo_with_branch, tmp_path, fake_bins):
         out = server.dispatch(
             "critique_branch",
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature"},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 1},
             default_engine_name="codex", log_dir=tmp_path / "logs", now=lambda: "t1",
         )
         assert "FAKE CODEX REVIEW" in out
@@ -93,7 +93,7 @@ class TestDispatchEndToEnd:
         out = server.dispatch(
             "rebut",
             {"repo_path": str(repo), "session_ref": "fake-thread-1",
-             "rebuttal": "that branch is unreachable"},
+             "rebuttal": "that branch is unreachable", "round": 1},
             default_engine_name="codex", log_dir=tmp_path / "logs", now=lambda: "t1",
         )
         assert "FAKE CODEX REVIEW" in out

--- a/tests/test_plan_class_closure.py
+++ b/tests/test_plan_class_closure.py
@@ -72,8 +72,10 @@ PROCEDURE_CLASS = (
 
 def run_round(engine: FakeEngine, tmp_path: Path, *, lineage: str = "proj-1-plan",
               round_no: int = 1, plan: str = "# Plan\n\nDo the thing.",
-              already: list[str] | None = None, closure: bool = True) -> str:
-    args = {"plan_text": plan, "round": round_no, "class_closure": closure}
+              already: list[str] | None = None, closure: bool = True,
+              repo: Path | None = None) -> str:
+    args = {"plan_text": plan, "round": round_no, "class_closure": closure,
+            "repo_path": str(repo or _bare_repo(tmp_path))}
     if lineage:
         args["lineage"] = lineage
     if already:
@@ -304,19 +306,25 @@ class TestLineageIsRequiredAndNeverDerived:
             plan.write_text("# Plan")
             args = {"plan_path": str(plan)}
         with pytest.raises(ValueError, match="needs an explicit `lineage`"):
-            handlers.critique_plan({**args, "class_closure": True},
-                                   engine=FakeEngine(), log_dir=tmp_path / "logs")
+            handlers.critique_plan(
+                {**args, "class_closure": True, "round": 1,
+                 "repo_path": str(_bare_repo(tmp_path))},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
 
     def test_the_refusal_mints_no_lineage(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError):
-            handlers.critique_plan({"plan_text": "# Plan", "class_closure": True},
-                                   engine=FakeEngine(), log_dir=tmp_path / "logs")
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "class_closure": True, "round": 1,
+                 "repo_path": str(_bare_repo(tmp_path))},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
         assert not list(cc.lineage_dir(cc.default_state_root()).glob("*.json"))
 
     def test_the_error_names_both_remedies(self, tmp_path: Path) -> None:
         with pytest.raises(ValueError) as exc:
-            handlers.critique_plan({"plan_text": "# Plan", "class_closure": True},
-                                   engine=FakeEngine(), log_dir=tmp_path / "logs")
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "class_closure": True, "round": 1,
+                 "repo_path": str(_bare_repo(tmp_path))},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
         assert "mode-qualified" in str(exc.value) and "class_closure: false" in str(exc.value)
 
     def test_the_same_lineage_survives_a_completely_rewritten_plan(
@@ -470,30 +478,53 @@ class TestBranchPathUnchanged:
 # ── the off switch, and the audit record ──────────────────────────────────────
 
 
-class TestDefaultOff:
-    def test_closure_is_off_unless_asked_for(self, tmp_path: Path) -> None:
+class TestDefaultOnAndTheOneShotEscape:
+    """Closure is ON by default; `class_closure: false` is the ONE explicit one-shot mode,
+    and it is also what drops the `round` requirement — one rule, not two."""
+
+    def test_closure_is_on_without_being_asked_for(self, tmp_path: Path) -> None:
+        out = handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "round": 1, "lineage": "default-on-plan"},
+            engine=FakeEngine(review_with(PROCEDURE_CLASS)), log_dir=tmp_path / "logs")
+        assert "CONVERGENCE: BLOCKED" in out
+
+    def test_the_default_refuses_a_call_with_no_lineage_and_names_the_one_shot_escape(
+        self, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="class_closure: false"):
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)), "round": 1},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+
+    def test_the_one_shot_mode_needs_neither_lineage_nor_round(self, tmp_path: Path) -> None:
         engine = FakeEngine(review_with(PROCEDURE_CLASS))
-        out = handlers.critique_plan({"plan_text": "# Plan"}, engine=engine,
-                                     log_dir=tmp_path / "logs")
+        out = handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "class_closure": False},
+            engine=engine, log_dir=tmp_path / "logs")
         assert "CONVERGENCE:" not in out
         assert cc.UNMECHANIZED_HEADER not in engine.calls[0]
 
-    def test_off_writes_no_state_at_all(self, tmp_path: Path) -> None:
-        handlers.critique_plan({"plan_text": "# Plan"}, engine=FakeEngine(review_with("NONE")),
-                               log_dir=tmp_path / "logs")
+    def test_the_one_shot_mode_writes_no_state_at_all(self, tmp_path: Path) -> None:
+        handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "class_closure": False},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
         assert not cc.lineage_dir(cc.default_state_root()).exists() or \
             not list(cc.lineage_dir(cc.default_state_root()).iterdir())
 
-    def test_paranoia_toml_cannot_turn_plan_closure_on(self, tmp_path: Path) -> None:
-        """Sharing the branch key would flip plan closure on for any project that set it,
-        and then hard-error every plan call that has no lineage."""
-        repo = tmp_path / "repo"
-        (repo / ".git").mkdir(parents=True)
-        (repo / ".paranoia.toml").write_text("class_closure = true\n")
-        engine = FakeEngine(review_with(PROCEDURE_CLASS))
-        out = handlers.critique_plan({"plan_text": "# Plan", "repo_path": str(repo)},
-                                     engine=engine, log_dir=tmp_path / "logs")
-        assert "CONVERGENCE:" not in out
+    def test_paranoia_toml_cannot_turn_plan_closure_off(self, tmp_path: Path) -> None:
+        """The branch key must not reach across tools in EITHER direction: a project that
+        set `class_closure = false` for its branch reviews must not silently disable the
+        plan gate."""
+        repo = _bare_repo(tmp_path)
+        (repo / ".paranoia.toml").write_text("class_closure = false\n")
+        out = handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(repo), "round": 1,
+             "lineage": "toml-plan"},
+            engine=FakeEngine(review_with(PROCEDURE_CLASS)), log_dir=tmp_path / "logs")
+        assert "CONVERGENCE: BLOCKED" in out
 
 
 class TestPlanAuditRecord:
@@ -515,7 +546,8 @@ class TestPlanAuditRecord:
         plan = tmp_path / "plan.md"
         plan.write_text("# Plan\n\nfrom a file")
         handlers.critique_plan(
-            {"plan_path": str(plan), "class_closure": True, "lineage": "p-plan"},
+            {"plan_path": str(plan), "class_closure": True, "lineage": "p-plan",
+             "round": 1, "repo_path": str(_bare_repo(tmp_path))},
             engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
         record = _log_record(tmp_path)
         assert record["plan_path"] == str(plan)
@@ -534,9 +566,11 @@ class TestPlanAuditRecord:
         assert "PROCEDURE:" in record["retry_register"]
         assert "PATTERN:" not in record["retry_register"]
 
-    def test_an_uninstrumented_plan_review_still_logs(self, tmp_path: Path) -> None:
-        handlers.critique_plan({"plan_text": "# Plan"}, engine=FakeEngine(review_with("NONE")),
-                               log_dir=tmp_path / "logs")
+    def test_a_one_shot_plan_review_still_logs(self, tmp_path: Path) -> None:
+        handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "class_closure": False},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
         record = _log_record(tmp_path)
         assert record["class_closure"] is False and record["lineage"] is None
 
@@ -566,6 +600,18 @@ class TestFailedReviewLeavesStateAlone:
 
 
 # ── helpers ───────────────────────────────────────────────────────────────────
+
+
+def _bare_repo(tmp_path: Path) -> Path:
+    """`critique_plan` now requires a repo to ground against; these tests do not care
+    which, so one empty repo per tmp_path serves every call."""
+    import subprocess
+
+    r = tmp_path / "plan-repo"
+    if not r.exists():
+        r.mkdir()
+        subprocess.run(["git", "init", "-q"], cwd=r, check=True, capture_output=True)
+    return r
 
 
 @pytest.fixture
@@ -602,3 +648,108 @@ def _only_class_id(tmp_path: Path) -> str:
 def _log_record(tmp_path: Path) -> dict:
     files = sorted((tmp_path / "logs").glob("*critique_plan*.json"))
     return json.loads(files[-1].read_text())
+
+
+# ── the mandatory contract ────────────────────────────────────────────────────
+
+
+class TestRoundIsRequiredWhileAClosureLoopRuns:
+    """`round` is the only thing that makes a loop terminate: `_CALIBRATION`'s severity
+    floor starts at round 3, so a loop driven without it reports at round-1 severity
+    forever. Required whenever closure is tracking a loop, and deliberately not in the
+    one-shot mode, which has no next round to floor."""
+
+    def test_a_plan_closure_call_without_round_is_refused(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError, match="needs `round`"):
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+                 "lineage": "no-round-plan"},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+
+    def test_a_branch_call_without_round_is_refused(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ValueError, match="needs `round`"):
+            handlers.critique_branch(
+                {"repo_path": str(git_repo), "base_ref": "main"},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+
+    def test_the_refusal_names_the_one_shot_escape(self, tmp_path: Path) -> None:
+        with pytest.raises(ValueError) as exc:
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+                 "lineage": "no-round-plan"},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+        assert "class_closure: false" in str(exc.value)
+
+    @pytest.mark.parametrize("tool", ["plan", "branch"])
+    def test_the_one_shot_mode_needs_no_round_on_either_tool(
+        self, tool: str, git_repo: Path, tmp_path: Path
+    ) -> None:
+        if tool == "plan":
+            out = handlers.critique_plan(
+                {"plan_text": "# Plan", "repo_path": str(git_repo),
+                 "class_closure": False},
+                engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
+        else:
+            out = handlers.critique_branch(
+                {"repo_path": str(git_repo), "base_ref": "main", "class_closure": False},
+                engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
+        assert "CONVERGENCE:" not in out
+
+
+class TestPlanReviewsMustBeGrounded:
+    def test_a_plan_review_without_a_repo_is_refused(self, tmp_path: Path) -> None:
+        """225 of 225 logged plan reviews passed one, so this refuses nothing real — and
+        an ungrounded review cannot do the job the prompt calls its most valuable."""
+        with pytest.raises(ValueError, match="repo_path is required"):
+            handlers.critique_plan(
+                {"plan_text": "# Plan", "class_closure": False},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+
+    def test_the_schema_says_so_too(self) -> None:
+        from paranoia_local import server
+
+        schema = [t for t in server.TOOLS if t.name == "critique_plan"][0].inputSchema
+        assert schema["required"] == ["repo_path"]
+
+    def test_the_schema_encodes_plan_text_xor_plan_path(self) -> None:
+        """The handler has always enforced it; a client could not see it before spending."""
+        from paranoia_local import server
+
+        schema = [t for t in server.TOOLS if t.name == "critique_plan"][0].inputSchema
+        assert schema["oneOf"] == [{"required": ["plan_text"]}, {"required": ["plan_path"]}]
+
+
+class TestUnstatedStakesAreSurfacedNotBlocked:
+    """Absent stakes is the largest cause of review scope-creep, but its fallback is the
+    SAFE reading — so this shows, and never refuses."""
+
+    def test_a_review_with_no_stakes_anywhere_says_so(self, tmp_path: Path) -> None:
+        out = run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path)
+        assert handlers.STAKES_NOTICE in out
+
+    def test_stated_stakes_silence_the_notice(self, tmp_path: Path) -> None:
+        out = handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "class_closure": False, "stakes": "a real deployment boundary"},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
+        assert handlers.STAKES_NOTICE not in out
+
+    def test_the_literal_unstated_is_an_explicit_acceptance_not_an_omission(
+        self, tmp_path: Path
+    ) -> None:
+        """`arbitrate`'s trick: saying `unstated` calibrates the reviewer to one fixed
+        reading AND records that the caller chose it, so it must not be nagged."""
+        engine = FakeEngine(review_with("NONE"))
+        out = handlers.critique_plan(
+            {"plan_text": "# Plan", "repo_path": str(_bare_repo(tmp_path)),
+             "class_closure": False, "stakes": "unstated"},
+            engine=engine, log_dir=tmp_path / "logs")
+        assert handlers.STAKES_NOTICE not in out
+        assert "modest single-team internal tool" in engine.calls[0]
+
+    def test_the_notice_never_blocks_the_review(self, tmp_path: Path) -> None:
+        out = run_round(FakeEngine(review_with("NONE")), tmp_path)
+        assert "CONVERGENCE: NOT-BLOCKED" in out
+        assert handlers.STAKES_NOTICE in out

--- a/tests/test_plan_class_closure.py
+++ b/tests/test_plan_class_closure.py
@@ -426,11 +426,19 @@ class TestPlanModeNeverGreps:
         run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path, round_no=1)
         run_round(FakeEngine(review_with("NONE")), tmp_path, round_no=2)
 
-    def test_a_plan_round_completes_without_git_being_reachable(self, tmp_path: Path) -> None:
-        """Renamed: it used to claim "needs no repository at all", which `run_round` had
-        stopped being true of — the helper supplies one, and `critique_plan` now requires
-        it. What it actually pins is that the round completes with no git work."""
-        out = run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path)
+    def test_a_plan_round_runs_no_git_subprocess(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """The sibling test proves no grep is CONSTRUCTED; this proves none is RUN. It
+        used to claim "needs no repository at all" and prove nothing, because the helper
+        builds one with `git init` — so the stub goes in after the fixture exists."""
+        repo = _bare_repo(tmp_path)
+
+        def explode(*a, **k):
+            raise AssertionError("plan mode ran a git subprocess")
+
+        monkeypatch.setattr(handlers, "_run_git", explode)
+        out = run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path, repo=repo)
         assert "CONVERGENCE: BLOCKED" in out
 
 

--- a/tests/test_plan_class_closure.py
+++ b/tests/test_plan_class_closure.py
@@ -462,11 +462,13 @@ class TestBranchPathUnchanged:
     def test_branch_audit_records_carry_the_round_and_the_suppression_list(
         self, git_repo: Path, tmp_path: Path, converge: bool
     ) -> None:
-        """Both branch paths: the legacy in-place review logs from a different call site."""
+        """Both branch paths: the legacy in-place review logs from a different call site.
+        The legacy path is reachable only in the one-shot mode, since closure never ran
+        there — so `class_closure` tracks `converge` here."""
         handlers.critique_branch(
             {"repo_path": str(git_repo), "base_ref": "main", "round": 6,
              "lineage": "audit-branch", "already_raised": ["a prior claim, x.py:1"],
-             "converge": converge},
+             "converge": converge, "class_closure": converge},
             engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs",
             now=lambda: "T3")
         files = sorted((tmp_path / "logs").glob("*critique_branch*.json"))
@@ -753,3 +755,59 @@ class TestUnstatedStakesAreSurfacedNotBlocked:
         out = run_round(FakeEngine(review_with("NONE")), tmp_path)
         assert "CONVERGENCE: NOT-BLOCKED" in out
         assert handlers.STAKES_NOTICE in out
+
+
+class TestThereIsExactlyOneEscape:
+    """The gap round 1 named: nothing proved that an ACCEPTED branch call with closure
+    enabled actually emits a trailer. `converge: false` was a second, silent escape —
+    closure never runs on the legacy path, so the call demanded a round, looked gated,
+    and returned a review whose own `CONVERGED` nothing could contradict."""
+
+    @pytest.mark.parametrize("extra", [
+        {},
+        {"converge": True},
+        {"include_uncommitted": True},
+        {"isolate": False},
+        {"already_raised": ["a prior claim, x.py:1"]},
+    ])
+    def test_every_accepted_closure_enabled_branch_call_emits_a_trailer(
+        self, extra: dict, git_repo: Path, tmp_path: Path
+    ) -> None:
+        out = handlers.critique_branch(
+            {"repo_path": str(git_repo), "base_ref": "main", "round": 1,
+             "lineage": f"one-escape-{len(extra)}-branch", **extra},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs",
+            now=lambda: "T9")
+        assert "CONVERGENCE:" in out
+
+    def test_converge_false_with_closure_on_is_refused_naming_both_remedies(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
+        with pytest.raises(ValueError) as exc:
+            handlers.critique_branch(
+                {"repo_path": str(git_repo), "base_ref": "main", "round": 1,
+                 "converge": False},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+        assert "converge: false" in str(exc.value)
+        assert "class_closure: false" in str(exc.value)
+
+    def test_the_legacy_path_is_still_reachable_through_the_one_shot_mode(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
+        out = handlers.critique_branch(
+            {"repo_path": str(git_repo), "base_ref": "main", "converge": False,
+             "class_closure": False},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs")
+        assert "CONVERGENCE:" not in out
+
+    @pytest.mark.parametrize("bad", [0, -1, "3", 1.0, True, None])
+    def test_a_round_that_renders_no_floor_is_refused_not_silently_accepted(
+        self, bad: object, git_repo: Path, tmp_path: Path
+    ) -> None:
+        """`_calibration` renders ROUND only for an int >= 1, so 0 and "3" produce exactly
+        what omitting it produces — no floor — while only None ever looked like a mistake."""
+        args = {"repo_path": str(git_repo), "base_ref": "main", "lineage": "bad-round-branch"}
+        if bad is not None:
+            args["round"] = bad
+        with pytest.raises(ValueError, match="integer >= 1"):
+            handlers.critique_branch(args, engine=FakeEngine(), log_dir=tmp_path / "logs")

--- a/tests/test_plan_class_closure.py
+++ b/tests/test_plan_class_closure.py
@@ -1,4 +1,11 @@
-"""Class closure for `critique_plan`: unmechanized classes, no repository, no git.
+"""Class closure for `critique_plan`: unmechanized classes, no git.
+
+Two claims that are easy to conflate and are NOT the same: the closure COORDINATOR
+needs no repository and runs no git subprocess (`TestPlanModeNeverGreps`), while the
+`critique_plan` HANDLER requires one, because an ungrounded plan review cannot test the
+plan's premises against the code (`TestPlanReviewsMustBeGrounded`). This module's
+helper therefore always supplies a repository, and any test claiming to omit one is
+lying.
 
 Design contract: `docs/plan_class_closure_proposal.md`. Each block names the plan-review
 round whose finding it pins, so a later change that re-opens one fails with the history

--- a/tests/test_plan_class_closure.py
+++ b/tests/test_plan_class_closure.py
@@ -426,7 +426,10 @@ class TestPlanModeNeverGreps:
         run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path, round_no=1)
         run_round(FakeEngine(review_with("NONE")), tmp_path, round_no=2)
 
-    def test_a_plan_review_needs_no_repository_at_all(self, tmp_path: Path) -> None:
+    def test_a_plan_round_completes_without_git_being_reachable(self, tmp_path: Path) -> None:
+        """Renamed: it used to claim "needs no repository at all", which `run_round` had
+        stopped being true of — the helper supplies one, and `critique_plan` now requires
+        it. What it actually pins is that the round completes with no git work."""
         out = run_round(FakeEngine(review_with(PROCEDURE_CLASS)), tmp_path)
         assert "CONVERGENCE: BLOCKED" in out
 
@@ -790,6 +793,31 @@ class TestThereIsExactlyOneEscape:
                 engine=FakeEngine(), log_dir=tmp_path / "logs")
         assert "converge: false" in str(exc.value)
         assert "class_closure: false" in str(exc.value)
+
+    def test_a_config_sourced_converge_false_is_refused_with_a_remedy_that_works(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
+        """`converge` resolves from .paranoia.toml too, so "drop `converge: false`" is no
+        remedy at all when the caller never passed it. The gap that let that ship was
+        testing only the call-argument shape."""
+        (git_repo / ".paranoia.toml").write_text("converge = false\n")
+        with pytest.raises(ValueError) as exc:
+            handlers.critique_branch(
+                {"repo_path": str(git_repo), "base_ref": "main", "round": 1},
+                engine=FakeEngine(), log_dir=tmp_path / "logs")
+        assert "converge: true" in str(exc.value)
+        assert ".paranoia.toml" in str(exc.value)
+
+    def test_the_config_sourced_remedy_actually_resolves_the_refusal(
+        self, git_repo: Path, tmp_path: Path
+    ) -> None:
+        (git_repo / ".paranoia.toml").write_text("converge = false\n")
+        out = handlers.critique_branch(
+            {"repo_path": str(git_repo), "base_ref": "main", "round": 1,
+             "converge": True, "lineage": "cfg-remedy-branch"},
+            engine=FakeEngine(review_with("NONE")), log_dir=tmp_path / "logs",
+            now=lambda: "T8")
+        assert "CONVERGENCE:" in out
 
     def test_the_legacy_path_is_still_reachable_through_the_one_shot_mode(
         self, git_repo: Path, tmp_path: Path

--- a/tests/test_progress.py
+++ b/tests/test_progress.py
@@ -192,34 +192,37 @@ class TestHandlerAndDispatchPlumbing:
             self.received_on_progress = on_progress
             return Review(text="R", session_ref=session_ref, raw="")
 
-    def test_critique_plan_threads_on_progress(self, tmp_path: Path) -> None:
+    def test_critique_plan_threads_on_progress(self, repo: Path, tmp_path: Path) -> None:
         spy = self.SpyEngine()
         seen: list[str] = []
         critique_plan(
-            {"plan_text": "# plan"}, engine=spy, log_dir=tmp_path,
+            {"plan_text": "# plan", "repo_path": str(repo), "class_closure": False},
+            engine=spy, log_dir=tmp_path,
             now=lambda: "t", on_progress=seen.append,
         )
         assert spy.received_on_progress is not None
         assert spy.received_on_progress != "UNSET"
         assert "engine says hi" in seen
 
-    def test_dispatch_forwards_on_progress(self, tmp_path: Path, monkeypatch) -> None:
+    def test_dispatch_forwards_on_progress(self, repo: Path, tmp_path: Path, monkeypatch) -> None:
         spy = self.SpyEngine()
         monkeypatch.setattr(server, "get_engine", lambda name: spy)
         seen: list[str] = []
         out = server.dispatch(
-            "critique_plan", {"plan_text": "# plan"},
+            "critique_plan", {"plan_text": "# plan", "repo_path": str(repo),
+                              "class_closure": False},
             default_engine_name="codex", log_dir=tmp_path, now=lambda: "t",
             on_progress=seen.append,
         )
         assert "R" in out
         assert "engine says hi" in seen
 
-    def test_dispatch_without_on_progress_unchanged(self, tmp_path: Path, monkeypatch) -> None:
+    def test_dispatch_without_on_progress_unchanged(self, repo: Path, tmp_path: Path, monkeypatch) -> None:
         spy = self.SpyEngine()
         monkeypatch.setattr(server, "get_engine", lambda name: spy)
         out = server.dispatch(
-            "critique_plan", {"plan_text": "# plan"},
+            "critique_plan", {"plan_text": "# plan", "repo_path": str(repo),
+                              "class_closure": False},
             default_engine_name="codex", log_dir=tmp_path, now=lambda: "t",
         )
         assert "R" in out


### PR DESCRIPTION
Operator decision: the levers that make a review loop terminate should be on by default or required, not opt-in.

## What changed

- **`critique_plan` `class_closure` defaults TRUE** (was false), matching `critique_branch`.
- **`round` is REQUIRED on both critiques** while closure tracks a loop. Without it the reviewer never reaches the round-3 severity floor, so the loop reports at round-1 severity forever and has no terminating pressure — the 2026-08-03 incident's own diagnosis. A *supplied* round is validated in both modes (`0` and `"3"` render no ROUND line, so silently ignoring one is how a loop believes it has a floor it never had); only *omitting* it is the one-shot mode's privilege.
- **`critique_plan` REQUIRES `repo_path`.** Testing the plan's premises against the code is the reviewer's highest-value job and an ungrounded review cannot do it. All 225 logged plan reviews already passed one, so this refuses nothing anyone does.
- **The schema encodes `plan_text` XOR `plan_path`** via `oneOf`. The handler always enforced it; clients could not catch it before spending a call.
- **`converge: false` with closure on is refused.** Closure runs only on the converge path, so this was a second, silent escape: the call demanded a round, looked gated, emitted no trailer, and let a reviewer's own `CONVERGED` end a loop with a blocking class live. There is now exactly **one** escape, `class_closure: false`, and it is also what drops the round requirement.

**`stakes` deliberately stays optional and non-blocking.** It is settable once per project in `.paranoia.toml` and Parallax uses that; its fallback is the *safe* reading, so a gate would refuse valid work to prevent a miscalibration the caller can simply be shown. Instead a review that resolved no stakes from either source ends with a `STAKES: unstated` line, and `arbitrate`'s trick is adopted: the literal `stakes: "unstated"` is an explicit acceptance of one fixed reading that calibrates the reviewer and silences the line.

## Review

Four cold codex branch rounds with class closure on, lineage `paranoia-mandatory-defaults-branch`. It found, among others:

- a **BLOCKER** — the `converge: false` second escape, above;
- a **BLOCKER gap** — nothing proved an accepted closure-enabled call emits a trailer at all, and the nearest test pinned the opposite;
- a **MAJOR** of my own making — the mechanical test update wrote `{..., **extra, "round": 1}`, so the fixed default overwrote every explicit override and the three-site known-positive's "rounds 7–10" were all silently running at round 1;
- a remedy that did not work — "drop `converge: false`" does nothing for a value resolved from `.paranoia.toml`.

**The loop was stopped by operator instruction at round 4 and did not converge.** Round 4 returned one MAJOR and one MINOR — both recurrences of a documentation class raised in every one of the four rounds, because each fix patched the instances the reviewer happened to cite. Both are fixed in the final commit and neither fix has been reviewed. Class `f38d0fe7` remains open in that lineage.

562 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)