### PR TITLE
Retry malformed arbitration verdicts once

### DIFF
--- a/README.md
+++ b/README.md
@@ -830,8 +830,11 @@ whose active claims are all supported makes zero claim-model calls. The normal s
 review still runs in every round and remains the dominant irreducible cost of convergence.
 
 `arbitrate` is the expensive one and the only tool that spends from **both**
-subscriptions in a single call: typically 4 agent turns, 8 at worst (a cleaning
-retry plus a reconciliation round).
+subscriptions in a single call. Research is on unless `research: false` explicitly
+selects repository-only mode. A parser-rejected decider reply receives one
+complete correction attempt while the sibling result and completed cleaning/research
+work are retained; execution failures are not retried. Every attempt remains subject
+to the phase cap and 3,600-second whole-call deadline.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -833,8 +833,9 @@ review still runs in every round and remains the dominant irreducible cost of co
 subscriptions in a single call. Research is on unless `research: false` explicitly
 selects repository-only mode. A parser-rejected decider reply receives one
 complete correction attempt while the sibling result and completed cleaning/research
-work are retained; execution failures are not retried. Every attempt remains subject
-to the phase cap and 3,600-second whole-call deadline.
+work are retained. If correction still fails, the audit records both rejected replies,
+the completed sibling, and the actual phase provenance; execution failures are not
+retried. Every attempt remains subject to the phase cap and 3,600-second whole-call deadline.
 
 ---
 

--- a/docs/arbitration_plan.md
+++ b/docs/arbitration_plan.md
@@ -11,7 +11,9 @@
 > repository-only mode. Deciders now read inert raw-tree materializations rather than Git
 > worktrees, so repository-controlled Git helpers and executable/symlink semantics are not part
 > of evidence presentation. Where this historical brief says otherwise, the current research
-> plan and README describe the shipped contract.
+> plan and README describe the shipped contract. The shipped handler also gives a parser-rejected
+> decider reply one bounded full-reply correction while retaining its completed sibling; the
+> eight-turn accounting later in this historical brief is therefore no longer normative.
 
 Status: FINAL for implementation, revision 11. Ten codex adversarial-review rounds
 folded — round 1: 1 FATAL, 9 MAJOR, 4 MINOR; round 2: 2 FATAL, 9 MAJOR, 3 MINOR;

--- a/docs/arbitration_research_plan.md
+++ b/docs/arbitration_research_plan.md
@@ -384,6 +384,11 @@ materialization, logging, and teardown. The handler tracks one monotonic whole-r
 will not start a phase whose cap plus reserved teardown margin cannot fit; that produces a visible
 bounded failure rather than a client timeout.
 
+A parser-rejected decider reply receives one complete correction attempt against the same inert
+snapshot and shared research packet. The completed sibling vote and all cleaning and research work
+are retained. This correction is still subject to the 900-second phase cap and whole-call deadline;
+it is not additional unbounded budget. Provider execution failures are not retried.
+
 ### 7. Audit and progress
 
 Add progress events for shared research and validation. Add trailer fields:

--- a/docs/arbitration_research_plan.md
+++ b/docs/arbitration_research_plan.md
@@ -386,8 +386,10 @@ bounded failure rather than a client timeout.
 
 A parser-rejected decider reply receives one complete correction attempt against the same inert
 snapshot and shared research packet. The completed sibling vote and all cleaning and research work
-are retained. This correction is still subject to the 900-second phase cap and whole-call deadline;
-it is not additional unbounded budget. Provider execution failures are not retried.
+are retained. If the correction is also rejected, those replies, the sibling, and the actual phase
+provenance remain in the failure audit. This correction is still subject to the 900-second phase cap
+and whole-call deadline; it is not additional unbounded budget. Provider execution failures are not
+retried.
 
 ### 7. Audit and progress
 

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -92,7 +92,7 @@ class DeciderFanOutError(ArbitrationError):
         self.failures = tuple(failures)
 
 
-class InvalidDeciderReply(ArbitrationError):
+class DeciderAttemptFailure(ArbitrationError):
     def __init__(self, message: str, attempts: Sequence[DeciderAttempt]) -> None:
         super().__init__(message)
         self.attempts = tuple(attempts)
@@ -1480,19 +1480,30 @@ def _fan_out(
             attempt_body = body
             attempts: list[DeciderAttempt] = []
             for attempt in range(2):
-                text = agent(
-                    engine_name=engine.name,
-                    model=models.get(engine.name) or engine.default_model,
-                    instructions=prompts.ARBITRATE_INSTRUCTIONS,
-                    body=attempt_body, cwd=review_cwd, effort=effort, web_search=False,
-                    timeout=DECIDE_TIMEOUT_SEC, text_only=False, role=eng.ROLE_REPOSITORY,
-                )
+                try:
+                    text = agent(
+                        engine_name=engine.name,
+                        model=models.get(engine.name) or engine.default_model,
+                        instructions=prompts.ARBITRATE_INSTRUCTIONS,
+                        body=attempt_body, cwd=review_cwd, effort=effort, web_search=False,
+                        timeout=DECIDE_TIMEOUT_SEC, text_only=False, role=eng.ROLE_REPOSITORY,
+                    )
+                except Exception as exc:
+                    if attempts:
+                        attempts.append(DeciderAttempt(
+                            attempt_body, "", f"execution failure: {type(exc).__name__}: {exc}",
+                        ))
+                        raise DeciderAttemptFailure(
+                            f"correction execution failed after a rejected reply: "
+                            f"{type(exc).__name__}: {exc}", attempts,
+                        ) from exc
+                    raise
                 try:
                     vote = arb.parse_verdict(text, presentation)
                 except ArbitrationError as exc:
                     attempts.append(DeciderAttempt(attempt_body, text, str(exc)))
                     if attempt == 1:
-                        raise InvalidDeciderReply(
+                        raise DeciderAttemptFailure(
                             f"reply remained invalid after one correction: {exc}", attempts,
                         ) from exc
                     attempt_body = (

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -1062,7 +1062,7 @@ def _failed_decision_report(
             snapshot=snapshot,
             seed=seed,
             refs_moved=refs_moved,
-            audit=str(audit) if audit else "none",
+            audit=str(audit) if audit else "FAILED could not write log",
             rounds=len(completed),
             research=research,
             research_digest=digest,

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -74,6 +74,30 @@ class Cast:
     attempts: tuple[DeciderAttempt, ...] = ()
 
 
+@dataclass(frozen=True)
+class DeciderFailure:
+    engine: str
+    error: str
+    attempts: tuple[DeciderAttempt, ...] = ()
+
+
+class DeciderFanOutError(ArbitrationError):
+    """A failed fan-out whose completed peer and rejected replies remain auditable."""
+
+    def __init__(
+        self, message: str, *, casts: Sequence[Cast], failures: Sequence[DeciderFailure],
+    ) -> None:
+        super().__init__(message)
+        self.casts = tuple(casts)
+        self.failures = tuple(failures)
+
+
+class InvalidDeciderReply(ArbitrationError):
+    def __init__(self, message: str, attempts: Sequence[DeciderAttempt]) -> None:
+        super().__init__(message)
+        self.attempts = tuple(attempts)
+
+
 @dataclass
 class Packet:
     """The cleaned, attested framing every decider sees identically."""
@@ -759,11 +783,23 @@ def _arbitrate(
 
     engine_names = [p.engine for p in presentations]
     progress(f"round 1: {', '.join(engine_names)}")
-    casts1 = _fan_out(
-        agent=budgeted_agent, repo=repo, snapshot=snapshot, deciders=deciders,
-        presentations=presentations, packet=packet, carried={}, models=models,
-        effort=effort, web_search=web_search,
-    )
+    try:
+        casts1 = _fan_out(
+            agent=budgeted_agent, repo=repo, snapshot=snapshot, deciders=deciders,
+            presentations=presentations, packet=packet, carried={}, models=models,
+            effort=effort, web_search=web_search,
+        )
+    except DeciderFanOutError as exc:
+        return _failed_decision_report(
+            failure=exc, completed=[], repo=repo, snapshot=snapshot, seed=seed,
+            refs_before=refs_before, cleaning_note=cleaning_note, packet=packet,
+            research_runs=research_runs, presentations=presentations,
+            label_attempts=attempts, log_dir=log_dir,
+            now=now, raw_input={
+                "decision": decision, "stakes": stakes, "context": context,
+                "options": originals, "files": hints,
+            },
+        )
     round1 = [c.vote for c in casts1]
 
     def resolve_region(citation: Citation) -> Region | None:
@@ -800,11 +836,23 @@ def _arbitrate(
             # cannot be the evidence a vote was reconciled by.
             sent = [region for region, _ in carried_bodies]
             carried = {v.engine: carried_bodies for v in round1}
-            casts2 = _fan_out(
-                agent=budgeted_agent, repo=repo, snapshot=snapshot, deciders=deciders,
-                presentations=presentations, packet=packet, carried=carried,
-                models=models, effort=effort, web_search=web_search,
-            )
+            try:
+                casts2 = _fan_out(
+                    agent=budgeted_agent, repo=repo, snapshot=snapshot, deciders=deciders,
+                    presentations=presentations, packet=packet, carried=carried,
+                    models=models, effort=effort, web_search=web_search,
+                )
+            except DeciderFanOutError as exc:
+                return _failed_decision_report(
+                    failure=exc, completed=[casts1], repo=repo, snapshot=snapshot,
+                    seed=seed, refs_before=refs_before, cleaning_note=cleaning_note,
+                    packet=packet, research_runs=research_runs,
+                    presentations=presentations, label_attempts=attempts,
+                    log_dir=log_dir, now=now, raw_input={
+                        "decision": decision, "stakes": stakes, "context": context,
+                        "options": originals, "files": hints,
+                    },
+                )
             round2 = [c.vote for c in casts2]
             transcripts.append(casts2)
             per_round.append({v.engine: v for v in round2})
@@ -865,24 +913,7 @@ def _arbitrate(
             "label_attempts": attempts,
             "cleaning": cleaning_note,
             "attestation": packet.attestation,
-            "research": {
-                "enabled": do_research,
-                "digest": research_core.digest(packet.research_packets) if do_research else None,
-                "packets": packet.research_text if do_research else None,
-                "runs": [
-                    {
-                        "engine": run.engine,
-                        "model": run.model,
-                        "discovery_raw": run.discovery_raw,
-                        "binding_raw": run.binding_raw,
-                        "calls": run.calls,
-                        "usage": run.usage,
-                        "durations_ms": run.durations_ms,
-                        "captures": [asdict(capture) for capture in run.captures],
-                    }
-                    for run in research_runs
-                ],
-            },
+            "research": _research_record(packet, research_runs),
             "raw_input": {
                 "decision": decision, "stakes": stakes, "context": context,
                 "options": originals, "files": hints,
@@ -898,12 +929,7 @@ def _arbitrate(
             # does not hold them, the run is unauditable once that happens.
             "rounds": [
                 {
-                    cast.vote.engine: {
-                        **_vote_record(cast.vote),
-                        "prompt": cast.body,
-                        "reply": cast.raw,
-                        "attempts": [asdict(attempt) for attempt in cast.attempts],
-                    }
+                    cast.vote.engine: _cast_record(cast)
                     for cast in casts
                 }
                 for casts in transcripts
@@ -931,6 +957,119 @@ def _arbitrate(
     )
 
 
+def _research_record(packet: Packet, runs: Sequence[ResearchRun]) -> dict[str, Any]:
+    return {
+        "enabled": packet.research_enabled,
+        "digest": (
+            research_core.digest(packet.research_packets)
+            if packet.research_enabled else None
+        ),
+        "packets": packet.research_text if packet.research_enabled else None,
+        "runs": [
+            {
+                "engine": run.engine,
+                "model": run.model,
+                "discovery_raw": run.discovery_raw,
+                "binding_raw": run.binding_raw,
+                "calls": run.calls,
+                "usage": run.usage,
+                "durations_ms": run.durations_ms,
+                "captures": [asdict(capture) for capture in run.captures],
+            }
+            for run in runs
+        ],
+    }
+
+
+def _failed_decision_report(
+    *,
+    failure: DeciderFanOutError,
+    completed: Sequence[Sequence[Cast]],
+    repo: Path,
+    snapshot: str,
+    seed: str,
+    refs_before: str,
+    cleaning_note: str,
+    packet: Packet,
+    research_runs: Sequence[ResearchRun],
+    presentations: Sequence[Presentation],
+    label_attempts: int,
+    raw_input: Mapping[str, Any],
+    log_dir: Path,
+    now: Clock,
+) -> str:
+    """Report a failed decider round without erasing work completed before it."""
+    refs_moved = evidence.refs_digest(repo) != refs_before
+    partial = {cast.vote.engine: _cast_record(cast) for cast in failure.casts}
+    partial.update({
+        item.engine: {
+            "status": "failed",
+            "error": item.error,
+            "attempts": [asdict(attempt) for attempt in item.attempts],
+        }
+        for item in failure.failures
+    })
+    audit = logs.write_log(
+        log_dir,
+        tool="arbitrate",
+        record={
+            "repo": str(repo),
+            "snapshot": snapshot,
+            "order_seed": seed,
+            "label_attempts": label_attempts,
+            "cleaning": cleaning_note,
+            "attestation": packet.attestation,
+            "research": _research_record(packet, research_runs),
+            "raw_input": dict(raw_input),
+            "cleaned": {
+                "decision": packet.decision,
+                "context": packet.context,
+                "statements": packet.statements,
+            },
+            "label_maps": {p.engine: dict(p.label_to_id) for p in presentations},
+            "rounds": [
+                {cast.vote.engine: _cast_record(cast) for cast in casts}
+                for casts in completed
+            ],
+            "failed_round": {
+                "number": len(completed) + 1,
+                "deciders": partial,
+            },
+            "outcome": arb.FAILED,
+            "selected": None,
+            "reason": str(failure),
+            "refs_moved": refs_moved,
+        },
+        timestamp=now(),
+    )
+    research = (
+        f"complete {len(packet.research_packets)} packets"
+        if packet.research_enabled else "repository-only"
+    )
+    digest = (
+        research_core.digest(packet.research_packets)
+        if packet.research_enabled else "none"
+    )
+    return "\n".join([
+        "# Arbitration: FAILED",
+        "",
+        str(failure),
+        "",
+        render_trailer(
+            arb.Outcome(arb.FAILED, None, str(failure)),
+            advisory="none",
+            cleaning=cleaning_note,
+            snapshot=snapshot,
+            seed=seed,
+            refs_moved=refs_moved,
+            audit=str(audit) if audit else "none",
+            rounds=len(completed),
+            research=research,
+            research_digest=digest,
+        ),
+    ])
+
+
 def _cited(vote: Vote) -> list[Citation]:
     """Every citation a vote offers — decisive plus supporting. Used to build the
     carried union; substantiation still looks only at the decisive one."""
@@ -951,6 +1090,15 @@ def _vote_record(vote: Vote) -> dict[str, Any]:
         "constraint": vote.constraint,
         "decisive": vote.decisive.render() if vote.decisive else None,
         "citations": [c.render() for c in vote.citations],
+    }
+
+
+def _cast_record(cast: Cast) -> dict[str, Any]:
+    return {
+        **_vote_record(cast.vote),
+        "prompt": cast.body,
+        "reply": cast.raw,
+        "attempts": [asdict(attempt) for attempt in cast.attempts],
     }
 
 
@@ -1344,8 +1492,8 @@ def _fan_out(
                 except ArbitrationError as exc:
                     attempts.append(DeciderAttempt(attempt_body, text, str(exc)))
                     if attempt == 1:
-                        raise ArbitrationError(
-                            f"reply remained invalid after one correction: {exc}"
+                        raise InvalidDeciderReply(
+                            f"reply remained invalid after one correction: {exc}", attempts,
                         ) from exc
                     attempt_body = (
                         body
@@ -1366,13 +1514,21 @@ def _fan_out(
         futures = {engine.name: pool.submit(one, engine) for engine in deciders}
     casts: list[Cast] = []
     errors: list[str] = []
+    failures: list[DeciderFailure] = []
     for name, future in futures.items():
         try:
             casts.append(future.result())
         except Exception as exc:  # noqa: BLE001 — name the engine that failed
             errors.append(f"{name}: {type(exc).__name__}: {exc}")
+            failures.append(DeciderFailure(
+                engine=name,
+                error=f"{type(exc).__name__}: {exc}",
+                attempts=getattr(exc, "attempts", ()),
+            ))
     if errors:
-        raise ArbitrationError("decider failure — " + "; ".join(errors))
+        raise DeciderFanOutError(
+            "decider failure — " + "; ".join(errors), casts=casts, failures=failures,
+        )
     return casts
 
 

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -54,6 +54,15 @@ def _default_clock() -> str:
 
 
 @dataclass(frozen=True)
+class DeciderAttempt:
+    """One complete decider reply, including why a superseded reply was rejected."""
+
+    body: str
+    raw: str
+    rejection: str | None = None
+
+
+@dataclass(frozen=True)
 class Cast:
     """One decider's turn: the vote, the exact prompt body it saw, and its raw
     reply. The prompt and reply are kept so the audit can reconstruct the decision
@@ -62,6 +71,7 @@ class Cast:
     vote: Vote
     body: str
     raw: str
+    attempts: tuple[DeciderAttempt, ...] = ()
 
 
 @dataclass
@@ -892,6 +902,7 @@ def _arbitrate(
                         **_vote_record(cast.vote),
                         "prompt": cast.body,
                         "reply": cast.raw,
+                        "attempts": [asdict(attempt) for attempt in cast.attempts],
                     }
                     for cast in casts
                 }
@@ -1318,14 +1329,38 @@ def _fan_out(
         body = render_decider_body(packet, presentation, tuple(carried.get(engine.name, ())))
         with inert_tree.evidence_workspace(repo, snapshot) as workspace:
             review_cwd = workspace.cwd_for(engine.name)
-            text = agent(
-                engine_name=engine.name,
-                model=models.get(engine.name) or engine.default_model,
-                instructions=prompts.ARBITRATE_INSTRUCTIONS,
-                body=body, cwd=review_cwd, effort=effort, web_search=False,
-                timeout=DECIDE_TIMEOUT_SEC, text_only=False, role=eng.ROLE_REPOSITORY,
-            )
-        return Cast(vote=arb.parse_verdict(text, presentation), body=body, raw=text)
+            attempt_body = body
+            attempts: list[DeciderAttempt] = []
+            for attempt in range(2):
+                text = agent(
+                    engine_name=engine.name,
+                    model=models.get(engine.name) or engine.default_model,
+                    instructions=prompts.ARBITRATE_INSTRUCTIONS,
+                    body=attempt_body, cwd=review_cwd, effort=effort, web_search=False,
+                    timeout=DECIDE_TIMEOUT_SEC, text_only=False, role=eng.ROLE_REPOSITORY,
+                )
+                try:
+                    vote = arb.parse_verdict(text, presentation)
+                except ArbitrationError as exc:
+                    attempts.append(DeciderAttempt(attempt_body, text, str(exc)))
+                    if attempt == 1:
+                        raise ArbitrationError(
+                            f"reply remained invalid after one correction: {exc}"
+                        ) from exc
+                    attempt_body = (
+                        body
+                        + "\n\n=== FORMAT CORRECTION ===\n"
+                        + f"Your previous reply was rejected: {str(exc)[:1000]}\n"
+                        + "Fix exactly that. Return one complete replacement reply. Do not "
+                        "quote, preview, or discuss any trailer field name in the prose before "
+                        "the final trailer block."
+                    )
+                    continue
+                attempts.append(DeciderAttempt(attempt_body, text))
+                return Cast(
+                    vote=vote, body=attempt_body, raw=text, attempts=tuple(attempts),
+                )
+        raise AssertionError("bounded decider correction loop did not return")
 
     with ThreadPoolExecutor(max_workers=max(1, len(deciders))) as pool:
         futures = {engine.name: pool.submit(one, engine) for engine in deciders}

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -307,7 +307,9 @@ TOOLS: list[Tool] = [
             "counterbalanced option order under its own opaque labels. Python computes the "
             "verdict: CONVERGED only on a unanimous, unblocked, evidence-substantiated choice. "
             "On divergence it runs one fact-only reconciliation round, and only when there is "
-            "novel evidence to carry. Up to 8 agent turns across both subscriptions. "
+            "novel evidence to carry. Each malformed decider reply gets one bounded full-reply "
+            "correction; execution failures are not retried. All phases remain inside the "
+            "whole-call deadline. "
             "SHAPE THE INPUT LIKE THIS: put every shared fact and the FULL specification of "
             "whatever only one option adopts into `context`, prefaced as 'the rules under "
             "consideration, if adopted'; leave each option statement to say only how much of it "
@@ -371,6 +373,7 @@ TOOLS: list[Tool] = [
                 "web_search": _COMMON["web_search"],
                 "research": {
                     "type": "boolean",
+                    "default": True,
                     "description": (
                         "Run shared authoritative external research before voting (default true). "
                         "Provider search discovers URLs; the server downloads and extracts pages, "

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -306,6 +306,40 @@ def test_decider_execution_failure_is_not_retried(repo: Path, tmp_path: Path):
     assert claude_calls == 1
 
 
+def test_correction_execution_failure_preserves_the_rejected_reply(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+    claude_calls = 0
+
+    def failed_correction(**kwargs):
+        nonlocal claude_calls
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            claude_calls += 1
+            if claude_calls == 2:
+                raise RuntimeError("provider unavailable during correction")
+        text = scripted(**kwargs)
+        return (
+            "AUTHORITY: duplicated too early\n" + text
+            if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude"
+            else text
+        )
+
+    report = run(repo, failed_correction, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "correction execution failed after a rejected reply" in report
+    assert claude_calls == 2
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    failure = record["failed_round"]["deciders"]["claude"]
+    assert len(failure["attempts"]) == 2
+    assert "reply mentions AUTHORITY:" in failure["attempts"][0]["rejection"]
+    assert "FORMAT CORRECTION" in failure["attempts"][1]["body"]
+    assert failure["attempts"][1]["raw"] == ""
+    assert "execution failure" in failure["attempts"][1]["rejection"]
+    assert record["failed_round"]["deciders"]["codex"]["selected"] == "opt-decimal"
+
+
 def test_whole_run_deadline_refuses_a_phase_that_cannot_fit(
     repo: Path, tmp_path: Path, monkeypatch,
 ):

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -221,6 +221,42 @@ def test_malformed_decider_reply_gets_one_full_correction(
     assert "FORMAT CORRECTION" in claude["attempts"][1]["body"]
 
 
+def test_terminal_decider_failure_preserves_default_research_provenance(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+
+    def researcher(**kwargs):
+        return ah.ResearchRun(
+            kwargs["engine"].name, kwargs["model"], (), (), (),
+            "discovery", "binding", 2, ({}, {}), (1, 1),
+        )
+
+    def always_bad_claude(**kwargs):
+        text = scripted(**kwargs)
+        return (
+            "AUTHORITY: duplicated too early\n" + text
+            if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude"
+            else text
+        )
+
+    args = {k: v for k, v in BASE.items() if k != "research"}
+    report = ah.arbitrate(
+        {**args, "repo_path": str(repo), "clean": False},
+        log_dir=tmp_path / "logs", engines=ENGINES, run_agent=always_bad_claude,
+        run_research=researcher, now=lambda: "20260727T120000",
+    )
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "RESEARCH") == "complete 0 packets"
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["research"]["enabled"] is True
+    assert len(record["research"]["runs"]) == 2
+    assert record["failed_round"]["deciders"]["codex"]["selected"] == "opt-decimal"
+    assert len(record["failed_round"]["deciders"]["claude"]["attempts"]) == 2
+
+
 def test_decider_reply_fails_after_exactly_one_correction(
     repo: Path, tmp_path: Path,
 ):
@@ -241,6 +277,15 @@ def test_decider_reply_fails_after_exactly_one_correction(
     decider_calls = [call for call in scripted.calls if call["cwd"] is not None]
     assert [call["engine"] for call in decider_calls].count("codex") == 1
     assert [call["engine"] for call in decider_calls].count("claude") == 2
+    assert trailer_field(report, "CLEANING") == "skipped"
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert trailer_field(report, "ROUNDS") == "0"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["failed_round"]["number"] == 1
+    assert record["failed_round"]["deciders"]["codex"]["selected"] == "opt-decimal"
+    failed = record["failed_round"]["deciders"]["claude"]
+    assert failed["status"] == "failed"
+    assert len(failed["attempts"]) == 2
 
 
 def test_decider_execution_failure_is_not_retried(repo: Path, tmp_path: Path):

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -5,6 +5,7 @@ both deciders, that labels are cleared against the real repository, that the
 round-2 gate is consulted before spending, and that the trailer tells the truth.
 """
 
+import json
 from pathlib import Path
 
 import pytest
@@ -191,6 +192,75 @@ def test_converged(repo: Path, tmp_path: Path):
     assert trailer_field(report, "ADVISORY") == "none"
 
 
+def test_malformed_decider_reply_gets_one_full_correction(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+    claude_attempts = 0
+
+    def flaky(**kwargs):
+        nonlocal claude_attempts
+        text = scripted(**kwargs)
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            claude_attempts += 1
+            if claude_attempts == 1:
+                return "AUTHORITY: technical\n" + text
+        return text
+
+    report = run(repo, flaky, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    decider_calls = [call for call in scripted.calls if call["cwd"] is not None]
+    assert [call["engine"] for call in decider_calls].count("codex") == 1
+    assert [call["engine"] for call in decider_calls].count("claude") == 2
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    claude = record["rounds"][0]["claude"]
+    assert len(claude["attempts"]) == 2
+    assert "reply mentions AUTHORITY:" in claude["attempts"][0]["rejection"]
+    assert claude["attempts"][1]["rejection"] is None
+    assert "FORMAT CORRECTION" in claude["attempts"][1]["body"]
+
+
+def test_decider_reply_fails_after_exactly_one_correction(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+
+    def always_bad_claude(**kwargs):
+        text = scripted(**kwargs)
+        return (
+            "SELECTED: duplicated too early\n" + text
+            if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude"
+            else text
+        )
+
+    report = run(repo, always_bad_claude, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "reply remained invalid after one correction" in report
+    decider_calls = [call for call in scripted.calls if call["cwd"] is not None]
+    assert [call["engine"] for call in decider_calls].count("codex") == 1
+    assert [call["engine"] for call in decider_calls].count("claude") == 2
+
+
+def test_decider_execution_failure_is_not_retried(repo: Path, tmp_path: Path):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+    claude_calls = 0
+
+    def failed_claude(**kwargs):
+        nonlocal claude_calls
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            claude_calls += 1
+            raise RuntimeError("provider unavailable")
+        return scripted(**kwargs)
+
+    report = run(repo, failed_claude, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "provider unavailable" in report
+    assert claude_calls == 1
+
+
 def test_whole_run_deadline_refuses_a_phase_that_cannot_fit(
     repo: Path, tmp_path: Path, monkeypatch,
 ):
@@ -254,6 +324,23 @@ def test_default_research_injects_one_shared_captured_packet_before_voting(
     assert len(decider_calls) == 2
     assert all(call["web_search"] is False for call in decider_calls)
     assert all(packet_id in call["body"] for call in decider_calls)
+
+
+def test_research_false_is_the_explicit_repository_only_switch(
+    repo: Path, tmp_path: Path,
+):
+    def researcher(**kwargs):
+        pytest.fail("research must not run when explicitly disabled")
+
+    agent = Agent(lambda engine, rnd: "opt-decimal")
+    report = ah.arbitrate(
+        {**BASE, "repo_path": str(repo), "clean": False},
+        log_dir=tmp_path / "logs", engines=ENGINES, run_agent=agent,
+        run_research=researcher, now=lambda: "20260727T120000",
+    )
+
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert trailer_field(report, "RESEARCH") == "repository-only"
 
 
 def test_research_packet_rejects_caller_id_in_captured_passage_before_voting(

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -904,6 +904,26 @@ def test_audit_failure_is_surfaced_not_swallowed(repo: Path, tmp_path: Path, mon
     assert trailer_field(report, "ARBITRATION") == "CONVERGED"  # verdict still returned
 
 
+def test_terminal_correction_audit_failure_is_surfaced(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    scripted = Agent(lambda e, r: "opt-float")
+
+    def malformed_claude(**kwargs):
+        text = scripted(**kwargs)
+        return (
+            "AUTHORITY: duplicated too early\n" + text
+            if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude"
+            else text
+        )
+
+    monkeypatch.setattr(ah.logs, "write_log", lambda *a, **k: None)
+    report = run(repo, malformed_claude, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "AUDIT") == "FAILED could not write log"
+
+
 def test_report_pairs_original_with_cleaned(repo: Path, tmp_path: Path):
     agent = Agent(
         lambda e, r: "opt-float",

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -51,6 +51,7 @@ class TestToolListing:
         props = tool.inputSchema["properties"]
         assert "engine" not in props and "model" not in props
         assert set(props["models"]["properties"]) == {"codex", "claude"}
+        assert props["research"]["default"] is True
 
     def test_critique_branch_requires_repo_path(self) -> None:
         tool = next(t for t in server.TOOLS if t.name == "critique_branch")


### PR DESCRIPTION
Adds one bounded correction attempt for parser-rejected decider replies while preserving the completed sibling and prior cleaning/research work. Strict verdict validation remains unchanged and provider execution failures are not retried. Terminal failures retain truthful phase provenance and rejected replies in the audit. Also makes arbitration research explicitly default-on in the public schema, with research: false as the opt-out.\n\nValidation:\n- 692 tests passed\n- Codex CODE review converged with 0 open classes