### PR TITLE
Make tracked plan reviews converge through staged census

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -113,9 +113,12 @@ state and reviewer-native capabilities meet the supported model.
   requires a full current server-captured and cold-attested evidence packet rather than a compact
   verdict-only assessment; edited
   wording also requires a new full packet. Removed and mechanically out-of-scope claims do not
-  consume active context. This optimization applies only to external verification: the
-  structural FATAL/MAJOR review remains broad and cold on every convergence round and must not
-  reopen evidence inventory for repository mechanics or “missing atomic bridges.”
+  consume active context. This optimization applies only to external verification. For tracked
+  structural review, a new snapshot's census and the final regression are broad and cold;
+  intervening correction rounds are deliberately targeted to open findings/classes, the claimed
+  corrections, and their transitive effects. Do not reopen external inventory for repository
+  mechanics or “missing atomic bridges,” and do not repeatedly hunt unrelated unchanged material
+  for novelty between the census and final regression.
 - Model omission and ID reuse are not removal: exact propositions alone preserve identity;
   every other predecessor requires old wording to be absent plus an explicit `removed`
   disposition. Surface absent old anchors as removal candidates on both the initial audit and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,10 +116,11 @@ state and reviewer-native capabilities meet the supported model.
   consume active context. This optimization applies only to external verification. For tracked
   plan reviews with claim verification explicitly disabled, retain claim packets without rendering
   or gating on them; if stakes change, persist a re-verification requirement and exhaustively audit
-  the preserved inventory when verification is next enabled. For tracked structural review, a new
-  snapshot's census and the final regression are broad and cold;
-  intervening correction rounds are deliberately targeted to open findings/classes, the claimed
-  corrections, and their transitive effects. Do not reopen external inventory for repository
+  the preserved inventory when verification is next enabled. For tracked plan structural review,
+  a new plan snapshot's census and the final regression are broad and cold; intervening correction
+  rounds are deliberately targeted to open findings/classes, the claimed corrections, and their
+  transitive effects. Tracked branch review remains broad and cold on every convergence round while
+  its staged lifecycle is validated separately. Do not reopen external inventory for repository
   mechanics or “missing atomic bridges,” and do not repeatedly hunt unrelated unchanged material
   for novelty between the census and final regression.
 - Model omission and ID reuse are not removal: exact propositions alone preserve identity;

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -114,7 +114,10 @@ state and reviewer-native capabilities meet the supported model.
   verdict-only assessment; edited
   wording also requires a new full packet. Removed and mechanically out-of-scope claims do not
   consume active context. This optimization applies only to external verification. For tracked
-  structural review, a new snapshot's census and the final regression are broad and cold;
+  plan reviews with claim verification explicitly disabled, retain claim packets without rendering
+  or gating on them; if stakes change, persist a re-verification requirement and exhaustively audit
+  the preserved inventory when verification is next enabled. For tracked structural review, a new
+  snapshot's census and the final regression are broad and cold;
   intervening correction rounds are deliberately targeted to open findings/classes, the claimed
   corrections, and their transitive effects. Do not reopen external inventory for repository
   mechanics or “missing atomic bridges,” and do not repeatedly hunt unrelated unchanged material

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,6 +8,9 @@
 - after plan approval, review the implementation branch—not the plan—unless design is explicitly
   reopened, and label runs PLAN versus CODE;
 - treat recurring classes as an architecture checkpoint, not permission for another patch;
+- use broad cold structural coverage for a tracked snapshot's census and final regression, while
+  targeting intervening correction rounds to open debt and correction effects rather than
+  repeatedly searching unrelated unchanged material for novelty;
 - prioritize accurate, fast, workable behavior and a small architecture over out-of-scope
   hardening;
 - keep plan claim verification on by default with reviewer-native search used only for URL

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,9 @@
 - after plan approval, review the implementation branch—not the plan—unless design is explicitly
   reopened, and label runs PLAN versus CODE;
 - treat recurring classes as an architecture checkpoint, not permission for another patch;
-- use broad cold structural coverage for a tracked snapshot's census and final regression, while
-  targeting intervening correction rounds to open debt and correction effects rather than
-  repeatedly searching unrelated unchanged material for novelty;
+- use broad cold structural coverage for a tracked plan snapshot's census and final regression, while
+  targeting its intervening correction rounds to open debt and correction effects; keep branch
+  convergence broad and cold until its staged lifecycle is separately accepted;
 - prioritize accurate, fast, workable behavior and a small architecture over out-of-scope
   hardening;
 - keep plan claim verification on by default with reviewer-native search used only for URL

--- a/README.md
+++ b/README.md
@@ -361,11 +361,13 @@ blocking debt; the server never starts a multiplicative hours-long tail or trunc
 false closure.
 The complete evidence phase also has a 3,000-second monotonic deadline and nine model calls
 maximum. That fits discovery, five maximum-size binding batches, cold attestation, and one
-correction in both discovery and binding. The full verified plan call is bounded to 3,540
-seconds: evidence state is persisted
-first, and the 1,200-second structural phase starts only if its complete cap still fits. Otherwise
-the result is blocked and the next round reuses frozen supported claims instead of repeating
-research. A class-register correction has its own 300-second cap under the same deadline.
+correction in both discovery and binding. The full verified plan call is bounded to 3,540 seconds.
+Evidence state is persisted first. A staged census starts only when its full 2,160-second
+lane/consolidation/retry reserve still fits; correction and final use a 1,560-second reserve. If the
+reserve no longer fits, the result is visibly pending and the next round reuses frozen supported
+claims instead of repeating research. Individual structural calls retain their 900/600/1,200 and
+300-second role limits. A legacy class-register correction has its own 300-second cap under the
+same deadline.
 The disposition parser consumes the claim ID, `removed` token, and reason while ignoring
 harmless extra model metadata; required fields, unambiguous aliases, and transition validity
 remain strict. Both governing coverage arrays remain required even when empty, and malformed
@@ -711,8 +713,8 @@ CONVERGENCE: BLOCKED — staged structural debt remains open.
 The legacy one-shot/injected-engine trailer retains `CLASS-REGISTER`, `CLASS-CLOSURE`, match, and
 unmechanized-class detail.
 
-`NOT-BLOCKED` asserts only that no blocking class is unclosed. It never asserts the
-change is correct — the reviewer's findings still govern that.
+`NOT-BLOCKED` asserts only that the computed structural-debt, class, and (for verified plans)
+external-claim gates are clear. It is a review result, not a proof that the change is correct.
 
 For verified plan reviews the claim gate and class gate are combined into one
 governing verdict:

--- a/README.md
+++ b/README.md
@@ -196,7 +196,10 @@ atomically with concrete finding debt. Every lane finding must be named by at le
 row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
 receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
-terminal register below remains the compatible contract for one-shot and injected-engine reviews:
+Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
+repository symlinks remain invalid. Disabling plan claim verification makes retained claim state
+dormant for that run: it is neither rendered nor gating, and is preserved for a later enabled run.
+The terminal register below remains the compatible contract for one-shot and injected-engine reviews:
 
 ```
 === CLASS REGISTER ===

--- a/README.md
+++ b/README.md
@@ -192,8 +192,11 @@ invariant, several sites. Class closure makes the class itself a tracked object
 that survives the round.
 
 Tracked Codex/Claude reviews return strict staged JSON, and the server applies their class records
-atomically with concrete finding debt. The terminal register below remains the compatible contract
-for one-shot and injected-engine reviews:
+atomically with concrete finding debt. Every lane finding must be named by at least one checklist
+row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
+receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
+Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
+terminal register below remains the compatible contract for one-shot and injected-engine reviews:
 
 ```
 === CLASS REGISTER ===

--- a/README.md
+++ b/README.md
@@ -845,9 +845,9 @@ Reviews draw on your subscription's agentic-usage pool. A tracked cold census is
 reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
 same-session format correction per call. Use `query` for quick checks.
 
-Audit `attempt_ledger` rows enumerate every provider run/resume exactly once. Concurrent census
-lanes are serialized in stable lane order for reproducible logs; that list is not a claim about
-their wall-clock start/completion order. Duration and session fields remain per-call telemetry.
+Audit `attempt_ledger` rows enumerate every provider run/resume exactly once. A synchronized
+sequence is assigned immediately before each concurrent census run/resume boundary, and the stage
+ledger is serialized by that sequence. Duration and session fields remain per-call telemetry.
 
 For `critique_plan`, round 1 pays for the exhaustive external-claim inventory. Later rounds send
 only the external edit cone and unresolved claims to the claim verifier; an unchanged plan

--- a/README.md
+++ b/README.md
@@ -133,12 +133,13 @@ round 1 ──► review ──► fix ──► round 2 ──► review ──
              └── already_raised ────────────┴── already_raised ────► CONVERGENCE: NOT-BLOCKED
 ```
 
-Tracked reviews use a staged lifecycle. A new or materially changed artifact starts with three
+Tracked plan reviews use a staged lifecycle. A new or materially changed plan starts with three
 independent cold lanes and one consolidation call. Their complete finding census becomes durable
 debt. Later correction rounds target that debt and correction effects; once it closes, one fresh
 whole-artifact final regression is mandatory. A clear initial census may converge immediately.
 This preserves broad first-pass/final coverage without paying for novelty hunting over unchanged
-material on every correction round.
+material on every correction round. Tracked branch reviews retain the established broad, cold
+single-review path while the branch census is validated separately.
 
 Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
 claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and
@@ -147,10 +148,10 @@ provider, parsing, deadline, or oversized-state failures block visibly rather th
 
 ### `round` — lineage ordering
 
-The 1-based round number. **Increment it every round.** In tracked staged review, census and final
+The 1-based round number. **Increment it every round.** In tracked staged plan review, census and final
 remain complete at every in-scope severity while correction is limited to durable debt and repair
-effects; convergence comes from that phase boundary, not a late-round sampling floor. The legacy
-single-review path retains its round-3 severity floor.
+effects; convergence comes from that phase boundary. Branch and other legacy single-review paths
+retain their broad review and round-3 severity floor.
 
 `round` is required on `critique_branch` and `critique_plan` unless you pass
 `class_closure: false`.
@@ -191,7 +192,7 @@ the claim and its citation, never the previous reviewer's prose.
 invariant, several sites. Class closure makes the class itself a tracked object
 that survives the round.
 
-Tracked Codex/Claude reviews return strict staged JSON, and the server applies their class records
+Tracked staged plan reviews return strict staged JSON, and the server applies their class records
 atomically with concrete finding debt. Every lane finding must be named by at least one checklist
 row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
 receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
@@ -477,7 +478,7 @@ Returns a [five-section critique](#review-output) plus a
 | `round` | integer | **required** unless `class_closure: false` | 1-based round number; must be an integer ≥ 1 |
 | `include_uncommitted` | boolean | `false` | Review the dirty working tree vs HEAD instead of a committed range. Runs in the live repo, not a worktree |
 | `isolate` | boolean | `true` | Review inside a throwaway worktree of `head_ref`. Ignored for uncommitted reviews |
-| `converge` | boolean | `true` | Pre-gather a bounded deterministic diff/file packet, materialize an immutable snapshot, and use the tracked census → correction → final lifecycle. Always materializes, overriding `isolate` |
+| `converge` | boolean | `true` | Pre-gather a bounded deterministic diff/file packet and materialize an immutable snapshot for tracked broad review. Always materializes, overriding `isolate` |
 | `max_packet_chars` | integer | `400000` | Character budget for that packet. `already_raised` is always preserved; only file evidence is trimmed |
 | `class_closure` | boolean | `true` | Track defect classes across rounds. `false` is the one-shot mode |
 | `lineage` | string | derived | Explicit class-closure key. Required when the reviewed ref is not a branch |
@@ -673,8 +674,8 @@ Accepted by the four review tools:
 
 ### Review output
 
-Every review returns exactly five headings, in this order. Legacy reviews populate their natural
-categories; tracked staged reviews put governing findings in `What doesn't work`, bounded remedies
+Every review returns exactly five headings, in this order. Legacy and tracked branch reviews populate
+their natural categories; tracked staged plan reviews put governing findings in `What doesn't work`, bounded remedies
 in `Improvements`, and write `Nothing notable.` in categories the settlement does not represent.
 
 | Section | Contains |
@@ -701,7 +702,7 @@ The footer carries the `session_ref` for [`rebut`](#rebut).
 
 ### Tracked convergence trailer
 
-Appended below the review whenever class closure ran:
+Appended below a staged tracked plan review:
 
 ```
 STRUCTURAL-PHASE: correction
@@ -718,8 +719,8 @@ CONVERGENCE: BLOCKED — staged structural debt remains open.
 | `STRUCTURAL-ERROR` / `STRUCTURAL-PENDING` | A bounded format/deadline path did not produce a settled review |
 | `STATE-UNAVAILABLE` | Lineage state is unreadable, unwritable, or a previous write may not have completed. The message names the absolute path; repair or delete it, then re-run |
 
-The legacy one-shot/injected-engine trailer retains `CLASS-REGISTER`, `CLASS-CLOSURE`, match, and
-unmechanized-class detail.
+Tracked branch, one-shot, and injected-engine trailers retain `CLASS-REGISTER`, `CLASS-CLOSURE`,
+match, and unmechanized-class detail.
 
 `NOT-BLOCKED` asserts only that the computed structural-debt, class, and (for verified plans)
 external-claim gates are clear. It is a review result, not a proof that the change is correct.
@@ -846,7 +847,7 @@ cannot silently reset a tracked lineage. Set `PARANOIA_STATE_ROOT` to relocate i
 
 ### Rate limits
 
-Reviews draw on your subscription's agentic-usage pool. A tracked cold census is three concurrent
+Reviews draw on your subscription's agentic-usage pool. A tracked plan cold census is three concurrent
 reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
 same-session format correction per call. Use `query` for quick checks.
 

--- a/README.md
+++ b/README.md
@@ -191,7 +191,9 @@ the claim and its citation, never the previous reviewer's prose.
 invariant, several sites. Class closure makes the class itself a tracked object
 that survives the round.
 
-The reviewer ends its review with a register block:
+Tracked Codex/Claude reviews return strict staged JSON, and the server applies their class records
+atomically with concrete finding debt. The terminal register below remains the compatible contract
+for one-shot and injected-engine reviews:
 
 ```
 === CLASS REGISTER ===
@@ -201,7 +203,7 @@ PATTERN: def (create|update)_[a-z_]+\(.*\):\n(?!.*validate)
 PATHSPEC: src/
 ```
 
-The server then, every round:
+The server then, on every applicable snapshot:
 
 - **re-runs each registered regex itself** against the reviewed snapshot
   (`git grep`), and lists every surviving match to the next reviewer;
@@ -223,14 +225,15 @@ soon as the wording changes, so predicates are not accepted there at all. Plan
 closure gives you *non-forgetting plus explicit closure*, not automatic recurrence
 detection.
 
-**Register transitions** a reviewer can emit, besides a new class:
+**Class transitions** a reviewer can emit, besides a new class:
 
 | Record | Effect |
 |---|---|
 | `CLOSED: <id>` | An unmechanized class is judged closed |
 | `REOPEN: <id>` | A closed unmechanized class is violated again |
 | `RECLASSIFY: <id> <severity>` | Correct a severity |
-| `SUPERSEDE: <id>` + `BY:` / `WITH-PATTERN:` / `WITH-PROCEDURE:` | Replace a class |
+| `SUPERSEDE: <id>` + `BY:` / `WITH-PATTERN:` / `WITH-PROCEDURE:` | Replace a class on the legacy text path |
+| staged `replace` | Atomically retire a predecessor and create its corrected open successor |
 
 You cannot emit these yourself — ask for them in `focus`, e.g. *"class 3f2a91c4 is
 registered MAJOR but its effect is cosmetic; reclassify it if you agree."*
@@ -327,11 +330,13 @@ calling coding agent performs the edit/rerun loop without waiting for a human:
    packets on the next targeted round; compact verdict-only assessments cannot cross the
    server-capture boundary. Settled claims
    cause no model call or web search. Edited claims inherit no verdict;
-5. repeat until the structural review says `CONVERGED` and the single computed trailer
+5. repeat until the single computed trailer
    says `CONVERGENCE: NOT-BLOCKED`.
 
-This changes only the external-evidence phase. Every round still runs the complete cold structural
-FATAL/MAJOR review with the full plan, repository, active claim register, and class lineage.
+Claim targeting changes only the external-evidence phase. Structural review runs a complete cold
+three-lane census for a new lineage/cleared snapshot, targeted correction against its durable debt,
+then one complete cold final regression. The full plan, repository, active claim register, and
+class lineage remain available throughout.
 The structural reviewer can still find architectural and repository blockers, but it is told
 not to manufacture evidence-register claims for repository mechanics or missing atomic bridges.
 
@@ -658,7 +663,9 @@ Accepted by the four review tools:
 
 ### Review output
 
-Every review returns exactly five sections, in this order:
+Every review returns exactly five headings, in this order. Legacy reviews populate their natural
+categories; tracked staged reviews put governing findings in `What doesn't work`, bounded remedies
+in `Improvements`, and write `Nothing notable.` in categories the settlement does not represent.
 
 | Section | Contains |
 |---|---|
@@ -682,27 +689,27 @@ next to its severity tag.
 
 The footer carries the `session_ref` for [`rebut`](#rebut).
 
-### Class-closure trailer
+### Tracked convergence trailer
 
 Appended below the review whenever class closure ran:
 
 ```
-LINEAGE: 9f2c1a4b0e77 (rounds recorded: 8)
-CLASS-REGISTER: parsed 1
-CLASS-CLOSURE: 1 open, 2 closed, 3 surviving matches, 0 exempt, 1 unmechanized
-CONVERGENCE: BLOCKED — 1 class(es) unclosed:
-  3f2a91c4 every public writer must validate before the first mutation (mechanized: 3 match(es))
+STRUCTURAL-PHASE: correction
+STRUCTURAL-DEBT: 2 blocking open
+CONVERGENCE: BLOCKED — staged structural debt remains open.
 ```
 
 | Line | Meaning |
 |---|---|
-| `CONVERGENCE: NOT-BLOCKED` | No blocking class is unclosed. Advisory classes may remain open |
-| `CONVERGENCE: BLOCKED` | Named classes are still open; any `CONVERGED` in the review above is void |
-| `CLASS-REGISTER: NONE` \| `parsed N` \| `malformed: …` | What the reviewer's register block contained |
-| `CLASS-CLOSURE-WARNING: … closed in the round it was registered` | The predicate matched nothing at birth — usually too narrow. Ask the next reviewer to `SUPERSEDE` it |
-| `BLOCKED — register debt from round N` | Two attempts at a parseable register failed. The next round with a good register clears it |
-| `unmechanized: awaiting reviewer CLOSED or RECLASSIFY` | A semantic class no regex can check |
+| `STRUCTURAL-PHASE: census\|correction\|final\|clear` | The next broad/targeted gate; `final` requires one fresh cold regression |
+| `STRUCTURAL-DEBT: N blocking open` | Concrete governing findings still requiring correction |
+| `CONVERGENCE: NOT-BLOCKED` | Structural debt/classes and, for plans, external claims are clear |
+| `CONVERGENCE: BLOCKED` | The named phase, debt, class, claim, format, or state condition still blocks |
+| `STRUCTURAL-ERROR` / `STRUCTURAL-PENDING` | A bounded format/deadline path did not produce a settled review |
 | `STATE-UNAVAILABLE` | Lineage state is unreadable, unwritable, or a previous write may not have completed. The message names the absolute path; repair or delete it, then re-run |
+
+The legacy one-shot/injected-engine trailer retains `CLASS-REGISTER`, `CLASS-CLOSURE`, match, and
+unmechanized-class detail.
 
 `NOT-BLOCKED` asserts only that no blocking class is unclosed. It never asserts the
 change is correct — the reviewer's findings still govern that.
@@ -829,14 +836,15 @@ cannot silently reset a tracked lineage. Set `PARANOIA_STATE_ROOT` to relocate i
 
 ### Rate limits
 
-Reviews draw on your subscription's agentic-usage pool, and a convergence loop is
-many agent turns. Use `query` for quick checks and reserve multi-round
-`critique_branch` loops for changes that warrant them.
+Reviews draw on your subscription's agentic-usage pool. A tracked cold census is three concurrent
+reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
+same-session format correction per call. Use `query` for quick checks.
 
 For `critique_plan`, round 1 pays for the exhaustive external-claim inventory. Later rounds send
 only the external edit cone and unresolved claims to the claim verifier; an unchanged plan
-whose active claims are all supported makes zero claim-model calls. The normal structural
-review still runs in every round and remains the dominant irreducible cost of convergence.
+whose active claims are all supported makes zero claim-model calls. Structural correction then
+targets durable debt instead of paying for another broad novelty search; the cold final remains the
+regression gate.
 
 `arbitrate` is the expensive one and the only tool that spends from **both**
 subscriptions in a single call. Research is on unless `research: false` explicitly

--- a/README.md
+++ b/README.md
@@ -469,7 +469,7 @@ Returns a [five-section critique](#review-output) plus a
 | `round` | integer | **required** unless `class_closure: false` | 1-based round number; must be an integer ≥ 1 |
 | `include_uncommitted` | boolean | `false` | Review the dirty working tree vs HEAD instead of a committed range. Runs in the live repo, not a worktree |
 | `isolate` | boolean | `true` | Review inside a throwaway worktree of `head_ref`. Ignored for uncommitted reviews |
-| `converge` | boolean | `true` | Pre-gather a deterministic evidence packet (every touched file in full, plus the diff) and review it against an immutable materialized snapshot. Always materializes, overriding `isolate` |
+| `converge` | boolean | `true` | Pre-gather a bounded deterministic diff/file packet, materialize an immutable snapshot, and use the tracked census → correction → final lifecycle. Always materializes, overriding `isolate` |
 | `max_packet_chars` | integer | `400000` | Character budget for that packet. `already_raised` is always preserved; only file evidence is trimmed |
 | `class_closure` | boolean | `true` | Track defect classes across rounds. `false` is the one-shot mode |
 | `lineage` | string | derived | Explicit class-closure key. Required when the reviewed ref is not a branch |

--- a/README.md
+++ b/README.md
@@ -145,12 +145,12 @@ claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PH
 `STRUCTURAL-DEBT` in the trailer show where the autonomous loop is. There is no fixed round ceiling:
 provider, parsing, deadline, or oversized-state failures block visibly rather than clearing.
 
-### `round` — the severity floor
+### `round` — lineage ordering
 
-The 1-based round number. **Increment it every round.** At `round >= 3` the
-reviewer reports only merge-blocking findings and withholds `[MINOR]` and
-`[OUT-OF-SCOPE]`, writing `CONVERGED` when none remain. This is the lever that
-makes a loop *stop* instead of grinding through diminishing findings.
+The 1-based round number. **Increment it every round.** In tracked staged review, census and final
+remain complete at every in-scope severity while correction is limited to durable debt and repair
+effects; convergence comes from that phase boundary, not a late-round sampling floor. The legacy
+single-review path retains its round-3 severity floor.
 
 `round` is required on `critique_branch` and `critique_plan` unless you pass
 `class_closure: false`.

--- a/README.md
+++ b/README.md
@@ -133,8 +133,17 @@ round 1 ──► review ──► fix ──► round 2 ──► review ──
              └── already_raised ────────────┴── already_raised ────► CONVERGENCE: NOT-BLOCKED
 ```
 
-Each structural round is a **fresh, cold reviewer**. Durable lineage state carries
-classes and plan-claim evidence forward; the reviewer never relies on chat memory.
+Tracked reviews use a staged lifecycle. A new or materially changed artifact starts with three
+independent cold lanes and one consolidation call. Their complete finding census becomes durable
+debt. Later correction rounds target that debt and correction effects; once it closes, one fresh
+whole-artifact final regression is mandatory. A clear initial census may converge immediately.
+This preserves broad first-pass/final coverage without paying for novelty hunting over unchanged
+material on every correction round.
+
+Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
+claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and
+`STRUCTURAL-DEBT` in the trailer show where the autonomous loop is. There is no fixed round ceiling:
+provider, parsing, deadline, or oversized-state failures block visibly rather than clearing.
 
 ### `round` — the severity floor
 

--- a/README.md
+++ b/README.md
@@ -845,6 +845,10 @@ Reviews draw on your subscription's agentic-usage pool. A tracked cold census is
 reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
 same-session format correction per call. Use `query` for quick checks.
 
+Audit `attempt_ledger` rows enumerate every provider run/resume exactly once. Concurrent census
+lanes are serialized in stable lane order for reproducible logs; that list is not a claim about
+their wall-clock start/completion order. Duration and session fields remain per-call telemetry.
+
 For `critique_plan`, round 1 pays for the exhaustive external-claim inventory. Later rounds send
 only the external edit cone and unresolved claims to the claim verifier; an unchanged plan
 whose active claims are all supported makes zero claim-model calls. Structural correction then

--- a/README.md
+++ b/README.md
@@ -199,6 +199,8 @@ Repository evidence anchors must resolve to ordinary files inside the exact iner
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state
 dormant for that run: it is neither rendered nor gating, and is preserved for a later enabled run.
+If stakes change while claims are disabled, the packets remain intact and the lineage records that
+the next enabled claim phase must exhaustively reverify them under the new stakes.
 The terminal register below remains the compatible contract for one-shot and injected-engine reviews:
 
 ```

--- a/docs/exhaustive_census_acceptance_evidence.md
+++ b/docs/exhaustive_census_acceptance_evidence.md
@@ -1,0 +1,90 @@
+# Implemented staged-census acceptance evidence
+
+This record freezes the pre-PR real-provider acceptance evidence for the staged structural-review
+lifecycle. The fixtures are historical snapshots; Paranoia Local did not edit them. Consequently,
+the acceptance question is whether the new mechanism recovers the old material defect classes,
+retains unresolved defects honestly, and spends later rounds on targeted re-entailment. A
+historical snapshot that still contains a material defect must not be made to converge merely to
+beat its former round count.
+
+All four successful reviews used Codex at high reasoning with live web search disabled. The stakes
+assumed one trusted operator and OS and first-party repositories. Correct numerical/identity logic,
+producer-consumer behaviour, provenance, recovery, and meaningful acceptance gates were material;
+hostile local races, compromised providers, multi-tenancy, security hardening, generic
+orchestration, unrelated legacy work, and scope expansion were excluded.
+
+## Plan replay
+
+- Historical lineage: `parallax~3~A3-HOLD-TERMINATOR~plan`, which reached round 16.
+- Census snapshot: `1376093e6d8febd0fd35d580b4390ddd45118675`.
+- Correction snapshot: `74c0355` (the fixture's historical revision-16 snapshot).
+- Census: three lane calls plus consolidation and one same-session consolidation format retry;
+  682,751 ms; lane finding counts 4 domain, 4 execution, and 4 integrity; five blocking governing
+  debts.
+- Correction: one targeted call plus one same-session marker-format retry; 208,376 ms; four debts
+  closed and one remained open.
+- Sessions: census consolidation `019fed53-f754-7083-a81a-5b9e2687ce7d`; correction
+  `019fed5e-b1b5-7ba3-b79a-0baaa3c1f4f4`.
+- Audit SHA-256: census
+  `77ea5d63beebd20fe6e7e298a2dab4e39a649157e0745b59986e0b8bbb15277d`; correction
+  `5a40c4cf0942c37a8aad8854de38846b2bfd2944f274dbc886ef48fb41aa24ed`.
+
+The census recovered the historical numerical/identity inconsistency, missing input/digest and
+artifact-authority contract, null-CIK disposition error, acceptance gaps, and recovery defects.
+Revision 16 repaired four governing roots. It did not supply the cap, threshold, transition,
+stale-operand, registry, regeneration, and canonical-tree evidence required by the final artifact
+contract, so that MAJOR stayed open. The result is `STRUCTURAL-DEBT: 1 blocking open`, not false
+convergence.
+
+The plan replay isolated structural review by setting `claim_verification:false`. The existing
+default-on external-claim acceptance and web-evidence tests remain separate because this change
+does not alter that pipeline; the staged lanes consume its retained claim packet when it is enabled.
+
+## Representative changing-branch replay
+
+- Historical lineage: `parallax~3~SPINE-COVERAGE-EXTENSION`; the implementation review progressed
+  through round 10 before its old mechanism reported convergence.
+- Base: `ddb319c171b14c7485034df893d3211d3e34df1f`.
+- First implementation snapshot: `d6bcb0c`.
+- Historical converged snapshot used for correction: `f79f89c4134f83c772e22605539acc6da8f10226`.
+- Census on the first implementation: three lane calls plus consolidation and one same-session
+  consolidation format retry; 666,728 ms; lane finding counts 7 behaviour, 8 execution, and 5
+  integrity; ten blocking governing debts plus one MINOR.
+- Correction on the historical converged snapshot: one targeted call plus one same-session
+  marker-format retry; 193,948 ms; four debts closed and six remained open.
+- Sessions: census consolidation `019fed53-9981-79a0-9a3a-664320411138`; correction
+  `019fed5d-f3fd-7c53-8115-ab4801ecb710`.
+- Audit SHA-256: census
+  `b525607ef277c64c67fb31057a39ca22ec7613af9cf8e0d180bbcf6c9f94de9a`; correction
+  `3bff7bf5d33294d741f7e5c996a6825fc65cbea82a353c5979e6bd43f25ac146`.
+
+The broad first census recovered the historical fresh-materialization ceiling, evidence routing,
+backlog declaration, mutation-head provenance, test-gate, and documentation roots. It also found
+material defects still present in the snapshot previously called converged: SPOT exclusion was
+resolution-dependent, completion provenance accepted a placeholder authorization, a focused test
+forbade the authorized append, linked worktrees were broken, Parquet schema was unchecked, and
+immutable-ledger replacement was non-atomic. The correction phase re-tested every debt and kept
+exactly those six open. This is stronger review quality than the old round-10 clearance, but it is
+not a claim that the unchanged historical code converged in two rounds.
+
+## Cost and conclusion
+
+The initial broad census is deliberately expensive: both real fixtures needed five provider turns
+because consolidation required its bounded formatting retry. Correction used two turns only
+because Codex again omitted the exact leading marker on its first otherwise substantive reply; the
+retry stayed in the same session and did no new broad review. Wall time fell from about 11 minutes
+for census to about 3.3 minutes for correction.
+
+This evidence supports the intended shape:
+
+- broad independent review catches at least the material roots the older long loops found, and in
+  the branch fixture caught six material survivors that old convergence missed;
+- durable debt prevents those findings from disappearing between rounds;
+- correction re-entails the fixed list rather than running three more novelty-seeking lanes;
+- the final cold review is reachable only after the operator or autonomous implementation loop has
+  actually repaired all blocking debt.
+
+The implemented Paranoia Local branch review is the end-to-end convergence gate: its own reported
+debts are repaired in the branch, followed by targeted correction and one cold final regression.
+The historical replays are a blinded quality/cost comparator, not an oracle allowed to force
+clearance of defective bytes.

--- a/docs/exhaustive_census_acceptance_evidence.md
+++ b/docs/exhaustive_census_acceptance_evidence.md
@@ -81,10 +81,14 @@ This evidence supports the intended shape:
   the branch fixture caught six material survivors that old convergence missed;
 - durable debt prevents those findings from disappearing between rounds;
 - correction re-entails the fixed list rather than running three more novelty-seeking lanes;
-- the final cold review is reachable only after the operator or autonomous implementation loop has
-  actually repaired all blocking debt.
+- zero blocking debt advances to one mandatory cold final; a final finding returns to targeted
+  correction and requires another cold regression after repair.
 
-The implemented Paranoia Local branch review is the end-to-end convergence gate: its own reported
-debts are repaired in the branch, followed by targeted correction and one cold final regression.
-The historical replays are a blinded quality/cost comparator, not an oracle allowed to force
-clearance of defective bytes.
+The public fake-backed acceptance now executes both plan and branch through census, correction, and
+cold final, including phase trailers and per-round audit ledgers. The implemented Paranoia Local
+branch review is the real-provider end-to-end convergence gate: its own reported debts are repaired
+in the branch, followed by targeted correction and a cold final regression. Its completed final
+session, snapshot, call count, elapsed time, and audit digest belong to the immutable audit log and
+PR/handoff report produced after the reviewed commit; writing that future result into this commit
+would change the snapshot and make the attestation stale. The historical replays are a blinded
+quality/cost comparator, not an oracle allowed to force clearance of defective bytes.

--- a/docs/exhaustive_census_acceptance_evidence.md
+++ b/docs/exhaustive_census_acceptance_evidence.md
@@ -1,94 +1,57 @@
-# Implemented staged-census acceptance evidence
+# Plan staged-census acceptance evidence
 
-This record freezes the pre-PR real-provider acceptance evidence for the staged structural-review
-lifecycle. The fixtures are historical snapshots; Paranoia Local did not edit them. Consequently,
-the acceptance question is whether the new mechanism recovers the old material defect classes,
-retains unresolved defects honestly, and spends later rounds on targeted re-entailment. A
-historical snapshot that still contains a material defect must not be made to converge merely to
-beat its former round count.
+This record freezes the real-provider acceptance evidence for activating the staged structural
+review lifecycle in tracked plan review. The branch lifecycle remains disabled: it is being
+validated separately and is not implied by this evidence.
 
-All four successful reviews used Codex at high reasoning with live web search disabled. The stakes
-assumed one trusted operator and OS and first-party repositories. Correct numerical/identity logic,
-producer-consumer behaviour, provenance, recovery, and meaningful acceptance gates were material;
-hostile local races, compromised providers, multi-tenancy, security hardening, generic
-orchestration, unrelated legacy work, and scope expansion were excluded.
+The replay used Codex at high reasoning with live web search disabled. Its frozen stakes assumed
+one trusted operator and OS and first-party repositories. Correct domain behaviour, provenance,
+recovery and meaningful acceptance gates were material. Hostile local races, compromised
+providers, multi-tenancy, generic orchestration, unrelated hardening and scope expansion were
+excluded.
 
-## Plan replay
+## Representative plan replay
 
-- Historical lineage: `parallax~3~A3-HOLD-TERMINATOR~plan`, which reached round 16.
-- Census snapshot: `1376093e6d8febd0fd35d580b4390ddd45118675`.
-- Correction snapshot: `74c0355` (the fixture's historical revision-16 snapshot).
-- Census: three lane calls plus consolidation and one same-session consolidation format retry;
-  682,751 ms; lane finding counts 4 domain, 4 execution, and 4 integrity; five blocking governing
-  debts.
-- Correction: one targeted call plus one same-session marker-format retry; 208,376 ms; four debts
-  closed and one remained open.
-- Sessions: census consolidation `019fed53-f754-7083-a81a-5b9e2687ce7d`; correction
-  `019fed5e-b1b5-7ba3-b79a-0baaa3c1f4f4`.
-- Audit SHA-256: census
-  `77ea5d63beebd20fe6e7e298a2dab4e39a649157e0745b59986e0b8bbb15277d`; correction
-  `5a40c4cf0942c37a8aad8854de38846b2bfd2944f274dbc886ef48fb41aa24ed`.
+- Historical lineage: `parallax~3~A3-HOLD-TERMINATOR~plan`, whose previous review required 16
+  rounds/calls.
+- New lifecycle: five rounds and nine observed provider calls. One call was an exact settlement
+  marker correction that the implemented parser now accepts directly, so the same transcript
+  shape requires eight calls in the completed implementation.
+- New measured usage: 26,021,382 processed input tokens, including 24,432,640 cached; 110,779
+  output tokens, including 69,627 reasoning; 1,699,521 uncached-input-plus-output tokens.
+- Historical usage: approximately 97.4 million processed input tokens, 489,800 output tokens and
+  3.93 million uncached-input-plus-output tokens.
+- New elapsed wall time: approximately 35.4 minutes. Comparable historical wall time was not
+  recorded, so no unsupported elapsed-time ratio is claimed.
 
-The census recovered the historical numerical/identity inconsistency, missing input/digest and
-artifact-authority contract, null-CIK disposition error, acceptance gaps, and recovery defects.
-Revision 16 repaired four governing roots. It did not supply the cap, threshold, transition,
-stale-operand, registry, regeneration, and canonical-tree evidence required by the final artifact
-contract, so that MAJOR stayed open. The result is `STRUCTURAL-DEBT: 1 blocking open`, not false
-convergence.
+The cold census recovered every applicable historical FATAL/MAJOR root and found three additional
+material defects. The operator corrected the dossier from the reviewer's actionable evidence
+packets. Targeted correction retained unresolved debt instead of rediscovering the plan, and the
+mandatory cold final regression reached `CONVERGENCE: NOT-BLOCKED`. This is materially stronger
+review quality with 50% of the historical provider calls after the parser correction, about 27% of
+processed input, and about 43% of uncached-input-plus-output.
 
-The plan replay isolated structural review by setting `claim_verification:false`. The existing
-default-on external-claim acceptance and web-evidence tests remain separate because this change
-does not alter that pipeline; the staged lanes consume its retained claim packet when it is enabled.
+The replay isolated structural review with `claim_verification:false` because the change does not
+alter the default-on external-claim pipeline. Plan claim acceptance and real captured-web-evidence
+tests cover that pipeline separately; when enabled, staged structural lanes consume the retained
+claim register and evidence packets.
 
-## Representative changing-branch replay
+## Branch status: deferred
 
-- Historical lineage: `parallax~3~SPINE-COVERAGE-EXTENSION`; the implementation review progressed
-  through round 10 before its old mechanism reported convergence.
-- Base: `ddb319c171b14c7485034df893d3211d3e34df1f`.
-- First implementation snapshot: `d6bcb0c`.
-- Historical converged snapshot used for correction: `f79f89c4134f83c772e22605539acc6da8f10226`.
-- Census on the first implementation: three lane calls plus consolidation and one same-session
-  consolidation format retry; 666,728 ms; lane finding counts 7 behaviour, 8 execution, and 5
-  integrity; ten blocking governing debts plus one MINOR.
-- Correction on the historical converged snapshot: one targeted call plus one same-session
-  marker-format retry; 193,948 ms; four debts closed and six remained open.
-- Sessions: census consolidation `019fed53-9981-79a0-9a3a-664320411138`; correction
-  `019fed5d-f3fd-7c53-8115-ab4801ecb710`.
-- Audit SHA-256: census
-  `b525607ef277c64c67fb31057a39ca22ec7613af9cf8e0d180bbcf6c9f94de9a`; correction
-  `3bff7bf5d33294d741f7e5c996a6825fc65cbea82a353c5979e6bd43f25ac146`.
+The strict same-start branch comparison did converge and found additional material defects, but it
+did not pass the all-metrics efficiency gate: eight rounds plus one rebuttal, 14 provider calls,
+33,990,209 processed input tokens, and 2,033,499 uncached-input-plus-output tokens, versus the old
+lineage's 10 rounds/calls, 27,907,358 processed input tokens, and approximately 1,901,974
+uncached-input-plus-output tokens. Stronger quality does not justify claiming an efficiency win.
 
-The broad first census recovered the historical fresh-materialization ceiling, evidence routing,
-backlog declaration, mutation-head provenance, test-gate, and documentation roots. It also found
-material defects still present in the snapshot previously called converged: SPOT exclusion was
-resolution-dependent, completion provenance accepted a placeholder authorization, a focused test
-forbade the authorized append, linked worktrees were broken, Parquet schema was unchecked, and
-immutable-ledger replacement was non-atomic. The correction phase re-tested every debt and kept
-exactly those six open. This is stronger review quality than the old round-10 clearance, but it is
-not a claim that the unchanged historical code converged in two rounds.
+Consequently this change activates staged census only for tracked plans. Tracked branch review
+continues to use the established broad, cold single-review/class-register path until a separate
+implementation proves both review quality and representative convergence efficiency.
 
-## Cost and conclusion
+## Acceptance conclusion
 
-The initial broad census is deliberately expensive: both real fixtures needed five provider turns
-because consolidation required its bounded formatting retry. Correction used two turns only
-because Codex again omitted the exact leading marker on its first otherwise substantive reply; the
-retry stayed in the same session and did no new broad review. Wall time fell from about 11 minutes
-for census to about 3.3 minutes for correction.
-
-This evidence supports the intended shape:
-
-- broad independent review catches at least the material roots the older long loops found, and in
-  the branch fixture caught six material survivors that old convergence missed;
-- durable debt prevents those findings from disappearing between rounds;
-- correction re-entails the fixed list rather than running three more novelty-seeking lanes;
-- zero blocking debt advances to one mandatory cold final; a final finding returns to targeted
-  correction and requires another cold regression after repair.
-
-The public fake-backed acceptance now executes both plan and branch through census, correction, and
-cold final, including phase trailers and per-round audit ledgers. The implemented Paranoia Local
-branch review is the real-provider end-to-end convergence gate: its own reported debts are repaired
-in the branch, followed by targeted correction and a cold final regression. Its completed final
-session, snapshot, call count, elapsed time, and audit digest belong to the immutable audit log and
-PR/handoff report produced after the reviewed commit; writing that future result into this commit
-would change the snapshot and make the attestation stale. The historical replays are a blinded
-quality/cost comparator, not an oracle allowed to force clearance of defective bytes.
+Focused schema/handler tests cover the four-call cold census, targeted correction, mandatory cold
+final, parser correction, durable debt, phase trailers and audit ledgers. The full local suite is
+the regression gate. The real plan replay establishes the intended product outcome: exhaustive
+first-pass coverage, evidence-directed autonomous correction, honest durable debt, and materially
+cheaper convergence without weakening the final cold regression.

--- a/docs/exhaustive_census_prototype_evidence.md
+++ b/docs/exhaustive_census_prototype_evidence.md
@@ -1,0 +1,91 @@
+# Exhaustive-census prototype evidence
+
+This record freezes the evidence used to choose the staged-census architecture. It is not a shipping
+acceptance result. Shipping still requires the blinded, implemented A/B convergence replays in
+`docs/exhaustive_review_census_plan.md`.
+
+## Plan fixture
+
+- Historical lineage: `parallax~3~A3-HOLD-TERMINATOR~plan` (16 review rounds).
+- Repository commit: `1376093e6d8febd0fd35d580b4390ddd45118675`.
+- Artifact: `dataset/certification/A3-HOLD-TERMINATOR_contract.md`.
+- Artifact SHA-256: `5cce5bf952455959cf69dfbae74120c03386746eca2888316a2a58592606300d`.
+- Raw prototype record SHA-256:
+  `a11a8cb3c3eb960e016f28713d4fe1670076810f941efe3e2d4ad668141a2291`.
+- Engine: Codex, high reasoning; no historical findings or class oracle was supplied.
+- Method: three independent whole-artifact lanes (`domain`, `execution`, `integrity`) ran in
+  parallel with the fixed nine-item checklist in the plan. A fourth call consolidated every lane
+  finding by source ID without conducting another review.
+- Sessions: `019fecae-11f3-7c03-ab0c-ce5480a1c520` (domain),
+  `019fecae-1466-7f33-8da8-a6a1ac890529` (execution),
+  `019fecae-11ca-7500-b46a-21f426601514` (integrity), and
+  `019fecb7-5e18-7900-b038-c6f4e3edbc38` (consolidation).
+- Calls and time: four valid calls; 691,728 ms monotonic elapsed, of which consolidation used
+  81,907 ms. Lane output contained 5, 7, and 7 findings respectively. The complete four-call JSON
+  record was 46,708 bytes.
+
+The consolidation mapped all 19 source findings exactly once into these eight governing findings:
+
+| ID | Severity | Governing finding | Historical root class recovered |
+| --- | --- | --- | --- |
+| C1 | FATAL | The plan targets a retired producer and specifies an artifact the canonical consumer does not accept. | Wrong executable producer/consumer |
+| C2 | MAJOR | The numerical minimum and predicted movement image are not established by the measurements. | Unsupported numerical and movement-image conclusions |
+| C3 | MAJOR | CIK and lifetime-symbol identity bridge distinct issuer/security epochs and mishandle unknown identity. | Null-CIK/reused-identity error |
+| C4 | MAJOR | Required A1, ADR digest, and class-economics inputs are absent or unbound. | Missing reproducible inputs/digests |
+| C5 | MAJOR | The proposed artifact lacks a complete, authenticated, deterministic producer/consumer contract. | Incomplete artifact contract |
+| C6 | MAJOR | Acceptance omits material identity, predicate, provenance, and poison-boundary behavior. | Acceptance/test gaps |
+| C7 | MAJOR | The declared card base conflicts with the pinned Git history. | Card-base mismatch |
+| C8 | MAJOR | The escalation and recovery sequence is prose, not an executable fail-closed protocol. | Non-executable escalation path |
+
+The historical first-round claim verifier separately registered eight external claims, refuting
+three and leaving five unverified. Structural census is therefore additive to, not a replacement
+for, the existing authoritative external-evidence path.
+
+## Interpretation
+
+This blind first-pass result recovered every applicable historical FATAL/MAJOR root class used as
+the oracle. It supports the small design choice: exact retention of reported findings, fixed
+responsibility ownership, durable debt, targeted correction, and one cold final regression. It
+does not show how many rounds the implemented loop needs or prove branch-mode coverage. Those are
+mandatory pre-PR gates and will receive their own frozen acceptance records.
+
+## Branch fixture
+
+- Historical lineage: `parallax~3~SPINE-COVERAGE-EXTENSION`, which reached sequential round 11.
+  Its 17 audit logs include replayed round numbers and must not be reported as 17 sequential rounds.
+- Base: `9f8961521fc2da53bf6184b7c56746ba709035a9`.
+- Head: `4787a36aed9fd99987eb7682cdba21af5fa18a16`.
+- Raw prototype record SHA-256:
+  `a6768c95dc3033779aa22a1bd51a35e880975d52ba78b071fd30163b841fe57d`.
+- Engine: Codex, high reasoning; no historical findings or class oracle was supplied.
+- Method: three independent whole-diff lanes (`behaviour`, `execution`, `integrity`) plus one
+  source-ID-complete consolidation call, using the same fixed checklist as the plan prototype.
+- Sessions: `019fecc1-e644-78e3-904d-d2a341efda50` (behaviour),
+  `019fecc1-e664-7dd3-a7b8-4d1d3bb220dd` (execution),
+  `019fecc1-e60d-7fd2-bce3-9cb954bdce22` (integrity), and
+  `019fecca-78fa-72e0-9222-e7b06c1ed4ad` (consolidation).
+- Calls and time: four valid calls; 603,685 ms monotonic elapsed, of which consolidation used
+  41,462 ms. Lanes returned 3, 4, and 2 findings; all nine were mapped exactly once into six
+  governing findings.
+
+The governing result comprised five MAJORs and one MINOR. It recovered the historical
+missing-adjudication/default-classification defect and the known-red/governance-test branch-gate
+coverage defects. It also identified whole-module rather than identity-bounded ledger repair,
+caller-controlled/circular `source_commit` provenance, incomplete nested-test selection, and drift
+between reviewed backlog population and application. This is a useful first-pass branch signal,
+but it is not the shipping A/B: the acceptance replay must follow the lineage's ordered snapshots,
+evaluate findings against the frozen per-snapshot historical oracle, and measure complete
+convergence rather than only one final-head census.
+
+## Existing-state sizing observation
+
+On 2026-08-10, the design pass parsed all 106 JSON lineage files in the operator's existing
+`~/.paranoia/lineages` store and ran each through the current mode-appropriate context renderers:
+`render_unclosed`, `render_unmechanized`, and `render_exempt`. This includes headings, class state,
+detail, every retained match, exemptions, and displayed escaping—not only the semantic fields. The
+largest exact rendered context was 20,973 characters
+(`parallax~3~APPEND-ASSURANCE-SUCCESSOR~plan`, 36 active class records); the largest individual
+procedure was 651 characters. This observation supports a 64,000-character
+active-class-context boundary for the stated real-world scale. It does not justify silent
+truncation: any state outside that supported boundary must report `STATE-OVERSIZED` and remain
+blocked.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -105,8 +105,9 @@ required integrity class assessment and every finding with lane-scoped ID, sever
 resolved evidence anchors, and remedy. Stakes and snapshot identity are server-owned inputs; the
 manifest is governing and extra prose is rejected.
 The server rejects missing/duplicate checklist IDs, dangling or unbound findings, invalid severity,
-and unresolvable plan/repository/diff anchors. Repository anchors may not traverse symlinks; they
-must name ordinary files in the inert reviewed tree. It does not claim to validate semantic entailment or enumerate every
+and unresolvable plan/repository/diff anchors. Repository anchors may not traverse repository
+symlinks; Codex's server-owned `repository/` launch alias is resolved to the inert tree before
+validation. Anchors must name ordinary files in that tree. It does not claim to validate semantic entailment or enumerate every
 paragraph and hunk. One same-session correction names the exact schema error; a second malformed
 reply visibly blocks the attempt.
 

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -1,14 +1,18 @@
-# Staged census for tracked plan and branch review
+# Staged census for tracked plan review
 
-Status: revision 13, approved for implementation by the operator after an architecture checkpoint
-and blinded prototypes.
+Status: the plan lifecycle is accepted and activated. The branch lifecycle remains a design under
+separate validation and is not activated by this change.
 
 ## 1. Outcome and proportionate stakes
 
-Tracked `critique_plan` and `critique_branch` reviews should front-load independent structural
+Tracked `critique_plan` reviews should front-load independent structural
 coverage, correct one consolidated finding set, and converge through targeted closure plus one cold
 full regression. They should stop using every correction round as another novelty-maximising review
 of unchanged material.
+
+The same architecture may later serve `critique_branch`, but only after a representative strict
+same-start comparison proves both material review quality and convergence efficiency. Until then,
+tracked branch review retains its established broad, cold single-review/class-register path.
 
 Operating model: one trusted operator and OS; first-party repositories; plan/repository bytes and
 model replies are untrusted data. There is no hostile same-user race, compromised OS or provider,
@@ -270,24 +274,27 @@ assessment, exact severity/debt retention, resolved anchors, atomic `REPLACE`, a
 the unchanged injected-engine/one-shot contracts. Real acceptance below supplies the provider and
 maximum-real-input coverage that fake-backed tests cannot establish.
 
-Pre-PR real gates:
+Plan activation gates:
 
 1. full local suite;
-2. simulated plan and branch census → correction → final, including failures and audit fields;
+2. simulated plan census → correction → final, including failures and audit fields;
 3. real Codex plan review convergence under section 1 stakes;
-4. real Codex implementation review convergence under the same stakes;
+4. real Codex implementation review convergence under the established branch-review path;
 5. blinded replay of the recoverable 16-round plan fixture above through the implemented path,
    with frozen historical-class oracle, provider-call count and monotonic elapsed time;
-6. equivalent blinded replay for a recoverable changing-branch lineage that historically reached
-   round 10–19, testing its first implementation and historically converged snapshots;
-7. each new census must recover every applicable historical FATAL/MAJOR root class without an
+6. each new plan census must recover every applicable historical FATAL/MAJOR root class without an
    unresolved new FATAL/MAJOR false positive. Targeted correction must close repaired roots and
    retain any material defect still present in the historical bytes; old convergence is comparison
    evidence, not authority to force a new false clearance. The implementation's own convergence
    run must use the staged correction/final lifecycle, and measured wall time/call cost must be
    reported rather than waived;
-8. acceptance records with fixture/digest/oracle/result metadata committed under `docs/`. The
+7. acceptance records with fixture/digest/oracle/result metadata committed under `docs/`. The
    completed final review's invocation metadata remains in its immutable audit log and PR/handoff
    report: committing a statement that the current commit passed a later review would change the
    reviewed snapshot and make that statement self-referentially stale;
-9. only then open a PR, pass CI, merge, and update the primary `main` worktree.
+8. only then open a PR, pass CI, merge, and update the primary `main` worktree.
+
+Branch activation has a separate gate: a strict same-start representative replay must be materially
+better than the established path in quality, rounds, provider calls, processed input, and
+uncached-input-plus-output. The first comparison improved quality but used 14 calls versus 10 and
+more tokens, so branch staging is deliberately deferred.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -1,0 +1,292 @@
+# Staged census for tracked plan and branch review
+
+Status: revision 13, approved for implementation by the operator after an architecture checkpoint
+and blinded prototypes.
+
+## 1. Outcome and proportionate stakes
+
+Tracked `critique_plan` and `critique_branch` reviews should front-load independent structural
+coverage, correct one consolidated finding set, and converge through targeted closure plus one cold
+full regression. They should stop using every correction round as another novelty-maximising review
+of unchanged material.
+
+Operating model: one trusted operator and OS; first-party repositories; plan/repository bytes and
+model replies are untrusted data. There is no hostile same-user race, compromised OS or provider,
+multi-tenancy, public service, adversarial process environment, or deliberate quota exhaustion.
+Real inputs include plans around 300 KB, existing branch packets up to 400 KB, and tens of findings.
+False structural clearance is high impact. Visible blocking, one bounded format correction, or one
+additional cold regression is recoverable. Material correctness and evidence quality come first;
+useful wall time, subscription cost, and a small maintainable architecture follow. Exclude generic
+workflow engines, security hardening, project-specific rules, automatic source edits, formal proof,
+and numerical round ceilings that convert incomplete review into clearance.
+
+The server freezes the normalised stakes text and digest in lineage state. A changed or absent
+calibration invalidates frozen claim support, reopens active unmechanised classes for re-triage, and
+starts a new claim inventory and structural census. It does not mix clearance made under unknown or
+different stakes.
+
+## 2. Evidence before implementation
+
+The earlier design attempted to prove semantic completeness with one status per paragraph, hunk,
+search term, and discovered consumer. That created a second analysis protocol, Git-search
+calibration, large manifests, and maximum-shape problems. It was disproportionate: a parser can
+prove that a model filled fields, but cannot prove that the model understood every premise. The
+mechanical guarantee should instead be exact retention of every blocking finding the reviewers
+actually report, complete ownership of a fixed stakes-bounded responsibility checklist, durable
+debt, and a mandatory final cold review.
+
+A blinded disposable prototype tested that smaller architecture against the exact first input of a
+representative 16-round historical plan lineage:
+
+- lineage: `parallax~3~A3-HOLD-TERMINATOR~plan`;
+- repository commit: `1376093e6d8febd0fd35d580b4390ddd45118675`;
+- plan SHA-256: `5cce5bf952455959cf69dfbae74120c03386746eca2888316a2a58592606300d`;
+- three independent Codex lanes plus one consolidation call;
+- elapsed time: 691,728 ms; valid model calls: four;
+- lane findings: 5 domain, 7 execution, and 7 integrity; consolidation produced eight blocking root
+  findings.
+
+Without seeing the historical findings, the prototype recovered the material numerical
+movement-image error, null-CIK/reused-identity error, missing digest/input closure, wrong executable
+consumer, incomplete artifact contract, acceptance gaps, card-base mismatch, and non-executable
+escalation path. The existing first-round external-claim verifier separately registered eight
+external claims for this frozen input, with three refuted and five unverified, covering the
+historical evidence-authority failure. The frozen method, sessions, governing results, and
+raw-output digest are recorded in `docs/exhaustive_census_prototype_evidence.md`; no acceptance
+premise depends on the temporary raw file.
+
+This is sufficient to proceed with the small architecture, not sufficient to ship it. Before PR
+creation, repeat the comparison through the implemented path and add a representative 10–19-round
+changing-branch fixture as described in section 7.
+
+## 3. Lifecycle
+
+The staged lifecycle applies only when tracked class closure is enabled. One-shot and explicit
+`converge:false` behaviour keep their current single-call contracts.
+
+### 3.1 Census
+
+A new lineage or materially new clear snapshot runs three independent lanes concurrently against
+the same immutable plan/repository snapshot, frozen stakes, and captured external-claim packets.
+Each receives the complete artifact and existing repository tools. Plan lanes are `domain`,
+`execution`, and `integrity`; branch lanes are `behaviour`, `execution`, and `integrity`.
+
+Each lane owns the same fixed checklist from its perspective:
+
+1. complete artifact and stated requirements;
+2. repository/current-behaviour premises;
+3. inputs, transformations, outputs and calculations;
+4. consumers, callers and blast radius;
+5. failure and recovery paths;
+6. tests and acceptance;
+7. documentation and operator workflow;
+8. cross-section/component consistency;
+9. simplicity, proportionality and scope.
+
+The `integrity` lane also receives every active class, including closed unmechanised classes, and
+must assess each as `satisfied|violated` with a resolved anchor. Each `violated` assessment must
+name a source finding. Settlement maps every assessment ID exactly once: `violated` requires open
+concrete debt and, when the class was closed, either `REOPEN` or one atomic `REPLACE` that retires
+the predecessor and creates an open successor with the corrected invariant, severity and procedure.
+`REPLACE` is the staged representation of existing supersession semantics; it never emits a second
+transition against the predecessor. `satisfied` requires `CLOSED` when the class was open and no
+transition when it was already closed. Omission, contradiction, or two operations against one class
+rejects the whole settlement. This makes recurrence mechanically blocking before a blocker-free
+census can use immediate clearance without repeating the class context in all three lane prompts.
+
+The lane returns one strict JSON manifest: lane/snapshot/stakes digests, every checklist ID exactly
+once with `covered|finding|not_applicable`, a bounded summary and one or more resolved evidence
+anchors, every required integrity class assessment, and every finding with lane-scoped ID, severity,
+summary, resolved evidence anchors, and remedy. The manifest is governing; prose is optional diagnostics.
+The server rejects missing/duplicate checklist IDs, dangling findings, invalid severity, and
+unresolvable plan/repository/diff anchors. It does not claim to validate semantic entailment or
+enumerate every paragraph and hunk. One same-session correction names the exact schema error; a
+second malformed reply visibly blocks the attempt.
+
+One consolidation call receives the parsed findings, checklist digests/summaries, integrity class
+assessments, frozen stakes, and current class IDs/invariants. Claim packets and repeated lane prose
+are omitted: their structural conclusions are already present in validated findings. Consolidation
+groups shared root causes without conducting another broad review. Its one staged JSON envelope
+contains every source-finding disposition, integrity-assessment disposition, governing finding,
+concrete-debt record, and class registration/transition in structured form. Every source finding
+of every severity and every integrity assessment is mapped exactly once; the governing severity
+cannot be lower than any merged source; every blocking governing finding maps to exactly one open
+concrete-debt record. The server parses the complete envelope into the existing
+`Register`/lineage types, validates all fields, then applies finding and class state atomically. A
+missing source or assessment ID, dangling merge, missing blocking debt, unsupported class
+transition, or prose-only blocker rejects the whole envelope. The legacy terminal text class block
+remains only on unstaged one-shot paths.
+
+A valid census costs four model calls over two serial wall-clock phases. The bounded worst case is
+eight calls when all four replies need their one format correction. All limits use Python Unicode
+characters. The existing `MAX_PACKET_CHARS = 400_000` evidence-packet contract remains unchanged.
+Each active-claim projection is capped at 8,000 characters after the binding limits above, so the
+existing 500-claim maximum contributes at most 4,000,000 characters; current retirements have a
+separate 500,000-character aggregate bound. The staged lane's exact complete prompt therefore has
+a separate 5,000,000-character ceiling: this composes
+the maximum claim projection with the existing packet, instructions, stakes and class context
+without consuming artifact capacity. Each lane envelope is
+capped at 48,000 characters, with 2,000-character summaries/remedies and 512-character anchors.
+New class invariant/procedure fields are capped at 1,000/2,000 characters and total rendered active
+class context at 64,000 characters. Before a lane call, render its exact prompt and reject over
+5,000,000 characters; do not further truncate an already valid evidence packet. Consolidation has no
+artifact packet and retains a 400,000-character exact-prompt ceiling; three maximum lane envelopes
+leave more than 250,000 characters for its instructions, stakes, and class context. The plan
+prototype's complete raw four-call JSON record was 46,708 bytes.
+
+The real lineage census at design time found a largest exact rendered class context of 20,973
+characters and a largest procedure of 651 characters, so every existing operator lineage fits. The
+measurement used the current plan/branch context renderers and included headings, state, detail,
+matches, exemptions and escaping. Persisted state
+already beyond the new 64,000-character support boundary returns explicit `STATE-OVERSIZED` with
+its path and measured size and cannot clear. Building an autonomous semantic compactor for a
+hypothetical legacy shape would add a new review protocol and is excluded under the stated
+non-adversarial, observed-scale stakes.
+
+### 3.2 Correction
+
+A later round beginning with blocking debt runs one targeted reviewer. It receives every open
+concrete finding, every active open class including advisory classes, surviving mechanised matches,
+the claimed corrections, and their transitive effects. Closed unmechanised classes are omitted. The
+prompt permits new or reopened findings only when introduced or exposed by the correction; it does
+not ask for unrelated novelty in unchanged material.
+
+Its terminal staged JSON envelope accounts for every open concrete finding as `closed|open`, with
+resolved evidence for closure, may add a correction-introduced finding, and carries structured new
+class records/transitions. The server converts those class records to the existing reusable
+invariant model only after the whole envelope validates. Missing debt or an unregistered prose
+blocker rejects the reply and gets one bounded same-session format correction.
+
+When correction closes all blocking finding, class, and claim debt, computed output remains blocked
+with `FINAL-REGRESSION: required`. The same round cannot declare final convergence.
+
+### 3.3 Final regression
+
+The next round is one fresh, cold, whole-artifact review using the normal broad reviewer contract,
+the fixed checklist, complete current snapshot, frozen stakes, actionable claim packets, and every
+active class. Its strict staged envelope uses `role: final`, evidence-bearing checklist results,
+findings, concrete-debt transitions, exact-one `class_assessments`, and structured class
+records/transitions. The same `satisfied|violated`, debt, `REOPEN`, and `REPLACE` settlement rules
+used by census apply through one shared validator. If it finds no new/reopened blocker and claim
+closure is clear, the server emits `CONVERGENCE: NOT-BLOCKED`. A blocker returns the lineage to
+correction and requires another final regression after repair.
+
+A census with no blocker may converge immediately: three independent broad lanes already supplied
+the cold review. There is no arbitrary maximum round. Repeated root classes remain visible and
+trigger the existing architecture-checkpoint guidance rather than automatic patching.
+
+## 4. Minimal durable state
+
+Extend the existing atomically replaced lineage JSON; do not add a state store. Versioned
+`review_state` contains:
+
+- frozen stakes text/digest;
+- `census|correction|final|clear` phase;
+- last census/final snapshot digest;
+- concrete review debt: ID, severity, summary, evidence, source IDs, status and round metadata.
+
+Concrete debt carries exact census findings until correction. The existing class register continues
+to carry reusable invariants; claim state continues to carry external evidence. Clearance requires
+no blocking debt in any of the three.
+
+Transitions settle with class results in one atomic lineage write: census with blockers →
+correction; census clear → clear; correction with blockers → correction; correction clear → final;
+final with blockers → correction; final clear → clear. `clear` plus a changed artifact starts a new
+census. Artifact changes during correction remain correction because edits are expected there.
+
+A legacy lineage without `review_state` has unknown calibration and starts a new inventory+census.
+Plan claim verification still runs before structural review. Valid claim-evidence progress may
+persist when structural work later fails or lacks deadline; structural phase does not advance until
+a valid structural settlement. Audit logs record phase, stakes/snapshot digests, validated
+manifests/dispositions, and one attempt-ledger row for every actual `run`/`resume`: role,
+engine/session, outcome, duration, and usage. Aggregate provider calls are the ledger length, never
+inferred from a status string.
+
+## 5. Small code shape
+
+- Add one pure `review_census.py` module for lane/checklist definitions, manifest/disposition parsing,
+  anchor validation and consolidation rendering. It contains no provider, Git-search or persistence
+  subsystem.
+- Extend the existing `Transition` with one `REPLACE` kind carrying successor invariant, severity
+  and procedure/predicate. `apply_register` retires the predecessor and creates one open successor
+  atomically; this is not encoded as `REOPEN` plus another transition.
+- Add census, correction and final instruction blocks in `prompts.py`; retain the existing review
+  sections, claim packets and class-register semantics.
+- Add one shared handler runner for three parallel calls plus consolidation. Plan and branch use it
+  only in census; existing single-review paths implement correction and final.
+- Thread the same small attempt-ledger collector through plan discovery, capture binding,
+  attestation, every retry, and structural calls; expose its rows in the existing audit JSON.
+- Extend current closure preparation/settlement with stakes, phase and concrete finding debt.
+- Preserve plan claim verification exactly: authoritative server-captured web evidence remains
+  default-on, frozen unchanged supported claims avoid repeat web/model calls, and structural lanes
+  receive the complete active claim register and current-round retirements with live web disabled,
+  preserving the canonical cold-review invariant. Each claim carries its proposition, replacement,
+  source URL/location and up to two decisive passages; durable state retains extra corroboration.
+  Ingestion bounds all rendered fields and each selected exact passage, while the aggregate exact
+  renderer caps each claim record at 8,000 characters. Existing oversized state returns
+  `STATE-OVERSIZED` and cannot clear.
+- Keep `AGENTS.md` and `CLAUDE.md` amendments already made: census/final are broad and cold;
+  correction is targeted to open debt and correction effects.
+- Update README and tool schemas with default phases, costs, autonomous correction workflow,
+  frozen-stakes reset, final-regression gate, and the explicit limit that checklist completion is
+  strong review evidence rather than formal semantic proof.
+
+## 6. Deadlines and failure
+
+Create one monotonic 3,540-second tracked-review deadline for both modes. Census reserves 900 seconds
+for the parallel lanes, 600 for consolidation, and 60 for persistence/teardown. Correction/final
+reserve 1,200 seconds for the primary call, 300 for their sole format/register retry, and 60 for
+teardown. Preflight the complete applicable reserve and pass bounded remaining time to every
+`run`/`resume`; do not let engine defaults outlive the whole call.
+
+Plan evidence gathering can consume most of a request. If the full census reserve no longer fits,
+persist valid claim progress, leave phase and structural round unchanged, and return explicit
+resumable structural-pending output. The autonomous caller repeats the same round; retained evidence
+makes it cheaper. Completed sibling lane replies remain in failure audit diagnostics, but a retry
+starts one fresh immutable census attempt. Cancellation, provider execution failure and deadline are
+terminal for that attempt, not format errors.
+
+The supported local runtime is a trusted execution boundary, not an externally researched factual
+premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local
+caps; a provider refusal, truncation, timeout, malformed response, or exhausted deadline visibly
+blocks and cannot settle review state. Pinning provider versions, researching advertised context
+windows, or treating the monotonic clock as an internet claim would not establish what happened in
+the current invocation and is outside the frozen stakes.
+
+## 7. Tests and acceptance
+
+Pure tests cover manifests, every schema rejection, consolidation retention/merge/severity,
+resolved anchors on every checklist row and finding, all-source/all-assessment disposition, phase
+transitions/migration, stakes reset, concrete debt and deadline arithmetic. They also prove that a
+closed active class recurring in an otherwise clean census is assessed by the integrity lane,
+registered as durable debt, and blocks clearance.
+
+Scripted handler tests cover concurrent byte-identical inputs; four-call valid census; one bounded
+format correction; sibling diagnostics; correction → required final → convergence/reopen; census
+immediate convergence; claim progress with structural phase unchanged; branch predicate sweeping;
+all active-class visibility in final; and unchanged one-shot/`converge:false` contracts. Maximum
+300 KB plan and 400 KB branch fixtures, maximum supported class context, and three maximum valid
+lane envelopes must fit the exact rendered requests without content truncation. A non-ASCII fixture
+proves limits count characters rather than UTF-8 bytes; an oversized legacy state visibly blocks.
+The plan maximum-shape fixture also carries 500 maximum 8,000-character active claim records plus
+current retirements and proves the complete lane prompt remains within 5,000,000 characters. Final tests
+require exact-one class assessment and exercise a closed recurrence settled by atomic `REPLACE`.
+Attempt-ledger tests enumerate discovery, binding batches, attestation, census lanes,
+consolidation, correction, final, and format retries exactly once.
+
+Pre-PR real gates:
+
+1. full local suite;
+2. simulated plan and branch census → correction → final, including failures and audit fields;
+3. real Codex plan review convergence under section 1 stakes;
+4. real Codex implementation review convergence under the same stakes;
+5. blinded A/B replay of the recoverable 16-round plan fixture above through both base-commit and
+   new mechanisms, with frozen historical-class oracle, provider-call count and monotonic elapsed
+   time;
+6. equivalent blinded A/B replay for a recoverable changing-branch lineage that historically took
+   10–19 rounds, including its ordered snapshots;
+7. each new census must recover every applicable historical FATAL/MAJOR root class without an
+   unresolved new FATAL/MAJOR false positive; the new convergence run must use fewer rounds, and its
+   measured wall time/call cost must be reported rather than waived;
+8. acceptance records with fixture/digest/oracle/result/audit metadata committed under `docs/`;
+9. only then open a PR, pass CI, merge, and update the primary `main` worktree.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -83,8 +83,9 @@ Each lane owns the same fixed checklist from its perspective:
 8. cross-section/component consistency;
 9. simplicity, proportionality and scope.
 
-The `integrity` lane also receives every active class, including closed unmechanised classes, and
-must assess each as `satisfied|violated` with a resolved anchor. Each `violated` assessment must
+The `integrity` lane also receives every active class, including closed unmechanised and closed
+mechanised classes, with its invariant, severity, state, and procedure or pattern/pathspec. It must
+assess each as `satisfied|violated` with a resolved anchor. Each `violated` assessment must
 name a source finding. Settlement maps every assessment ID exactly once: `violated` requires open
 concrete debt and, when the class was closed, either `REOPEN` or one atomic `REPLACE` that retires
 the predecessor and creates an open successor with the corrected invariant, severity and procedure.
@@ -95,15 +96,18 @@ closed satisfied class. Omission, contradiction, or two operations against one c
 rejects the whole settlement. This makes recurrence mechanically blocking before a blocker-free
 census can use immediate clearance without repeating the class context in all three lane prompts.
 
-The lane returns one strict JSON manifest: its lane, every checklist ID exactly
-once with `covered|finding|not_applicable`, a bounded summary and one or more resolved evidence
-anchors, every required integrity class assessment, and every finding with lane-scoped ID, severity,
-summary, resolved evidence anchors, and remedy. Stakes and snapshot identity are server-owned inputs;
-the manifest is governing and extra prose is rejected.
-The server rejects missing/duplicate checklist IDs, dangling findings, invalid severity, and
-unresolvable plan/repository/diff anchors. It does not claim to validate semantic entailment or
-enumerate every paragraph and hunk. One same-session correction names the exact schema error; a
-second malformed reply visibly blocks the attempt.
+The lane returns one strict JSON manifest: its lane, every checklist ID exactly once with
+`covered|finding|not_applicable`, a bounded summary, one or more resolved evidence anchors, and the
+IDs of findings governing that row. A `finding` row must name findings, other statuses must not,
+and every lane finding must be named by at least one checklist row. The manifest also carries every
+required integrity class assessment and every finding with lane-scoped ID, severity, summary,
+resolved evidence anchors, and remedy. Stakes and snapshot identity are server-owned inputs; the
+manifest is governing and extra prose is rejected.
+The server rejects missing/duplicate checklist IDs, dangling or unbound findings, invalid severity,
+and unresolvable plan/repository/diff anchors. Repository anchors may not traverse symlinks; they
+must name ordinary files in the inert reviewed tree. It does not claim to validate semantic entailment or enumerate every
+paragraph and hunk. One same-session correction names the exact schema error; a second malformed
+reply visibly blocks the attempt.
 
 One consolidation call receives the parsed findings, checklist digests/summaries, integrity class
 assessments, frozen stakes, and current class IDs/invariants. Claim packets and repeated lane prose

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -87,7 +87,8 @@ The `integrity` lane also receives every active class, including closed unmechan
 mechanised classes, with its invariant, severity, state, and procedure or pattern/pathspec. It must
 assess each as `satisfied|violated` with a resolved anchor. Each `violated` assessment must
 name a source finding. Settlement maps every assessment ID exactly once: `violated` requires open
-concrete debt and, when the class was closed, either `REOPEN` or one atomic `REPLACE` that retires
+concrete debt through the same governing finding as that cited lane finding and, when the class was
+closed, either `REOPEN` or one atomic `REPLACE` that retires
 the predecessor and creates an open successor with the corrected invariant, severity and procedure.
 `REPLACE` is the staged representation of existing supersession semantics; it never emits a second
 transition against the predecessor. A satisfied open unmechanised class requires `CLOSED`; a

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -205,8 +205,8 @@ persist when structural work later fails or lacks deadline; structural phase doe
 a valid structural settlement. Audit logs record phase, stakes/snapshot digests, validated
 manifests/dispositions, and one attempt-ledger row for every actual `run`/`resume`: role,
 engine/session, outcome, duration, and usage. Aggregate provider calls are the ledger length, never
-inferred from a status string. Concurrent lanes are serialized in stable lane order; without a
-provider-boundary timestamp the ledger does not claim temporal ordering between them.
+inferred from a status string. Concurrent structural calls receive a synchronized monotonic
+sequence immediately before each provider run/resume boundary and are serialized by that sequence.
 
 ## 5. Small code shape
 

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -89,15 +89,17 @@ name a source finding. Settlement maps every assessment ID exactly once: `violat
 concrete debt and, when the class was closed, either `REOPEN` or one atomic `REPLACE` that retires
 the predecessor and creates an open successor with the corrected invariant, severity and procedure.
 `REPLACE` is the staged representation of existing supersession semantics; it never emits a second
-transition against the predecessor. `satisfied` requires `CLOSED` when the class was open and no
-transition when it was already closed. Omission, contradiction, or two operations against one class
+transition against the predecessor. A satisfied open unmechanised class requires `CLOSED`; a
+mechanised class remains governed by its snapshot predicate. No transition is needed for an already
+closed satisfied class. Omission, contradiction, or two operations against one class
 rejects the whole settlement. This makes recurrence mechanically blocking before a blocker-free
 census can use immediate clearance without repeating the class context in all three lane prompts.
 
-The lane returns one strict JSON manifest: lane/snapshot/stakes digests, every checklist ID exactly
+The lane returns one strict JSON manifest: its lane, every checklist ID exactly
 once with `covered|finding|not_applicable`, a bounded summary and one or more resolved evidence
 anchors, every required integrity class assessment, and every finding with lane-scoped ID, severity,
-summary, resolved evidence anchors, and remedy. The manifest is governing; prose is optional diagnostics.
+summary, resolved evidence anchors, and remedy. Stakes and snapshot identity are server-owned inputs;
+the manifest is governing and extra prose is rejected.
 The server rejects missing/duplicate checklist IDs, dangling findings, invalid severity, and
 unresolvable plan/repository/diff anchors. It does not claim to validate semantic entailment or
 enumerate every paragraph and hunk. One same-session correction names the exact schema error; a
@@ -119,17 +121,15 @@ remains only on unstaged one-shot paths.
 
 A valid census costs four model calls over two serial wall-clock phases. The bounded worst case is
 eight calls when all four replies need their one format correction. All limits use Python Unicode
-characters. The existing `MAX_PACKET_CHARS = 400_000` evidence-packet contract remains unchanged.
-Each active-claim projection is capped at 8,000 characters after the binding limits above, so the
-existing 500-claim maximum contributes at most 4,000,000 characters; current retirements have a
-separate 500,000-character aggregate bound. The staged lane's exact complete prompt therefore has
-a separate 5,000,000-character ceiling: this composes
-the maximum claim projection with the existing packet, instructions, stakes and class context
-without consuming artifact capacity. Each lane envelope is
+characters. The existing `MAX_PACKET_CHARS = 400_000` branch evidence-packet contract remains
+unchanged. Plan review passes the complete active claim register and current retirements; it does
+not truncate evidence that may change authority or entailment. Each exact staged lane prompt has a
+5,000,000-character ceiling, and an oversized prompt persists visible format debt rather than
+running partially or clearing. Each lane envelope is
 capped at 48,000 characters, with 2,000-character summaries/remedies and 512-character anchors.
 New class invariant/procedure fields are capped at 1,000/2,000 characters and total rendered active
 class context at 64,000 characters. Before a lane call, render its exact prompt and reject over
-5,000,000 characters; do not further truncate an already valid evidence packet. Consolidation has no
+5,000,000 characters; do not truncate a valid evidence packet. Consolidation has no
 artifact packet and retains a 400,000-character exact-prompt ceiling; three maximum lane envelopes
 leave more than 250,000 characters for its instructions, stakes, and class context. The plan
 prototype's complete raw four-call JSON record was 46,708 bytes.
@@ -212,19 +212,16 @@ inferred from a status string.
   atomically; this is not encoded as `REOPEN` plus another transition.
 - Add census, correction and final instruction blocks in `prompts.py`; retain the existing review
   sections, claim packets and class-register semantics.
-- Add one shared handler runner for three parallel calls plus consolidation. Plan and branch use it
-  only in census; existing single-review paths implement correction and final.
+- Add one shared handler runner for three parallel calls plus consolidation and for the targeted
+  correction/final calls.
 - Thread the same small attempt-ledger collector through plan discovery, capture binding,
   attestation, every retry, and structural calls; expose its rows in the existing audit JSON.
 - Extend current closure preparation/settlement with stakes, phase and concrete finding debt.
 - Preserve plan claim verification exactly: authoritative server-captured web evidence remains
   default-on, frozen unchanged supported claims avoid repeat web/model calls, and structural lanes
   receive the complete active claim register and current-round retirements with live web disabled,
-  preserving the canonical cold-review invariant. Each claim carries its proposition, replacement,
-  source URL/location and up to two decisive passages; durable state retains extra corroboration.
-  Ingestion bounds all rendered fields and each selected exact passage, while the aggregate exact
-  renderer caps each claim record at 8,000 characters. Existing oversized state returns
-  `STATE-OVERSIZED` and cannot clear.
+  preserving the canonical cold-review invariant. The exact composed prompt is checked before each
+  call; existing oversized state returns explicit staged debt and cannot clear.
 - Keep `AGENTS.md` and `CLAUDE.md` amendments already made: census/final are broad and cold;
   correction is targeted to open debt and correction effects.
 - Update README and tool schemas with default phases, costs, autonomous correction workflow,
@@ -233,11 +230,10 @@ inferred from a status string.
 
 ## 6. Deadlines and failure
 
-Create one monotonic 3,540-second tracked-review deadline for both modes. Census reserves 900 seconds
-for the parallel lanes, 600 for consolidation, and 60 for persistence/teardown. Correction/final
-reserve 1,200 seconds for the primary call, 300 for their sole format/register retry, and 60 for
-teardown. Preflight the complete applicable reserve and pass bounded remaining time to every
-`run`/`resume`; do not let engine defaults outlive the whole call.
+Plan review keeps its existing monotonic 3,540-second whole-review deadline and reserves the
+complete structural phase before starting it. In both modes, each census lane has a 900-second
+timeout, consolidation 600 seconds, correction/final 1,200 seconds, and a format correction at
+most 300 seconds. The three census lanes run concurrently.
 
 Plan evidence gathering can consume most of a request. If the full census reserve no longer fits,
 persist valid claim progress, leave phase and structural round unchanged, and return explicit
@@ -261,18 +257,11 @@ transitions/migration, stakes reset, concrete debt and deadline arithmetic. They
 closed active class recurring in an otherwise clean census is assessed by the integrity lane,
 registered as durable debt, and blocks clearance.
 
-Scripted handler tests cover concurrent byte-identical inputs; four-call valid census; one bounded
-format correction; sibling diagnostics; correction → required final → convergence/reopen; census
-immediate convergence; claim progress with structural phase unchanged; branch predicate sweeping;
-all active-class visibility in final; and unchanged one-shot/`converge:false` contracts. Maximum
-300 KB plan and 400 KB branch fixtures, maximum supported class context, and three maximum valid
-lane envelopes must fit the exact rendered requests without content truncation. A non-ASCII fixture
-proves limits count characters rather than UTF-8 bytes; an oversized legacy state visibly blocks.
-The plan maximum-shape fixture also carries 500 maximum 8,000-character active claim records plus
-current retirements and proves the complete lane prompt remains within 5,000,000 characters. Final tests
-require exact-one class assessment and exercise a closed recurrence settled by atomic `REPLACE`.
-Attempt-ledger tests enumerate discovery, binding batches, attestation, census lanes,
-consolidation, correction, final, and format retries exactly once.
+Scripted handler tests cover the four-call valid census, structural-only tracked plan entry,
+one bounded format correction, correction → required final, complete final coverage/class
+assessment, exact severity/debt retention, resolved anchors, atomic `REPLACE`, attempt logging, and
+the unchanged injected-engine/one-shot contracts. Real acceptance below supplies the provider and
+maximum-real-input coverage that fake-backed tests cannot establish.
 
 Pre-PR real gates:
 

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -205,7 +205,8 @@ persist when structural work later fails or lacks deadline; structural phase doe
 a valid structural settlement. Audit logs record phase, stakes/snapshot digests, validated
 manifests/dispositions, and one attempt-ledger row for every actual `run`/`resume`: role,
 engine/session, outcome, duration, and usage. Aggregate provider calls are the ledger length, never
-inferred from a status string.
+inferred from a status string. Concurrent lanes are serialized in stable lane order; without a
+provider-boundary timestamp the ledger does not claim temporal ordering between them.
 
 ## 5. Small code shape
 
@@ -284,5 +285,8 @@ Pre-PR real gates:
    evidence, not authority to force a new false clearance. The implementation's own convergence
    run must use the staged correction/final lifecycle, and measured wall time/call cost must be
    reported rather than waived;
-8. acceptance records with fixture/digest/oracle/result/audit metadata committed under `docs/`;
+8. acceptance records with fixture/digest/oracle/result metadata committed under `docs/`. The
+   completed final review's invocation metadata remains in its immutable audit log and PR/handoff
+   report: committing a statement that the current commit passed a later review would change the
+   reviewed snapshot and make that statement self-referentially stale;
 9. only then open a PR, pass CI, merge, and update the primary `main` worktree.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -269,13 +269,15 @@ Pre-PR real gates:
 2. simulated plan and branch census → correction → final, including failures and audit fields;
 3. real Codex plan review convergence under section 1 stakes;
 4. real Codex implementation review convergence under the same stakes;
-5. blinded A/B replay of the recoverable 16-round plan fixture above through both base-commit and
-   new mechanisms, with frozen historical-class oracle, provider-call count and monotonic elapsed
-   time;
-6. equivalent blinded A/B replay for a recoverable changing-branch lineage that historically took
-   10–19 rounds, including its ordered snapshots;
+5. blinded replay of the recoverable 16-round plan fixture above through the implemented path,
+   with frozen historical-class oracle, provider-call count and monotonic elapsed time;
+6. equivalent blinded replay for a recoverable changing-branch lineage that historically reached
+   round 10–19, testing its first implementation and historically converged snapshots;
 7. each new census must recover every applicable historical FATAL/MAJOR root class without an
-   unresolved new FATAL/MAJOR false positive; the new convergence run must use fewer rounds, and its
-   measured wall time/call cost must be reported rather than waived;
+   unresolved new FATAL/MAJOR false positive. Targeted correction must close repaired roots and
+   retain any material defect still present in the historical bytes; old convergence is comparison
+   evidence, not authority to force a new false clearance. The implementation's own convergence
+   run must use the staged correction/final lifecycle, and measured wall time/call cost must be
+   reported rather than waived;
 8. acceptance records with fixture/digest/oracle/result/audit metadata committed under `docs/`;
 9. only then open a PR, pass CI, merge, and update the primary `main` worktree.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,8 @@ license = { text = "MIT" }
 authors = [{ name = "Andrew Hillel" }]
 keywords = ["mcp", "code-review", "claude-code", "codex", "adversarial-review"]
 dependencies = [
-    "mcp>=1.2.0",
+    # MCP 2.0 renamed Tool.inputSchema and is not API-compatible with this server.
+    "mcp>=1.2.0,<2",
     "trafilatura>=2.0,<3",
 ]
 

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -320,6 +320,9 @@ class Lineage:
     #: instead of introducing a second store/transaction protocol.  Branch mode leaves
     #: it empty and otherwise behaves byte-for-byte as before.
     claim_state: dict[str, Any] = field(default_factory=dict)
+    #: Staged structural-review phase and concrete finding debt. Kept in the same
+    #: atomic file as classes and claims so no partial clearance can cross stores.
+    review_state: dict[str, Any] = field(default_factory=dict)
     #: Which tool created this lineage. A plan lineage holds only unmechanized classes
     #: and is never swept; a branch lineage is swept against a repo snapshot. Opening
     #: one as the other is undefined, not merely surprising — see `load_lineage`.
@@ -425,6 +428,7 @@ def _from_json(lineage_id: str, raw: dict[str, Any]) -> Lineage:
         exemptions=[Exemption(**e) for e in raw.get("exemptions", [])],
         debt=raw.get("debt"),
         claim_state=deepcopy(raw.get("claim_state", {})),
+        review_state=deepcopy(raw.get("review_state", {})),
     )
 
 
@@ -440,6 +444,7 @@ def _to_json(lineage: Lineage) -> dict[str, Any]:
         "exemptions": [vars(e) for e in lineage.exemptions],
         "debt": lineage.debt,
         "claim_state": lineage.claim_state,
+        "review_state": lineage.review_state,
     }
 
 
@@ -545,6 +550,7 @@ def copy_lineage(lineage: Lineage) -> Lineage:
         lineage_id=lineage.lineage_id, rounds=lineage.rounds, next_seq=lineage.next_seq,
         classes=dict(lineage.classes), exemptions=list(lineage.exemptions), debt=lineage.debt,
         mode=lineage.mode, claim_state=deepcopy(lineage.claim_state),
+        review_state=deepcopy(lineage.review_state),
     )
 
 
@@ -586,6 +592,24 @@ def _apply_transition(lineage: Lineage, t: Transition, *, round_no: int, minted:
 
     if t.kind == "RECLASSIFY":
         lineage.classes[t.class_id] = replace(cls, severity=t.severity or cls.severity)
+        return
+
+    if t.kind == "REPLACE":
+        if t.target is not None:
+            raise RegisterError("REPLACE creates a successor and cannot name BY")
+        if cls.mechanized:
+            if not t.pattern or not t.pathspec:
+                raise RegisterError("mechanized REPLACE needs pattern and pathspec")
+        elif not t.procedure:
+            raise RegisterError("unmechanized REPLACE needs procedure")
+        new_id = _add(
+            lineage, t.invariant or cls.invariant, t.severity or cls.severity,
+            cls.first_round, t.pattern, t.pathspec, t.procedure,
+        )
+        minted.append(new_id)
+        lineage.classes[t.class_id] = replace(
+            cls, status=SUPERSEDED, superseded_by=new_id
+        )
         return
 
     # SUPERSEDE — the source must not survive as a blocker, so the replacement has to be real.

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -320,6 +320,10 @@ class Lineage:
     #: instead of introducing a second store/transaction protocol.  Branch mode leaves
     #: it empty and otherwise behaves byte-for-byte as before.
     claim_state: dict[str, Any] = field(default_factory=dict)
+    #: A structural-stakes transition invalidates claim verdict reuse too. Keep this
+    #: outside claim_state so an explicitly disabled claim phase preserves its evidence
+    #: byte-for-byte while remembering that the next enabled phase must be exhaustive.
+    claim_reverify_required: bool = False
     #: Staged structural-review phase and concrete finding debt. Kept in the same
     #: atomic file as classes and claims so no partial clearance can cross stores.
     review_state: dict[str, Any] = field(default_factory=dict)
@@ -428,6 +432,7 @@ def _from_json(lineage_id: str, raw: dict[str, Any]) -> Lineage:
         exemptions=[Exemption(**e) for e in raw.get("exemptions", [])],
         debt=raw.get("debt"),
         claim_state=deepcopy(raw.get("claim_state", {})),
+        claim_reverify_required=bool(raw.get("claim_reverify_required", False)),
         review_state=deepcopy(raw.get("review_state", {})),
     )
 
@@ -444,6 +449,7 @@ def _to_json(lineage: Lineage) -> dict[str, Any]:
         "exemptions": [vars(e) for e in lineage.exemptions],
         "debt": lineage.debt,
         "claim_state": lineage.claim_state,
+        "claim_reverify_required": lineage.claim_reverify_required,
         "review_state": lineage.review_state,
     }
 
@@ -550,6 +556,7 @@ def copy_lineage(lineage: Lineage) -> Lineage:
         lineage_id=lineage.lineage_id, rounds=lineage.rounds, next_seq=lineage.next_seq,
         classes=dict(lineage.classes), exemptions=list(lineage.exemptions), debt=lineage.debt,
         mode=lineage.mode, claim_state=deepcopy(lineage.claim_state),
+        claim_reverify_required=lineage.claim_reverify_required,
         review_state=deepcopy(lineage.review_state),
     )
 

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -301,12 +301,17 @@ class CodexEngine(Engine):
             etype = event.get("type")
             if etype == "thread.started":
                 thread_id = event.get("thread_id") or thread_id
-            if etype == "error":
+            if etype in {"error", "turn.failed"}:
                 error = True
             if etype == "turn.completed":
                 u = event.get("usage")
                 if isinstance(u, dict):
                     usage = u
+                # Codex can emit a transient top-level error while retrying a
+                # model stream and still finish the turn successfully.  The
+                # terminal event, not an earlier recovered event, governs the
+                # process result.
+                error = False
             item = event.get("item")
             if isinstance(item, dict):
                 if item.get("type") == "agent_message":

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -935,7 +935,11 @@ def critique_plan(
             type(engine) in (eng.CodexEngine, eng.ClaudeEngine)
             and unknown_calibration and has_prior_state
         ):
-            closure.lineage.claim_state = pc.empty_state()
+            # Structural calibration and claim authority share the same stakes. When the
+            # claim phase is disabled, retain its packets exactly but remember that no
+            # verdict may freeze across this transition. The next enabled call performs
+            # a full audit over that preserved inventory.
+            closure.lineage.claim_reverify_required = True
             closure.lineage.classes = {
                 cid: replace(cls, status=cc.OPEN) if not cls.mechanized else cls
                 for cid, cls in closure.lineage.classes.items()
@@ -975,6 +979,10 @@ def critique_plan(
                     plan_repo_path=plan_repo_path,
                     on_progress=on_progress,
                     attempt_ledger=attempt_ledger,
+                    force_exhaustive=bool(
+                        closure and closure.lineage
+                        and closure.lineage.claim_reverify_required
+                    ),
                     deadline=(
                         min(
                             plan_deadline - PLAN_TEARDOWN_RESERVE_SEC,
@@ -992,6 +1000,8 @@ def critique_plan(
                 raise
             if closure and closure.lineage is not None:
                 closure.lineage.claim_state = claim_state
+                if claim_status.startswith("parsed"):
+                    closure.lineage.claim_reverify_required = False
                 # Persist useful evidence before the structural reviewer runs.  If that
                 # later CLI call fails, the next autonomous round reuses the completed
                 # research instead of starting over.  The existing pending latch still
@@ -1171,9 +1181,10 @@ def _verify_plan_claims(
     on_progress: Callable[[str], None] | None,
     attempt_ledger: list[dict[str, Any]] | None = None,
     deadline: float | None = None,
+    force_exhaustive: bool = False,
 ) -> tuple[dict[str, Any], str]:
     """Run exhaustive round 1, then verify only the external-claim edit cone."""
-    targeted = pc.has_prior_snapshot(prior_state)
+    targeted = pc.has_prior_snapshot(prior_state) and not force_exhaustive
     server_capture_required = type(engine) in (eng.CodexEngine, eng.ClaudeEngine)
     frozen = (
         pc.frozen_supported_ids(

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -178,6 +178,7 @@ def _staged_structural_review(
         {
             "class_id": c.class_id, "invariant": c.invariant,
             "severity": c.severity, "status": c.status, "mechanized": c.mechanized,
+            "pattern": c.pattern, "pathspec": c.pathspec, "procedure": c.procedure,
         }
         for c in lineage.active()
     ]
@@ -229,7 +230,8 @@ def _staged_structural_review(
             instructions = prompts.STAGED_CENSUS_INSTRUCTIONS.replace("LANE", lane)
             lane_body = (
                 f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
-                f"ACTIVE CLASS IDS: {json.dumps(active_ids if lane == 'integrity' else [])}\n\n{body}"
+                "ACTIVE CLASSES: "
+                f"{json.dumps(active_classes if lane == 'integrity' else [])}\n\n{body}"
             )
             prompt = prompts.compose(instructions, lane_body)
             if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
@@ -302,9 +304,10 @@ def _staged_structural_review(
         attempts.extend(call_attempts)
     else:
         role = "final" if phase == "final" else "correction"
-        existing = [d["id"] for d in state.get("debt", []) if d.get("status") == "open"]
+        open_debt = [d for d in state.get("debt", []) if d.get("status") == "open"]
+        existing = [d["id"] for d in open_debt]
         stage_body = json.dumps({
-            "role": role, "stakes": stakes, "existing_debt": state.get("debt", []),
+            "role": role, "stakes": stakes, "existing_debt": open_debt,
             "active_classes": active_classes, "artifact": body,
         }, ensure_ascii=False)
         prompt = prompts.compose(prompts.STAGED_FOLLOWUP_INSTRUCTIONS, stage_body)

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -16,6 +16,7 @@ import shutil
 import subprocess
 import tempfile
 import time
+from concurrent.futures import ThreadPoolExecutor
 from copy import deepcopy
 from datetime import datetime
 from pathlib import Path
@@ -23,7 +24,7 @@ from typing import Any, Callable
 
 from . import arbitration, class_closure as cc
 from . import engines as eng, external_sources, inert_git, inert_tree
-from . import logs, orientation, plan_claims as pc, prompts
+from . import logs, orientation, plan_claims as pc, prompts, review_census as rc
 from .config import load_repo_config, resolve
 from .engines import Engine, Review
 from .worktree import worktree_at
@@ -43,6 +44,113 @@ PLAN_BINDING_MARKER = "=== PLAN EVIDENCE BINDING JSON ==="
 MAX_PLAN_BINDING_BATCH_CHARS = 400_000
 MAX_PLAN_CAPTURE_SOURCES = 200
 MAX_PLAN_BINDING_BATCHES = 5
+
+
+def _attempt(role: str, engine: Engine, review: Review) -> rc.Attempt:
+    return rc.Attempt(role, engine.name, review.session_ref,
+                      "failed" if review.error else "completed",
+                      review.duration_ms, review.usage)
+
+
+def _staged_structural_review(
+    *, engine: Engine, cwd: Path, model: str, effort: str, mode: str, body: str,
+    closure: "_ClosureRound", stakes: str, snapshot: str, round_no: int,
+    on_progress: Callable[[str], None] | None,
+) -> tuple[Review, str, list[dict[str, Any]]]:
+    """Run census/correction/final and atomically settle it into the open lineage."""
+    assert closure.lineage is not None
+    lineage = closure.lineage
+    state = rc.normalize_state(lineage.review_state, stakes=stakes, snapshot=snapshot)
+    phase = state["phase"]
+    active_ids = [c.class_id for c in lineage.active()]
+    attempts: list[rc.Attempt] = []
+
+    if phase == "census":
+        lanes = rc.LANES[mode]
+
+        def run_lane(lane: str) -> tuple[str, Review, dict[str, Any]]:
+            instructions = prompts.STAGED_CENSUS_INSTRUCTIONS.replace("LANE", lane)
+            lane_body = (
+                f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
+                f"ACTIVE CLASS IDS: {json.dumps(active_ids if lane == 'integrity' else [])}\n\n{body}"
+            )
+            prompt = prompts.compose(instructions, lane_body)
+            if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
+                raise rc.CensusError(f"staged lane prompt is {len(prompt)} characters")
+            result = engine.run(prompt, cwd, model, effort, False,
+                                timeout=900, **_progress_kwargs(on_progress))
+            if result.error:
+                raise rc.CensusError(f"{lane} lane failed (exit {result.returncode})")
+            return lane, result, rc.parse_lane(
+                result.text, lane=lane, class_ids=active_ids if lane == "integrity" else (),
+            )
+
+        with ThreadPoolExecutor(max_workers=3) as pool:
+            lane_rows = list(pool.map(run_lane, lanes))
+        for lane, result, _ in lane_rows:
+            attempts.append(_attempt(f"census-{lane}", engine, result))
+        manifests = [row[2] for row in lane_rows]
+        source_ids = [f["id"] for m in manifests for f in m["findings"]]
+        assessment_ids = [a["class_id"] for m in manifests for a in m["class_assessments"]]
+        consolidation_body = json.dumps({
+            "role": "census", "stakes": stakes, "manifests": manifests,
+            "active_classes": active_ids,
+        }, ensure_ascii=False)
+        prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
+        if len(prompt) > rc.MAX_CONSOLIDATION_PROMPT_CHARS:
+            raise rc.CensusError(f"consolidation prompt is {len(prompt)} characters")
+        review = engine.run(prompt, cwd, model, effort, False,
+                            timeout=600, **_progress_kwargs(on_progress))
+        attempts.append(_attempt("consolidation", engine, review))
+        if review.error:
+            raise rc.CensusError(f"consolidation failed (exit {review.returncode})")
+        settlement = rc.parse_settlement(
+            review.text, source_ids=source_ids, assessment_ids=assessment_ids, role="census",
+        )
+    else:
+        role = "final" if phase == "final" else "correction"
+        existing = [d["id"] for d in state.get("debt", []) if d.get("status") == "open"]
+        stage_body = json.dumps({
+            "role": role, "stakes": stakes, "existing_debt": state.get("debt", []),
+            "active_classes": active_ids, "artifact": body,
+        }, ensure_ascii=False)
+        prompt = prompts.compose(prompts.STAGED_FOLLOWUP_INSTRUCTIONS, stage_body)
+        if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
+            raise rc.CensusError(f"{role} prompt is {len(prompt)} characters")
+        review = engine.run(prompt, cwd, model, effort, False,
+                            timeout=1200, **_progress_kwargs(on_progress))
+        attempts.append(_attempt(role, engine, review))
+        if review.error:
+            raise rc.CensusError(f"{role} failed (exit {review.returncode})")
+        settlement = rc.parse_settlement(
+            review.text, source_ids=[], assessment_ids=active_ids if role == "final" else [],
+            known_debt=existing, role=role,
+        )
+
+    draft = cc.copy_lineage(lineage)
+    register = rc.register_from_records(
+        settlement["class_records"], mechanized=mode == cc.BRANCH_MODE,
+    )
+    minted = cc.apply_register(draft, register, round_no=round_no)
+    lineage.classes, lineage.next_seq, lineage.exemptions = (
+        draft.classes, draft.next_seq, draft.exemptions
+    )
+    if mode == cc.BRANCH_MODE:
+        closure._sweep(only=minted)
+    state = rc.settle_state(state, settlement, phase=phase, snapshot=snapshot, round_no=round_no)
+    claim_blocked = mode == cc.PLAN_MODE and pc.is_blocked(lineage.claim_state)
+    if lineage.blocking() or claim_blocked:
+        state["phase"] = "correction"
+    lineage.review_state = state
+    lineage.debt = None
+    lineage.rounds += 1
+    cc.save_lineage(closure.state_root, lineage)
+    closure._settled = True
+    closure.register_status = f"staged {phase} parsed"
+    trailer = rc.trailer(state)
+    if mode == cc.PLAN_MODE:
+        trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
+    return review, trailer, [a.json() for a in attempts]
 
 
 def _default_clock() -> str:
@@ -340,6 +448,7 @@ def _converge_branch_review(
     # entry and the engine call can all raise, and a latch stranded there would make every
     # later round STATE-UNAVAILABLE over a fault that already surfaced to the caller. A
     # failed *write* is the one case that deliberately keeps the latch (see `release`).
+    attempt_ledger: list[dict[str, Any]] = []
     try:
         packet = orientation.build_packet(
             repo, base_id, head_id,
@@ -352,12 +461,20 @@ def _converge_branch_review(
         prompt = prompts.compose(instructions, _prepend(calibration, packet))
 
         with worktree_at(repo, head_id) as wt:
-            review = engine.run(prompt, wt, model, effort, web_search,
-                                **_progress_kwargs(on_progress))
-            # Settle inside the worktree: a register retry resumes the same session and
-            # must see the same materialized snapshot the review did.
-            trailer = closure.settle(review, engine, wt, model, effort, web_search,
-                                     on_progress) if closure else None
+            if closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
+                review, trailer, attempt_ledger = _staged_structural_review(
+                    engine=engine.for_role(eng.ROLE_REPOSITORY), cwd=wt, model=model,
+                    effort=effort, mode=cc.BRANCH_MODE, body=_prepend(calibration, packet),
+                    closure=closure, stakes=calibration or "", snapshot=head_id,
+                    round_no=review_round or 1, on_progress=on_progress,
+                )
+            else:
+                review = engine.run(prompt, wt, model, effort, web_search,
+                                    **_progress_kwargs(on_progress))
+                # Settle inside the worktree: a register retry resumes the same session and
+                # must see the same materialized snapshot the review did.
+                trailer = closure.settle(review, engine, wt, model, effort, web_search,
+                                         on_progress) if closure else None
     except BaseException:
         if closure:
             closure.abandon()
@@ -378,7 +495,8 @@ def _converge_branch_review(
           "lineage": closure.lineage_id if closure else None,
           # The retry's register is what actually changed durable state, so it belongs in
           # the audit record; the original review only carries the malformed attempt.
-          "retry_register": closure.retry_register if closure else None})
+          "retry_register": closure.retry_register if closure else None,
+          "attempt_ledger": attempt_ledger})
     body = _footer(review, engine)
     if closure and closure.retry_register:
         # Same reason, for the operator: a CLOSED or a corrected predicate that the retry
@@ -565,6 +683,7 @@ def critique_plan(
         closure.claims_enabled = claim_verification
         closure.claim_state = claim_state
 
+    attempt_ledger: list[dict[str, Any]] = []
     try:
         body = _plan_body(plan_text, context, focus, already, repo_grounded=bool(repo),
                           class_blocks=blocks)
@@ -601,6 +720,17 @@ def critique_plan(
                         session_ref=None, raw="plan deadline exhausted",
                         returncode=124, error=True,
                     )
+                elif closure:
+                    staged_body = body + (
+                        "\n\nThe pinned repository evidence root is `repository/`. Treat that "
+                        "prefix as the project root; no live Git or web tools are available."
+                    )
+                    review, trailer, attempt_ledger = _staged_structural_review(
+                        engine=reviewer, cwd=review_cwd, model=model, effort=effort,
+                        mode=cc.PLAN_MODE, body=_prepend(calibration, staged_body),
+                        closure=closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
+                        round_no=arguments.get("round") or 1, on_progress=on_progress,
+                    )
                 else:
                     review = reviewer.run(
                         isolated_prompt, review_cwd, model, effort, False,
@@ -609,9 +739,10 @@ def critique_plan(
                     )
                 if closure:
                     closure.deadline = plan_deadline
-                trailer = closure.settle(
-                    review, reviewer, review_cwd, model, effort, False, on_progress,
-                ) if closure else None
+                if closure and not attempt_ledger:
+                    trailer = closure.settle(
+                        review, reviewer, review_cwd, model, effort, False, on_progress,
+                    )
         else:
             review = engine.run(prompt, cwd, model, effort, web_search,
                                 **_progress_kwargs(on_progress))
@@ -653,6 +784,7 @@ def critique_plan(
         # The retry's register is what actually changed durable state, so the original
         # (rejected) block alone would misreport the round.
         "retry_register": closure.retry_register if closure else None,
+        "attempt_ledger": attempt_ledger,
     })
     body_text = _footer(review, engine) + _stakes_notice(no_stakes)
     if closure and closure.retry_register:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -48,9 +48,12 @@ MAX_PLAN_BINDING_BATCHES = 5
 
 
 def _attempt(role: str, engine: Engine, review: Review) -> rc.Attempt:
+    response = review.raw or review.text or ""
     return rc.Attempt(role, engine.name, review.session_ref,
                       "failed" if review.error else "completed",
-                      review.duration_ms, review.usage)
+                      review.duration_ms, review.usage,
+                      rc.digest(response) if response else None,
+                      response[:4000] if response else None)
 
 
 def _staged_call(
@@ -69,6 +72,7 @@ def _staged_call(
     try:
         return review, parser(review.text), attempts
     except rc.CensusError as first:
+        attempts[-1] = replace(attempts[-1], outcome="format-invalid")
         if not review.session_ref:
             error = rc.CensusError(f"{role} format invalid and has no resumable session: {first}")
             error.attempts = attempts  # type: ignore[attr-defined]
@@ -88,6 +92,7 @@ def _staged_call(
         try:
             parsed = parser(retry.text)
         except rc.CensusError as second:
+            attempts[-1] = replace(attempts[-1], outcome="format-invalid")
             second.attempts = attempts  # type: ignore[attr-defined]
             raise
         return retry, parsed, attempts
@@ -104,6 +109,7 @@ def _settle_staged_failure(
     cc.save_lineage(closure.state_root, closure.lineage)
     closure._settled = True
     closure.register_status = f"staged rejected: {error}"
+    closure.staged_manifests = getattr(error, "manifests", [])
     attempts = [a.json() for a in getattr(error, "attempts", [])]
     review = Review(
         text=f"[paranoia-local error] staged review rejected: {error}",
@@ -116,6 +122,45 @@ def _settle_staged_failure(
     if mode == cc.PLAN_MODE:
         trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
     return review, trailer, attempts
+
+
+def _state_unavailable_review(
+    closure: "_ClosureRound", *, mode: str, claim_state: dict[str, Any] | None = None,
+) -> tuple[Review, str, list[dict[str, Any]]]:
+    """Return the established blocked result without running or mutating staged state."""
+    reason = closure.unavailable or "lineage state is unavailable"
+    review = Review(
+        text=f"[paranoia-local error] lineage state unavailable: {reason}",
+        session_ref=None, raw=reason, returncode=2, error=True,
+    )
+    trailer = (
+        f"CLASS-CLOSURE: STATE-UNAVAILABLE — {reason}\n"
+        "CONVERGENCE: BLOCKED — lineage state could not be used this round."
+    )
+    if mode == cc.PLAN_MODE and claim_state is not None:
+        trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
+    return review, trailer, []
+
+
+def _structural_pending_review(
+    closure: "_ClosureRound", *, mode: str, claim_state: dict[str, Any], reason: str,
+) -> tuple[Review, str, list[dict[str, Any]]]:
+    """Settle a zero-attempt plan round whose structural reserve no longer fits."""
+    assert closure.lineage is not None
+    phase = closure.lineage.review_state.get("phase", "census")
+    closure._settled = True
+    closure.register_status = "structural pending"
+    review = Review(
+        text=f"[paranoia-local error] {reason}", session_ref=None, raw=reason,
+        returncode=124, error=True,
+    )
+    trailer = (
+        f"STRUCTURAL-PHASE: {phase}\nSTRUCTURAL-PENDING: {reason}\n"
+        "CONVERGENCE: BLOCKED — structural review has not run."
+    )
+    if mode == cc.PLAN_MODE:
+        trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
+    return review, trailer, []
 
 
 def _staged_structural_review(
@@ -142,6 +187,41 @@ def _staged_structural_review(
     }
     attempts: list[rc.Attempt] = []
 
+    def validate_lane(text: str, lane: str) -> dict[str, Any]:
+        parsed = rc.parse_lane(
+            text, lane=lane, class_ids=active_ids if lane == "integrity" else (),
+        )
+        rc.resolve_anchors(parsed, root=cwd, plan_lines=plan_lines)
+        return parsed
+
+    def validate_settlement(
+        text: str, *, source_ids: list[str], assessment_ids: list[str],
+        source_severities: dict[str, str] | None = None,
+        assessment_verdicts: dict[str, str] | None = None,
+        known_debt: list[str] | None = None, role: str,
+    ) -> dict[str, Any]:
+        parsed = rc.parse_settlement(
+            text, source_ids=source_ids, source_severities=source_severities,
+            assessment_ids=assessment_ids, assessment_verdicts=assessment_verdicts,
+            class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
+            known_debt=known_debt or (), role=role,
+        )
+        rc.resolve_anchors(parsed, root=cwd, plan_lines=plan_lines)
+        reserved_debt = {
+            item.get("id") for item in state.get("debt", []) if isinstance(item, dict)
+        }
+        reused = [item["id"] for item in parsed["debt"] if item["id"] in reserved_debt]
+        if reused:
+            raise rc.CensusError(f"new debt reuses durable ids {sorted(reused)}")
+        try:
+            register = rc.register_from_records(
+                parsed["class_records"], mechanized=mode == cc.BRANCH_MODE,
+            )
+            cc.apply_register(cc.copy_lineage(lineage), register, round_no=round_no)
+        except cc.RegisterError as exc:
+            raise rc.CensusError(f"invalid class operation: {exc}") from exc
+        return parsed
+
     if phase == "census":
         lanes = rc.LANES[mode]
 
@@ -157,14 +237,7 @@ def _staged_structural_review(
             result, parsed, lane_attempts = _staged_call(
                 role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=900, on_progress=on_progress,
-                parser=lambda text: rc.parse_lane(
-                    text, lane=lane,
-                    class_ids=active_ids if lane == "integrity" else (),
-                ),
-            )
-            rc.resolve_anchors(
-                parsed, root=cwd,
-                plan_lines=plan_lines,
+                parser=lambda text: validate_lane(text, lane),
             )
             renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
             for finding in parsed["findings"]:
@@ -191,10 +264,12 @@ def _staged_structural_review(
             )
             first_error = lane_errors[0]
             first_error.attempts = all_attempts  # type: ignore[attr-defined]
+            first_error.manifests = [row[2] for row in lane_rows]  # type: ignore[attr-defined]
             raise first_error
         for _, _, _, lane_attempts in lane_rows:
             attempts.extend(lane_attempts)
         manifests = [row[2] for row in lane_rows]
+        closure.staged_manifests = manifests
         source_ids = [f["id"] for m in manifests for f in m["findings"]]
         source_severities = {f["id"]: f["severity"] for m in manifests for f in m["findings"]}
         assessment_ids = [a["class_id"] for m in manifests for a in m["class_assessments"]]
@@ -211,18 +286,13 @@ def _staged_structural_review(
         review, settlement, call_attempts = _staged_call(
             role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
             model=model, effort=effort, timeout=600, on_progress=on_progress,
-            parser=lambda text: rc.parse_settlement(
+            parser=lambda text: validate_settlement(
                 text, source_ids=source_ids, source_severities=source_severities,
-                assessment_ids=assessment_ids, assessment_verdicts=assessment_verdicts,
-                class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
-                role="census",
+                assessment_ids=assessment_ids,
+                assessment_verdicts=assessment_verdicts, role="census",
             ),
         )
         attempts.extend(call_attempts)
-        rc.resolve_anchors(
-            settlement, root=cwd,
-            plan_lines=plan_lines,
-        )
     else:
         role = "final" if phase == "final" else "correction"
         existing = [d["id"] for d in state.get("debt", []) if d.get("status") == "open"]
@@ -236,17 +306,13 @@ def _staged_structural_review(
         review, settlement, call_attempts = _staged_call(
             role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
             timeout=1200, on_progress=on_progress,
-            parser=lambda text: rc.parse_settlement(
-                text, source_ids=[], assessment_ids=active_ids if role == "final" else [],
-                class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
+            parser=lambda text: validate_settlement(
+                text, source_ids=[],
+                assessment_ids=active_ids if role == "final" else [],
                 known_debt=existing, role=role,
             ),
         )
         attempts.extend(call_attempts)
-        rc.resolve_anchors(
-            settlement, root=cwd,
-            plan_lines=plan_lines,
-        )
 
     draft = cc.copy_lineage(lineage)
     register = rc.register_from_records(
@@ -586,11 +652,16 @@ def _converge_branch_review(
         prompt = prompts.compose(instructions, _prepend(calibration, packet))
 
         with worktree_at(repo, head_id) as wt:
-            if closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
+            if closure and closure.unavailable:
+                review, trailer, attempt_ledger = _state_unavailable_review(
+                    closure, mode=cc.BRANCH_MODE,
+                )
+            elif closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
                 try:
                     review, trailer, attempt_ledger = _staged_structural_review(
                         engine=engine.for_role(eng.ROLE_REPOSITORY), cwd=wt, model=model,
-                        effort=effort, mode=cc.BRANCH_MODE, body=_prepend(calibration, packet),
+                        effort=effort, mode=cc.BRANCH_MODE,
+                        body=f"=== REVIEW STAKES ===\n{stakes}\n\n{packet}",
                         closure=closure, stakes=stakes, snapshot=head_id,
                         round_no=review_round or 1, on_progress=on_progress,
                     )
@@ -628,6 +699,7 @@ def _converge_branch_review(
           # the audit record; the original review only carries the malformed attempt.
           "retry_register": closure.retry_register if closure else None,
           "attempt_ledger": attempt_ledger,
+          "staged_manifests": getattr(closure, "staged_manifests", None) if closure else None,
           "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None})
     body = _footer(review, engine)
     if closure and closure.retry_register:
@@ -755,7 +827,21 @@ def critique_plan(
     if closure and closure.lineage is not None:
         prior_review = closure.lineage.review_state
         current_stakes_digest = rc.digest(stakes or "")
-        if prior_review and prior_review.get("stakes_digest") != current_stakes_digest:
+        claim_history = pc.normalize_state(closure.lineage.claim_state)
+        unknown_calibration = (
+            not isinstance(prior_review, dict)
+            or prior_review.get("version") != 1
+            or prior_review.get("stakes_digest") != current_stakes_digest
+        )
+        has_prior_state = bool(
+            closure.lineage.rounds or closure.lineage.classes
+            or claim_history["claims"] or claim_history.get("debt")
+            or claim_history.get("plan_snapshot")
+        )
+        if (
+            type(engine) in (eng.CodexEngine, eng.ClaudeEngine)
+            and unknown_calibration and has_prior_state
+        ):
             closure.lineage.claim_state = pc.empty_state()
             closure.lineage.classes = {
                 cid: replace(cls, status=cc.OPEN) if not cls.mechanized else cls
@@ -827,6 +913,7 @@ def critique_plan(
         closure.claims_enabled = claim_verification
         closure.claim_state = claim_state
 
+    trailer: str | None = None
     try:
         body = _plan_body(plan_text, context, focus, already, repo_grounded=bool(repo),
                           class_blocks=blocks)
@@ -846,6 +933,7 @@ def critique_plan(
                 ),
                 parent,
             )
+            structural_snapshot = rc.digest(f"{plan_text}\0{snapshot}")
             with inert_tree.evidence_workspace(repo, snapshot) as workspace:
                 reviewer = engine.for_role(eng.ROLE_REPOSITORY)
                 review_cwd = workspace.cwd_for(engine.name)
@@ -854,22 +942,37 @@ def critique_plan(
                     "prefix as the project root; no live Git or web tools are available."
                 )
                 staged_phase = (
-                    closure.lineage.review_state.get("phase", "census")
+                    rc.normalize_state(
+                        closure.lineage.review_state, stakes=stakes or "",
+                        snapshot=structural_snapshot,
+                    )["phase"]
                     if closure and closure.lineage else "census"
                 )
                 structural_reserve = 2160 if staged_phase == "census" else 1560
-                if plan_deadline is not None and (
+                if closure and closure.unavailable:
+                    review, trailer, structural_attempts = _state_unavailable_review(
+                        closure, mode=cc.PLAN_MODE, claim_state=claim_state,
+                    )
+                    attempt_ledger.extend(structural_attempts)
+                elif plan_deadline is not None and (
                     time.monotonic() + structural_reserve > plan_deadline
                 ):
-                    review = Review(
-                        text=(
-                            "[paranoia-local error] verified evidence work completed and was "
-                            "persisted, but the whole-plan deadline leaves insufficient time "
-                            "for the bounded structural review; rerun to reuse frozen claims"
-                        ),
-                        session_ref=None, raw="plan deadline exhausted",
-                        returncode=124, error=True,
+                    pending_reason = (
+                        "verified evidence work completed and was persisted, but the "
+                        "whole-plan deadline leaves insufficient time for the bounded "
+                        "structural review; rerun to reuse frozen claims"
                     )
+                    if closure:
+                        review, trailer, structural_attempts = _structural_pending_review(
+                            closure, mode=cc.PLAN_MODE, claim_state=claim_state,
+                            reason=pending_reason,
+                        )
+                        attempt_ledger.extend(structural_attempts)
+                    else:
+                        review = Review(
+                            text=f"[paranoia-local error] {pending_reason}",
+                            session_ref=None, raw=pending_reason, returncode=124, error=True,
+                        )
                 elif closure:
                     staged_body = body + (
                         "\n\nThe pinned repository evidence root is `repository/`. Treat that "
@@ -878,14 +981,15 @@ def critique_plan(
                     try:
                         review, trailer, structural_attempts = _staged_structural_review(
                             engine=reviewer, cwd=review_cwd, model=model, effort=effort,
-                            mode=cc.PLAN_MODE, body=_prepend(calibration, staged_body),
-                            closure=closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
+                            mode=cc.PLAN_MODE,
+                            body=f"=== REVIEW STAKES ===\n{stakes or ''}\n\n{staged_body}",
+                            closure=closure, stakes=stakes or "", snapshot=structural_snapshot,
                             round_no=arguments.get("round") or 1, on_progress=on_progress,
                             plan_lines=len(plan_text.splitlines()),
                         )
                     except rc.CensusError as error:
                         review, trailer, structural_attempts = _settle_staged_failure(
-                            closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
+                            closure, stakes=stakes or "", snapshot=structural_snapshot,
                             error=error, mode=cc.PLAN_MODE,
                         )
                     attempt_ledger.extend(structural_attempts)
@@ -941,6 +1045,7 @@ def critique_plan(
         # (rejected) block alone would misreport the round.
         "retry_register": closure.retry_register if closure else None,
         "attempt_ledger": attempt_ledger,
+        "staged_manifests": getattr(closure, "staged_manifests", None) if closure else None,
         "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None,
     })
     body_text = _footer(review, engine) + _stakes_notice(no_stakes)

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -48,6 +48,32 @@ MAX_PLAN_CAPTURE_SOURCES = 200
 MAX_PLAN_BINDING_BATCHES = 5
 
 
+def _allocate_fresh_debt_ids(
+    debt: list[dict[str, Any]], reserved: set[str | None],
+) -> None:
+    """Re-key model-local debt labels that collide with durable history.
+
+    A staged response has no reason to know every closed identifier retained by
+    the server.  Its debt IDs are local labels; durable identity is assigned at
+    settlement.  Preserve non-colliding labels for readable audits and allocate
+    deterministic D<n> labels only where history already owns the proposed ID.
+    """
+    unavailable = {item for item in reserved if isinstance(item, str)}
+    unavailable.update(
+        item["id"] for item in debt
+        if isinstance(item.get("id"), str) and item["id"] not in unavailable
+    )
+    next_number = 1
+    for item in debt:
+        if item["id"] not in reserved:
+            continue
+        while f"D{next_number}" in unavailable:
+            next_number += 1
+        item["id"] = f"D{next_number}"
+        unavailable.add(item["id"])
+        next_number += 1
+
+
 def _attempt(
     role: str, engine: Engine, review: Review, *, sequence: int | None = None,
 ) -> rc.Attempt:
@@ -271,9 +297,7 @@ def _staged_structural_review(
         reserved_debt = {
             item.get("id") for item in state.get("debt", []) if isinstance(item, dict)
         }
-        reused = [item["id"] for item in parsed["debt"] if item["id"] in reserved_debt]
-        if reused:
-            raise rc.CensusError(f"new debt reuses durable ids {sorted(reused)}")
+        _allocate_fresh_debt_ids(parsed["debt"], reserved_debt)
         try:
             register = rc.register_from_records(
                 parsed["class_records"], mechanized=mode == cc.BRANCH_MODE,

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -106,13 +106,30 @@ def _settle_staged_failure(
     state = rc.normalize_state(closure.lineage.review_state, stakes=stakes, snapshot=snapshot)
     state["format_debt"] = str(error)
     closure.lineage.review_state = state
-    cc.save_lineage(closure.state_root, closure.lineage)
+    try:
+        cc.save_lineage(closure.state_root, closure.lineage)
+    except cc.StateUnavailable as exc:
+        closure.unavailable = str(exc)
+        message = f"lineage state unavailable after staged failure: {exc}"
+        review = Review(
+            text=rc.render_error_review(f"[paranoia-local error] {message}"),
+            session_ref=None, raw=message, returncode=2, error=True,
+        )
+        trailer = (
+            f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
+            "CONVERGENCE: BLOCKED — staged failure state may not have persisted."
+        )
+        if mode == cc.PLAN_MODE:
+            trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
+        return review, trailer, [a.json() for a in getattr(error, "attempts", [])]
     closure._settled = True
     closure.register_status = f"staged rejected: {error}"
     closure.staged_manifests = getattr(error, "manifests", [])
     attempts = [a.json() for a in getattr(error, "attempts", [])]
     review = Review(
-        text=f"[paranoia-local error] staged review rejected: {error}",
+        text=rc.render_error_review(
+            f"[paranoia-local error] staged review rejected: {error}"
+        ),
         session_ref=None, raw=str(error), returncode=2, error=True,
     )
     trailer = (
@@ -130,7 +147,9 @@ def _state_unavailable_review(
     """Return the established blocked result without running or mutating staged state."""
     reason = closure.unavailable or "lineage state is unavailable"
     review = Review(
-        text=f"[paranoia-local error] lineage state unavailable: {reason}",
+        text=rc.render_error_review(
+            f"[paranoia-local error] lineage state unavailable: {reason}"
+        ),
         session_ref=None, raw=reason, returncode=2, error=True,
     )
     trailer = (
@@ -151,7 +170,8 @@ def _structural_pending_review(
     closure._settled = True
     closure.register_status = "structural pending"
     review = Review(
-        text=f"[paranoia-local error] {reason}", session_ref=None, raw=reason,
+        text=rc.render_error_review(f"[paranoia-local error] {reason}"),
+        session_ref=None, raw=reason,
         returncode=124, error=True,
     )
     trailer = (
@@ -314,7 +334,9 @@ def _staged_structural_review(
         existing = [d["id"] for d in open_debt]
         stage_body = json.dumps({
             "role": role, "stakes": stakes, "existing_debt": open_debt,
-            "active_classes": active_classes, "artifact": body,
+            "active_classes": active_classes,
+            "checklist": list(rc.CHECKLIST) if role == "final" else [],
+            "artifact": body,
         }, ensure_ascii=False)
         prompt = prompts.compose(prompts.STAGED_FOLLOWUP_INSTRUCTIONS, stage_body)
         if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
@@ -347,7 +369,23 @@ def _staged_structural_review(
     lineage.review_state = state
     lineage.debt = None
     lineage.rounds += 1
-    cc.save_lineage(closure.state_root, lineage)
+    try:
+        cc.save_lineage(closure.state_root, lineage)
+    except cc.StateUnavailable as exc:
+        closure.unavailable = str(exc)
+        closure.staged_settlement = settlement
+        message = f"lineage state unavailable after staged settlement: {exc}"
+        failed = Review(
+            text=rc.render_error_review(f"[paranoia-local error] {message}"),
+            session_ref=review.session_ref, raw=message, returncode=2, error=True,
+        )
+        trailer = (
+            f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
+            "CONVERGENCE: BLOCKED — this staged settlement may not have persisted."
+        )
+        if mode == cc.PLAN_MODE:
+            trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
+        return failed, trailer, [a.json() for a in attempts]
     closure._settled = True
     closure.register_status = f"staged {phase} parsed"
     closure.staged_settlement = settlement

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -268,6 +268,8 @@ def _staged_structural_review(
         repository_alias = cwd / "repository"
         if mode == cc.PLAN_MODE and repository_alias.is_symlink():
             trusted_roots = {"repository": repository_alias.resolve(strict=True)}
+        elif mode == cc.BRANCH_MODE:
+            trusted_roots = {"repository": cwd.resolve(strict=True)}
         rc.resolve_anchors(
             parsed, root=cwd, plan_lines=plan_lines, trusted_roots=trusted_roots,
         )
@@ -291,6 +293,8 @@ def _staged_structural_review(
         repository_alias = cwd / "repository"
         if mode == cc.PLAN_MODE and repository_alias.is_symlink():
             trusted_roots = {"repository": repository_alias.resolve(strict=True)}
+        elif mode == cc.BRANCH_MODE:
+            trusted_roots = {"repository": cwd.resolve(strict=True)}
         rc.resolve_anchors(
             parsed, root=cwd, plan_lines=plan_lines, trusted_roots=trusted_roots,
         )

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -21,6 +21,7 @@ from copy import deepcopy
 from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
+from threading import Lock
 from typing import Any, Callable
 
 from . import arbitration, class_closure as cc
@@ -47,24 +48,28 @@ MAX_PLAN_CAPTURE_SOURCES = 200
 MAX_PLAN_BINDING_BATCHES = 5
 
 
-def _attempt(role: str, engine: Engine, review: Review) -> rc.Attempt:
+def _attempt(
+    role: str, engine: Engine, review: Review, *, sequence: int | None = None,
+) -> rc.Attempt:
     response = review.raw or review.text or ""
     return rc.Attempt(role, engine.name, review.session_ref,
                       "failed" if review.error else "completed",
                       review.duration_ms, review.usage,
                       rc.digest(response) if response else None,
-                      response[:4000] if response else None)
+                      response[:4000] if response else None, sequence)
 
 
 def _staged_call(
     *, role: str, engine: Engine, prompt: str, cwd: Path, model: str, effort: str,
     timeout: int, parser: Callable[[str], dict[str, Any]],
     on_progress: Callable[[str], None] | None,
+    next_sequence: Callable[[], int] | None = None,
 ) -> tuple[Review, dict[str, Any], list[rc.Attempt]]:
     """One staged call plus exactly one same-session schema correction."""
+    sequence = next_sequence() if next_sequence else None
     review = engine.run(prompt, cwd, model, effort, False, timeout=timeout,
                         **_progress_kwargs(on_progress))
-    attempts = [_attempt(role, engine, review)]
+    attempts = [_attempt(role, engine, review, sequence=sequence)]
     if review.error:
         error = rc.CensusError(f"{role} failed (exit {review.returncode})")
         error.attempts = attempts  # type: ignore[attr-defined]
@@ -77,6 +82,7 @@ def _staged_call(
             error = rc.CensusError(f"{role} format invalid and has no resumable session: {first}")
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
+        retry_sequence = next_sequence() if next_sequence else None
         retry = engine.resume(
             review.session_ref,
             "Your staged JSON was rejected: " + str(first) +
@@ -84,7 +90,9 @@ def _staged_call(
             cwd, model, effort, False, timeout=min(300, timeout),
             **_progress_kwargs(on_progress),
         )
-        attempts.append(_attempt(f"{role}-format-retry", engine, retry))
+        attempts.append(_attempt(
+            f"{role}-format-retry", engine, retry, sequence=retry_sequence,
+        ))
         if retry.error:
             error = rc.CensusError(f"{role} format retry failed (exit {retry.returncode})")
             error.attempts = attempts  # type: ignore[attr-defined]
@@ -207,6 +215,14 @@ def _staged_structural_review(
         c.class_id: (c.status, c.mechanized, c.severity) for c in lineage.active()
     }
     attempts: list[rc.Attempt] = []
+    sequence_lock = Lock()
+    sequence_value = 0
+
+    def next_sequence() -> int:
+        nonlocal sequence_value
+        with sequence_lock:
+            sequence_value += 1
+            return sequence_value
 
     def validate_lane(text: str, lane: str) -> dict[str, Any]:
         parsed = rc.parse_lane(
@@ -261,7 +277,7 @@ def _staged_structural_review(
             result, parsed, lane_attempts = _staged_call(
                 role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=900, on_progress=on_progress,
-                parser=lambda text: validate_lane(text, lane),
+                parser=lambda text: validate_lane(text, lane), next_sequence=next_sequence,
             )
             renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
             for finding in parsed["findings"]:
@@ -286,6 +302,7 @@ def _staged_structural_review(
             all_attempts.extend(
                 a for error in lane_errors for a in getattr(error, "attempts", [])
             )
+            all_attempts.sort(key=lambda item: item.sequence or 0)
             first_error = lane_errors[0]
             first_error.attempts = all_attempts  # type: ignore[attr-defined]
             first_error.manifests = [row[2] for row in lane_rows]  # type: ignore[attr-defined]
@@ -314,6 +331,7 @@ def _staged_structural_review(
             review, settlement, call_attempts = _staged_call(
                 role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=600, on_progress=on_progress,
+                next_sequence=next_sequence,
                 parser=lambda text: validate_settlement(
                     text, source_ids=source_ids, source_severities=source_severities,
                     assessment_ids=assessment_ids,
@@ -343,7 +361,7 @@ def _staged_structural_review(
             raise rc.CensusError(f"{role} prompt is {len(prompt)} characters")
         review, settlement, call_attempts = _staged_call(
             role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
-            timeout=1200, on_progress=on_progress,
+            timeout=1200, on_progress=on_progress, next_sequence=next_sequence,
             parser=lambda text: validate_settlement(
                 text, source_ids=[],
                 assessment_ids=active_ids if role == "final" else [],
@@ -393,6 +411,7 @@ def _staged_structural_review(
     trailer = rc.trailer(state)
     if mode == cc.PLAN_MODE:
         trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
+    attempts.sort(key=lambda item: item.sequence or 0)
     return review, trailer, [a.json() for a in attempts]
 
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -199,11 +199,13 @@ def _staged_structural_review(
         text: str, *, source_ids: list[str], assessment_ids: list[str],
         source_severities: dict[str, str] | None = None,
         assessment_verdicts: dict[str, str] | None = None,
+        assessment_findings: dict[str, str | None] | None = None,
         known_debt: list[str] | None = None, role: str,
     ) -> dict[str, Any]:
         parsed = rc.parse_settlement(
             text, source_ids=source_ids, source_severities=source_severities,
             assessment_ids=assessment_ids, assessment_verdicts=assessment_verdicts,
+            assessment_findings=assessment_findings,
             class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
             known_debt=known_debt or (), role=role,
         )
@@ -278,6 +280,9 @@ def _staged_structural_review(
         assessment_verdicts = {
             a["class_id"]: a["verdict"] for m in manifests for a in m["class_assessments"]
         }
+        assessment_findings = {
+            a["class_id"]: a["finding_id"] for m in manifests for a in m["class_assessments"]
+        }
         consolidation_body = json.dumps({
             "role": "census", "stakes": stakes, "manifests": manifests,
             "active_classes": active_classes,
@@ -292,7 +297,8 @@ def _staged_structural_review(
                 parser=lambda text: validate_settlement(
                     text, source_ids=source_ids, source_severities=source_severities,
                     assessment_ids=assessment_ids,
-                    assessment_verdicts=assessment_verdicts, role="census",
+                    assessment_verdicts=assessment_verdicts,
+                    assessment_findings=assessment_findings, role="census",
                 ),
             )
         except rc.CensusError as error:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -315,7 +315,7 @@ def _staged_structural_review(
         lanes = rc.LANES[mode]
 
         def run_lane(lane: str) -> tuple[str, Review, dict[str, Any], list[rc.Attempt]]:
-            instructions = prompts.STAGED_CENSUS_INSTRUCTIONS.replace("LANE", lane)
+            instructions = prompts.staged_census_instructions(mode, lane)
             lane_body = (
                 f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
                 "ACTIVE CLASSES: "
@@ -408,7 +408,7 @@ def _staged_structural_review(
             "checklist": list(rc.CHECKLIST) if role == "final" else [],
             "artifact": body,
         }, ensure_ascii=False)
-        prompt = prompts.compose(prompts.STAGED_FOLLOWUP_INSTRUCTIONS, stage_body)
+        prompt = prompts.compose(prompts.staged_followup_instructions(mode), stage_body)
         if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
             raise rc.CensusError(f"{role} prompt is {len(prompt)} characters")
         review, settlement, call_attempts = _staged_call(

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -127,7 +127,7 @@ def _settle_staged_failure(
             f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
             "CONVERGENCE: BLOCKED — staged failure state may not have persisted."
         )
-        if mode == cc.PLAN_MODE:
+        if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
             trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
         return review, trailer, [a.json() for a in getattr(error, "attempts", [])]
     closure._settled = True
@@ -144,7 +144,7 @@ def _settle_staged_failure(
         f"STRUCTURAL-PHASE: {state['phase']}\nSTRUCTURAL-ERROR: {error}\n"
         "CONVERGENCE: BLOCKED — staged review did not settle."
     )
-    if mode == cc.PLAN_MODE:
+    if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
         trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
     return review, trailer, attempts
 
@@ -164,7 +164,10 @@ def _state_unavailable_review(
         f"CLASS-CLOSURE: STATE-UNAVAILABLE — {reason}\n"
         "CONVERGENCE: BLOCKED — lineage state could not be used this round."
     )
-    if mode == cc.PLAN_MODE and claim_state is not None:
+    if (
+        mode == cc.PLAN_MODE and claim_state is not None
+        and getattr(closure, "claims_enabled", False)
+    ):
         trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
     return review, trailer, []
 
@@ -186,7 +189,7 @@ def _structural_pending_review(
         f"STRUCTURAL-PHASE: {phase}\nSTRUCTURAL-PENDING: {reason}\n"
         "CONVERGENCE: BLOCKED — structural review has not run."
     )
-    if mode == cc.PLAN_MODE:
+    if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
         trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
     return review, trailer, []
 
@@ -228,7 +231,13 @@ def _staged_structural_review(
         parsed = rc.parse_lane(
             text, lane=lane, class_ids=active_ids if lane == "integrity" else (),
         )
-        rc.resolve_anchors(parsed, root=cwd, plan_lines=plan_lines)
+        trusted_roots = None
+        repository_alias = cwd / "repository"
+        if mode == cc.PLAN_MODE and repository_alias.is_symlink():
+            trusted_roots = {"repository": repository_alias.resolve(strict=True)}
+        rc.resolve_anchors(
+            parsed, root=cwd, plan_lines=plan_lines, trusted_roots=trusted_roots,
+        )
         return parsed
 
     def validate_settlement(
@@ -245,7 +254,13 @@ def _staged_structural_review(
             class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
             known_debt=known_debt or (), role=role,
         )
-        rc.resolve_anchors(parsed, root=cwd, plan_lines=plan_lines)
+        trusted_roots = None
+        repository_alias = cwd / "repository"
+        if mode == cc.PLAN_MODE and repository_alias.is_symlink():
+            trusted_roots = {"repository": repository_alias.resolve(strict=True)}
+        rc.resolve_anchors(
+            parsed, root=cwd, plan_lines=plan_lines, trusted_roots=trusted_roots,
+        )
         reserved_debt = {
             item.get("id") for item in state.get("debt", []) if isinstance(item, dict)
         }
@@ -282,6 +297,8 @@ def _staged_structural_review(
             renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
             for finding in parsed["findings"]:
                 finding["id"] = renamed[finding["id"]]
+            for coverage in parsed["coverage"]:
+                coverage["finding_ids"] = [renamed[fid] for fid in coverage["finding_ids"]]
             for assessment in parsed["class_assessments"]:
                 if assessment["finding_id"] is not None:
                     assessment["finding_id"] = renamed[assessment["finding_id"]]
@@ -381,7 +398,10 @@ def _staged_structural_review(
     if mode == cc.BRANCH_MODE:
         closure._sweep(only=minted)
     state = rc.settle_state(state, settlement, phase=phase, snapshot=snapshot, round_no=round_no)
-    claim_blocked = mode == cc.PLAN_MODE and pc.is_blocked(lineage.claim_state)
+    claim_blocked = (
+        mode == cc.PLAN_MODE and closure.claims_enabled
+        and pc.is_blocked(lineage.claim_state)
+    )
     if lineage.blocking() or claim_blocked:
         state["phase"] = "correction"
     lineage.review_state = state
@@ -401,7 +421,7 @@ def _staged_structural_review(
             f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
             "CONVERGENCE: BLOCKED — this staged settlement may not have persisted."
         )
-        if mode == cc.PLAN_MODE:
+        if mode == cc.PLAN_MODE and closure.claims_enabled:
             trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
         return failed, trailer, [a.json() for a in attempts]
     closure._settled = True
@@ -409,7 +429,7 @@ def _staged_structural_review(
     closure.staged_settlement = settlement
     review = replace(review, text=rc.render_review(settlement))
     trailer = rc.trailer(state)
-    if mode == cc.PLAN_MODE:
+    if mode == cc.PLAN_MODE and closure.claims_enabled:
         trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
     attempts.sort(key=lambda item: item.sequence or 0)
     return review, trailer, [a.json() for a in attempts]
@@ -2002,6 +2022,7 @@ class _ClosureRound:
         self.retry_register: str | None = None
         self.register_status: str | None = None
         self.deadline: float | None = None
+        self.claims_enabled = False
         self._latched = False
         self._settled = False
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -280,18 +280,25 @@ def _staged_structural_review(
             "role": "census", "stakes": stakes, "manifests": manifests,
             "active_classes": active_classes,
         }, ensure_ascii=False)
-        prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
-        if len(prompt) > rc.MAX_CONSOLIDATION_PROMPT_CHARS:
-            raise rc.CensusError(f"consolidation prompt is {len(prompt)} characters")
-        review, settlement, call_attempts = _staged_call(
-            role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
-            model=model, effort=effort, timeout=600, on_progress=on_progress,
-            parser=lambda text: validate_settlement(
-                text, source_ids=source_ids, source_severities=source_severities,
-                assessment_ids=assessment_ids,
-                assessment_verdicts=assessment_verdicts, role="census",
-            ),
-        )
+        try:
+            prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
+            if len(prompt) > rc.MAX_CONSOLIDATION_PROMPT_CHARS:
+                raise rc.CensusError(f"consolidation prompt is {len(prompt)} characters")
+            review, settlement, call_attempts = _staged_call(
+                role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
+                model=model, effort=effort, timeout=600, on_progress=on_progress,
+                parser=lambda text: validate_settlement(
+                    text, source_ids=source_ids, source_severities=source_severities,
+                    assessment_ids=assessment_ids,
+                    assessment_verdicts=assessment_verdicts, role="census",
+                ),
+            )
+        except rc.CensusError as error:
+            error.attempts = [  # type: ignore[attr-defined]
+                *attempts, *getattr(error, "attempts", []),
+            ]
+            error.manifests = manifests  # type: ignore[attr-defined]
+            raise
         attempts.extend(call_attempts)
     else:
         role = "final" if phase == "final" else "correction"

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -86,7 +86,14 @@ def _staged_call(
         retry = engine.resume(
             review.session_ref,
             "Your staged JSON was rejected: " + str(first) +
-            "\nFix exactly that. Return only the required marker and complete JSON object.",
+            "\nFix every schema violation in the complete object, not only the first one. "
+            "Finding rows have exactly id,severity,summary,evidence,remedy (never class_id). "
+            "Debt rows have exactly id,finding_id,status. Debt updates have exactly "
+            "id,status,evidence. Class records are operations: close/reopen have only "
+            "op,class_id; reclassify adds severity; new/replace use the exact invariant, "
+            "severity and mode-specific procedure or pattern/pathspec shape from the original "
+            "prompt. They never contain status,finding_ids,debt_ids. Return only the required "
+            "marker and complete JSON object.",
             cwd, model, effort, False, timeout=min(300, timeout),
             **_progress_kwargs(on_progress),
         )

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -784,20 +784,6 @@ def _converge_branch_review(
                 review, trailer, attempt_ledger = _state_unavailable_review(
                     closure, mode=cc.BRANCH_MODE,
                 )
-            elif closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
-                try:
-                    review, trailer, attempt_ledger = _staged_structural_review(
-                        engine=engine.for_role(eng.ROLE_REPOSITORY), cwd=wt, model=model,
-                        effort=effort, mode=cc.BRANCH_MODE,
-                        body=f"=== REVIEW STAKES ===\n{stakes}\n\n{packet}",
-                        closure=closure, stakes=stakes, snapshot=head_id,
-                        round_no=review_round or 1, on_progress=on_progress,
-                    )
-                except rc.CensusError as error:
-                    review, trailer, attempt_ledger = _settle_staged_failure(
-                        closure, stakes=stakes, snapshot=head_id, error=error,
-                        mode=cc.BRANCH_MODE,
-                    )
             else:
                 review = engine.run(prompt, wt, model, effort, web_search,
                                     **_progress_kwargs(on_progress))

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -16,8 +16,9 @@ import shutil
 import subprocess
 import tempfile
 import time
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
+from dataclasses import replace
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Callable
@@ -52,23 +53,99 @@ def _attempt(role: str, engine: Engine, review: Review) -> rc.Attempt:
                       review.duration_ms, review.usage)
 
 
+def _staged_call(
+    *, role: str, engine: Engine, prompt: str, cwd: Path, model: str, effort: str,
+    timeout: int, parser: Callable[[str], dict[str, Any]],
+    on_progress: Callable[[str], None] | None,
+) -> tuple[Review, dict[str, Any], list[rc.Attempt]]:
+    """One staged call plus exactly one same-session schema correction."""
+    review = engine.run(prompt, cwd, model, effort, False, timeout=timeout,
+                        **_progress_kwargs(on_progress))
+    attempts = [_attempt(role, engine, review)]
+    if review.error:
+        error = rc.CensusError(f"{role} failed (exit {review.returncode})")
+        error.attempts = attempts  # type: ignore[attr-defined]
+        raise error
+    try:
+        return review, parser(review.text), attempts
+    except rc.CensusError as first:
+        if not review.session_ref:
+            error = rc.CensusError(f"{role} format invalid and has no resumable session: {first}")
+            error.attempts = attempts  # type: ignore[attr-defined]
+            raise error from first
+        retry = engine.resume(
+            review.session_ref,
+            "Your staged JSON was rejected: " + str(first) +
+            "\nFix exactly that. Return only the required marker and complete JSON object.",
+            cwd, model, effort, False, timeout=min(300, timeout),
+            **_progress_kwargs(on_progress),
+        )
+        attempts.append(_attempt(f"{role}-format-retry", engine, retry))
+        if retry.error:
+            error = rc.CensusError(f"{role} format retry failed (exit {retry.returncode})")
+            error.attempts = attempts  # type: ignore[attr-defined]
+            raise error from first
+        try:
+            parsed = parser(retry.text)
+        except rc.CensusError as second:
+            second.attempts = attempts  # type: ignore[attr-defined]
+            raise
+        return retry, parsed, attempts
+
+
+def _settle_staged_failure(
+    closure: "_ClosureRound", *, stakes: str, snapshot: str, error: rc.CensusError,
+    mode: str,
+) -> tuple[Review, str, list[dict[str, Any]]]:
+    assert closure.lineage is not None
+    state = rc.normalize_state(closure.lineage.review_state, stakes=stakes, snapshot=snapshot)
+    state["format_debt"] = str(error)
+    closure.lineage.review_state = state
+    cc.save_lineage(closure.state_root, closure.lineage)
+    closure._settled = True
+    closure.register_status = f"staged rejected: {error}"
+    attempts = [a.json() for a in getattr(error, "attempts", [])]
+    review = Review(
+        text=f"[paranoia-local error] staged review rejected: {error}",
+        session_ref=None, raw=str(error), returncode=2, error=True,
+    )
+    trailer = (
+        f"STRUCTURAL-PHASE: {state['phase']}\nSTRUCTURAL-ERROR: {error}\n"
+        "CONVERGENCE: BLOCKED — staged review did not settle."
+    )
+    if mode == cc.PLAN_MODE:
+        trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
+    return review, trailer, attempts
+
+
 def _staged_structural_review(
     *, engine: Engine, cwd: Path, model: str, effort: str, mode: str, body: str,
     closure: "_ClosureRound", stakes: str, snapshot: str, round_no: int,
-    on_progress: Callable[[str], None] | None,
+    on_progress: Callable[[str], None] | None, plan_lines: int | None = None,
 ) -> tuple[Review, str, list[dict[str, Any]]]:
     """Run census/correction/final and atomically settle it into the open lineage."""
     assert closure.lineage is not None
     lineage = closure.lineage
+    rc.class_context(closure._blocks())
     state = rc.normalize_state(lineage.review_state, stakes=stakes, snapshot=snapshot)
     phase = state["phase"]
-    active_ids = [c.class_id for c in lineage.active()]
+    active_classes = [
+        {
+            "class_id": c.class_id, "invariant": c.invariant,
+            "severity": c.severity, "status": c.status, "mechanized": c.mechanized,
+        }
+        for c in lineage.active()
+    ]
+    active_ids = [c["class_id"] for c in active_classes]
+    class_states = {
+        c.class_id: (c.status, c.mechanized, c.severity) for c in lineage.active()
+    }
     attempts: list[rc.Attempt] = []
 
     if phase == "census":
         lanes = rc.LANES[mode]
 
-        def run_lane(lane: str) -> tuple[str, Review, dict[str, Any]]:
+        def run_lane(lane: str) -> tuple[str, Review, dict[str, Any], list[rc.Attempt]]:
             instructions = prompts.STAGED_CENSUS_INSTRUCTIONS.replace("LANE", lane)
             lane_body = (
                 f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
@@ -77,54 +154,98 @@ def _staged_structural_review(
             prompt = prompts.compose(instructions, lane_body)
             if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
                 raise rc.CensusError(f"staged lane prompt is {len(prompt)} characters")
-            result = engine.run(prompt, cwd, model, effort, False,
-                                timeout=900, **_progress_kwargs(on_progress))
-            if result.error:
-                raise rc.CensusError(f"{lane} lane failed (exit {result.returncode})")
-            return lane, result, rc.parse_lane(
-                result.text, lane=lane, class_ids=active_ids if lane == "integrity" else (),
+            result, parsed, lane_attempts = _staged_call(
+                role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
+                model=model, effort=effort, timeout=900, on_progress=on_progress,
+                parser=lambda text: rc.parse_lane(
+                    text, lane=lane,
+                    class_ids=active_ids if lane == "integrity" else (),
+                ),
             )
+            rc.resolve_anchors(
+                parsed, root=cwd,
+                plan_lines=plan_lines,
+            )
+            renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
+            for finding in parsed["findings"]:
+                finding["id"] = renamed[finding["id"]]
+            for assessment in parsed["class_assessments"]:
+                if assessment["finding_id"] is not None:
+                    assessment["finding_id"] = renamed[assessment["finding_id"]]
+            return lane, result, parsed, lane_attempts
 
+        lane_rows = []
+        lane_errors: list[rc.CensusError] = []
         with ThreadPoolExecutor(max_workers=3) as pool:
-            lane_rows = list(pool.map(run_lane, lanes))
-        for lane, result, _ in lane_rows:
-            attempts.append(_attempt(f"census-{lane}", engine, result))
+            pending = {pool.submit(run_lane, lane): lane for lane in lanes}
+            for future in as_completed(pending):
+                try:
+                    lane_rows.append(future.result())
+                except rc.CensusError as error:
+                    lane_errors.append(error)
+        lane_rows.sort(key=lambda row: lanes.index(row[0]))
+        if lane_errors:
+            all_attempts = [a for row in lane_rows for a in row[3]]
+            all_attempts.extend(
+                a for error in lane_errors for a in getattr(error, "attempts", [])
+            )
+            first_error = lane_errors[0]
+            first_error.attempts = all_attempts  # type: ignore[attr-defined]
+            raise first_error
+        for _, _, _, lane_attempts in lane_rows:
+            attempts.extend(lane_attempts)
         manifests = [row[2] for row in lane_rows]
         source_ids = [f["id"] for m in manifests for f in m["findings"]]
+        source_severities = {f["id"]: f["severity"] for m in manifests for f in m["findings"]}
         assessment_ids = [a["class_id"] for m in manifests for a in m["class_assessments"]]
+        assessment_verdicts = {
+            a["class_id"]: a["verdict"] for m in manifests for a in m["class_assessments"]
+        }
         consolidation_body = json.dumps({
             "role": "census", "stakes": stakes, "manifests": manifests,
-            "active_classes": active_ids,
+            "active_classes": active_classes,
         }, ensure_ascii=False)
         prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
         if len(prompt) > rc.MAX_CONSOLIDATION_PROMPT_CHARS:
             raise rc.CensusError(f"consolidation prompt is {len(prompt)} characters")
-        review = engine.run(prompt, cwd, model, effort, False,
-                            timeout=600, **_progress_kwargs(on_progress))
-        attempts.append(_attempt("consolidation", engine, review))
-        if review.error:
-            raise rc.CensusError(f"consolidation failed (exit {review.returncode})")
-        settlement = rc.parse_settlement(
-            review.text, source_ids=source_ids, assessment_ids=assessment_ids, role="census",
+        review, settlement, call_attempts = _staged_call(
+            role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
+            model=model, effort=effort, timeout=600, on_progress=on_progress,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=source_ids, source_severities=source_severities,
+                assessment_ids=assessment_ids, assessment_verdicts=assessment_verdicts,
+                class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
+                role="census",
+            ),
+        )
+        attempts.extend(call_attempts)
+        rc.resolve_anchors(
+            settlement, root=cwd,
+            plan_lines=plan_lines,
         )
     else:
         role = "final" if phase == "final" else "correction"
         existing = [d["id"] for d in state.get("debt", []) if d.get("status") == "open"]
         stage_body = json.dumps({
             "role": role, "stakes": stakes, "existing_debt": state.get("debt", []),
-            "active_classes": active_ids, "artifact": body,
+            "active_classes": active_classes, "artifact": body,
         }, ensure_ascii=False)
         prompt = prompts.compose(prompts.STAGED_FOLLOWUP_INSTRUCTIONS, stage_body)
         if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
             raise rc.CensusError(f"{role} prompt is {len(prompt)} characters")
-        review = engine.run(prompt, cwd, model, effort, False,
-                            timeout=1200, **_progress_kwargs(on_progress))
-        attempts.append(_attempt(role, engine, review))
-        if review.error:
-            raise rc.CensusError(f"{role} failed (exit {review.returncode})")
-        settlement = rc.parse_settlement(
-            review.text, source_ids=[], assessment_ids=active_ids if role == "final" else [],
-            known_debt=existing, role=role,
+        review, settlement, call_attempts = _staged_call(
+            role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
+            timeout=1200, on_progress=on_progress,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=[], assessment_ids=active_ids if role == "final" else [],
+                class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
+                known_debt=existing, role=role,
+            ),
+        )
+        attempts.extend(call_attempts)
+        rc.resolve_anchors(
+            settlement, root=cwd,
+            plan_lines=plan_lines,
         )
 
     draft = cc.copy_lineage(lineage)
@@ -147,6 +268,8 @@ def _staged_structural_review(
     cc.save_lineage(closure.state_root, lineage)
     closure._settled = True
     closure.register_status = f"staged {phase} parsed"
+    closure.staged_settlement = settlement
+    review = replace(review, text=rc.render_review(settlement))
     trailer = rc.trailer(state)
     if mode == cc.PLAN_MODE:
         trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
@@ -371,6 +494,7 @@ def critique_branch(
             project_summary=project_summary, diff_intent=diff_intent, focus=focus,
             already=already, model=model, effort=effort, web_search=web_search,
             max_packet_chars=max_packet_chars, calibration=calibration,
+            stakes=stakes or "",
             log_dir=log_dir, now=now, on_progress=on_progress,
             closure_on=closure_on, closure_args=arguments,
             review_round=arguments.get("round"), include_unc=include_unc,
@@ -411,6 +535,7 @@ def _converge_branch_review(
     web_search: bool,
     max_packet_chars: int,
     calibration: str | None,
+    stakes: str,
     log_dir: Path,
     now: Clock,
     on_progress: Callable[[str], None] | None,
@@ -462,12 +587,18 @@ def _converge_branch_review(
 
         with worktree_at(repo, head_id) as wt:
             if closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
-                review, trailer, attempt_ledger = _staged_structural_review(
-                    engine=engine.for_role(eng.ROLE_REPOSITORY), cwd=wt, model=model,
-                    effort=effort, mode=cc.BRANCH_MODE, body=_prepend(calibration, packet),
-                    closure=closure, stakes=calibration or "", snapshot=head_id,
-                    round_no=review_round or 1, on_progress=on_progress,
-                )
+                try:
+                    review, trailer, attempt_ledger = _staged_structural_review(
+                        engine=engine.for_role(eng.ROLE_REPOSITORY), cwd=wt, model=model,
+                        effort=effort, mode=cc.BRANCH_MODE, body=_prepend(calibration, packet),
+                        closure=closure, stakes=stakes, snapshot=head_id,
+                        round_no=review_round or 1, on_progress=on_progress,
+                    )
+                except rc.CensusError as error:
+                    review, trailer, attempt_ledger = _settle_staged_failure(
+                        closure, stakes=stakes, snapshot=head_id, error=error,
+                        mode=cc.BRANCH_MODE,
+                    )
             else:
                 review = engine.run(prompt, wt, model, effort, web_search,
                                     **_progress_kwargs(on_progress))
@@ -496,7 +627,8 @@ def _converge_branch_review(
           # The retry's register is what actually changed durable state, so it belongs in
           # the audit record; the original review only carries the malformed attempt.
           "retry_register": closure.retry_register if closure else None,
-          "attempt_ledger": attempt_ledger})
+          "attempt_ledger": attempt_ledger,
+          "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None})
     body = _footer(review, engine)
     if closure and closure.retry_register:
         # Same reason, for the operator: a CLOSED or a corrected predicate that the retry
@@ -620,6 +752,16 @@ def critique_plan(
     ) if closure_on else None
     blocks = closure.prepare() if closure else []
 
+    if closure and closure.lineage is not None:
+        prior_review = closure.lineage.review_state
+        current_stakes_digest = rc.digest(stakes or "")
+        if prior_review and prior_review.get("stakes_digest") != current_stakes_digest:
+            closure.lineage.claim_state = pc.empty_state()
+            closure.lineage.classes = {
+                cid: replace(cls, status=cc.OPEN) if not cls.mechanized else cls
+                for cid, cls in closure.lineage.classes.items()
+            }
+            blocks = closure._blocks()
     claim_state: dict[str, Any] = (
         closure.lineage.claim_state
         if closure and closure.lineage is not None
@@ -634,6 +776,7 @@ def critique_plan(
     )
     claim_status = "disabled"
     claim_duration_ms: int | None = None
+    attempt_ledger: list[dict[str, Any]] = []
     if claim_verification:
         claim_started = time.monotonic()
         if closure and closure.unavailable:
@@ -652,6 +795,7 @@ def critique_plan(
                     engine=engine, repo=repo, model=model, effort=effort,
                     plan_repo_path=plan_repo_path,
                     on_progress=on_progress,
+                    attempt_ledger=attempt_ledger,
                     deadline=(
                         min(
                             plan_deadline - PLAN_TEARDOWN_RESERVE_SEC,
@@ -683,7 +827,6 @@ def critique_plan(
         closure.claims_enabled = claim_verification
         closure.claim_state = claim_state
 
-    attempt_ledger: list[dict[str, Any]] = []
     try:
         body = _plan_body(plan_text, context, focus, already, repo_grounded=bool(repo),
                           class_blocks=blocks)
@@ -691,7 +834,10 @@ def critique_plan(
         if closure:
             instructions += "\n\n" + prompts.PLAN_CLASS_REGISTER_INSTRUCTIONS
         prompt = prompts.compose(instructions, _prepend(calibration, body))
-        if type(engine) in (eng.CodexEngine, eng.ClaudeEngine) and claim_verification:
+        staged_profile = bool(
+            closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine)
+        )
+        if type(engine) in (eng.CodexEngine, eng.ClaudeEngine) and (claim_verification or closure):
             parent = orientation.resolve_head(repo) if orientation.has_head(repo) else None
             snapshot = orientation.wrap_commit(
                 repo,
@@ -707,9 +853,13 @@ def critique_plan(
                     "\n\nThe pinned repository evidence root is `repository/`. Treat that "
                     "prefix as the project root; no live Git or web tools are available."
                 )
+                staged_phase = (
+                    closure.lineage.review_state.get("phase", "census")
+                    if closure and closure.lineage else "census"
+                )
+                structural_reserve = 2160 if staged_phase == "census" else 1560
                 if plan_deadline is not None and (
-                    time.monotonic() + PLAN_STRUCTURAL_PHASE_TIMEOUT_SEC
-                    + PLAN_TEARDOWN_RESERVE_SEC > plan_deadline
+                    time.monotonic() + structural_reserve > plan_deadline
                 ):
                     review = Review(
                         text=(
@@ -725,12 +875,20 @@ def critique_plan(
                         "\n\nThe pinned repository evidence root is `repository/`. Treat that "
                         "prefix as the project root; no live Git or web tools are available."
                     )
-                    review, trailer, attempt_ledger = _staged_structural_review(
-                        engine=reviewer, cwd=review_cwd, model=model, effort=effort,
-                        mode=cc.PLAN_MODE, body=_prepend(calibration, staged_body),
-                        closure=closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
-                        round_no=arguments.get("round") or 1, on_progress=on_progress,
-                    )
+                    try:
+                        review, trailer, structural_attempts = _staged_structural_review(
+                            engine=reviewer, cwd=review_cwd, model=model, effort=effort,
+                            mode=cc.PLAN_MODE, body=_prepend(calibration, staged_body),
+                            closure=closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
+                            round_no=arguments.get("round") or 1, on_progress=on_progress,
+                            plan_lines=len(plan_text.splitlines()),
+                        )
+                    except rc.CensusError as error:
+                        review, trailer, structural_attempts = _settle_staged_failure(
+                            closure, stakes=stakes or "", snapshot=rc.digest(plan_text),
+                            error=error, mode=cc.PLAN_MODE,
+                        )
+                    attempt_ledger.extend(structural_attempts)
                 else:
                     review = reviewer.run(
                         isolated_prompt, review_cwd, model, effort, False,
@@ -739,7 +897,7 @@ def critique_plan(
                     )
                 if closure:
                     closure.deadline = plan_deadline
-                if closure and not attempt_ledger:
+                if closure and not staged_profile:
                     trailer = closure.settle(
                         review, reviewer, review_cwd, model, effort, False, on_progress,
                     )
@@ -770,11 +928,9 @@ def critique_plan(
         "claim_verification": claim_verification,
         "claim_status": claim_status,
         "claim_duration_ms": claim_duration_ms,
-        "claim_model_calls": (
-            0 if claim_status.startswith("reused ")
-            else 2 if claim_status.startswith("parsed after retry") or "retry" in claim_status
-            else 1
-        ) if claim_verification and claim_status != "state-unavailable" else 0,
+        "claim_model_calls": sum(
+            1 for item in attempt_ledger if str(item.get("role", "")).startswith("claim-")
+        ),
         "claim_counts": {
             verdict: sum(
                 1 for claim in pc.normalize_state(claim_state)["claims"].values()
@@ -785,6 +941,7 @@ def critique_plan(
         # (rejected) block alone would misreport the round.
         "retry_register": closure.retry_register if closure else None,
         "attempt_ledger": attempt_ledger,
+        "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None,
     })
     body_text = _footer(review, engine) + _stakes_notice(no_stakes)
     if closure and closure.retry_register:
@@ -814,6 +971,7 @@ def _verify_plan_claims(
     effort: str,
     plan_repo_path: str | None,
     on_progress: Callable[[str], None] | None,
+    attempt_ledger: list[dict[str, Any]] | None = None,
     deadline: float | None = None,
 ) -> tuple[dict[str, Any], str]:
     """Run exhaustive round 1, then verify only the external-claim edit cone."""
@@ -860,12 +1018,15 @@ def _verify_plan_claims(
         captured_engine = _CapturedClaimEngine(
             engine, plan_text=plan_text, repo=repo, plan_repo_path=plan_repo_path,
             prior_state=prior_state, frozen_ids=frozen, deadline=deadline,
+            attempt_ledger=attempt_ledger,
         )
         claim_engine = captured_engine
     review = claim_engine.run(
         prompt, repo, model, effort, True, timeout=1800,
         **_progress_kwargs(on_progress),
     )
+    if captured_engine is None and attempt_ledger is not None:
+        attempt_ledger.append(_attempt("claim-audit", engine, review).json())
     if review.error:
         error = pc.AuditError(
             f"claim-audit reviewer failed (exit {review.returncode})", review.raw or review.text
@@ -903,6 +1064,8 @@ def _verify_plan_claims(
             ), repo,
             model, effort, True, timeout=1800, **_progress_kwargs(on_progress),
         )
+        if captured_engine is None and attempt_ledger is not None:
+            attempt_ledger.append(_attempt("claim-audit-retry", engine, retry).json())
         if retry.error:
             second = pc.AuditError(
                 f"initial audit invalid ({first.reason}); correction call failed "
@@ -965,6 +1128,7 @@ class _CapturedClaimEngine:
         plan_repo_path: str | None, prior_state: dict[str, Any] | None = None,
         frozen_ids: frozenset[str] = frozenset(),
         deadline: float | None = None,
+        attempt_ledger: list[dict[str, Any]] | None = None,
     ) -> None:
         self.engine = engine
         self.plan_text = plan_text
@@ -973,6 +1137,7 @@ class _CapturedClaimEngine:
         self.prior_state = prior_state or {}
         self.frozen_ids = frozen_ids
         self.deadline = deadline
+        self.attempt_ledger = attempt_ledger
         self.model_calls = 0
         self.launch = Path(tempfile.mkdtemp(prefix="paranoia-plan-evidence-"))
         self.binding_engine: Engine | None = None
@@ -1001,6 +1166,7 @@ class _CapturedClaimEngine:
         first = discoverer.run(
             prompt, self.launch, model, effort, True, **discovery_kwargs,
         )
+        self._record("claim-discovery", discoverer, first)
         if first.error or not first.session_ref:
             return first
         raw_parts = [first.raw]
@@ -1019,6 +1185,7 @@ class _CapturedClaimEngine:
                 ),
                 self.launch, model, effort, True, **discovery_kwargs,
             )
+            self._record("claim-discovery-retry", discoverer, corrected)
             raw_parts.append(corrected.raw)
             if corrected.error or not corrected.session_ref:
                 return corrected
@@ -1097,6 +1264,10 @@ class _CapturedClaimEngine:
         self.model_calls += 1
         return PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
 
+    def _record(self, role: str, engine: Engine, review: Review) -> None:
+        if self.attempt_ledger is not None:
+            self.attempt_ledger.append(_attempt(role, engine, review).json())
+
     @staticmethod
     def _deadline_failure(
         error: pc.AuditError, session_ref: str | None = None,
@@ -1134,6 +1305,7 @@ class _CapturedClaimEngine:
         corrected = role.resume(
             session_ref, prompt, self.launch, model, effort, False, **binding_kwargs,
         )
+        self._record("claim-binding-outer-retry", role, corrected)
         if corrected.error or self.discovery is None:
             return corrected
         try:
@@ -1255,6 +1427,7 @@ class _CapturedClaimEngine:
                 current_session, instruction, self.launch, model, effort, False,
                 **call_kwargs,
             )
+            self._record("claim-binding", self.binding_engine, review)
             reviews.append(review)
             if review.error or not review.session_ref:
                 raise pc.AuditError("captured-text binding call failed", review.raw)
@@ -1268,6 +1441,7 @@ class _CapturedClaimEngine:
                     f"{PLAN_BINDING_MARKER} object for exactly this batch.\n\n{rendered}",
                     self.launch, model, effort, False, **call_kwargs,
                 )
+                self._record("claim-binding-retry", self.binding_engine, correction)
                 reviews.append(correction)
                 if correction.error or not correction.session_ref:
                     raise pc.AuditError("captured-text binding correction failed", correction.raw)
@@ -1431,6 +1605,7 @@ class _CapturedClaimEngine:
         review = attester.run(
             prompt, self.launch, model, effort, False, timeout=timeout,
         )
+        self._record("claim-attestation", attester, review)
         self.attestation_raw = review.raw
         if review.error:
             return review

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -310,7 +310,8 @@ source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
 debt=[{"id":"D1","finding_id":"G1","status":"open"}];
-debt_updates=[]; class_records=[]. Do not emit prose."""
+debt_updates=[]; class_records=[]. A violated assessment must map to the same governing finding as
+its cited lane finding; a satisfied assessment maps to null. Do not emit prose."""
 
 
 STAGED_FOLLOWUP_INSTRUCTIONS = """Perform the staged structural role named in the task. Correction

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -286,8 +286,9 @@ def compose(instructions: str, body: str) -> str:
 
 STAGED_CENSUS_INSTRUCTIONS = """You are one independent lane in a cold structural review census.
 Read the complete supplied artifact and repository. Own every checklist item from your lane's
-perspective. Report all in-scope severities; do not defer issues to another lane. Evidence anchors
-must resolve to plan sections or repository path:line locations. Return only:
+perspective. Report all in-scope severities; do not defer issues to another lane. Cite the reviewed
+plan itself only as `plan:<line>` (never by its repository path); cite other supplied files as
+repository path:line locations. Every evidence anchor must resolve. Return only:
 === REVIEW CENSUS JSON ===
 {"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"],"finding_ids":[]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
 Include all nine checklist IDs named in the task. Non-integrity lanes return an empty
@@ -327,6 +328,8 @@ and one assessment disposition per class. The task's checklist array is governin
 final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
 "summary":"why","evidence":["path:line"],"finding_ids":[]}],"class_assessments":[{
 "class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}].
+A plan artifact must be cited only as `plan:<line>`, never by its repository path; other supplied
+files use repository path:line anchors. Every anchor must resolve.
 A finding row names one or more findings, all other coverage rows name none, and every finding is
 named by coverage."""
 

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -323,7 +323,12 @@ supplied open debt exactly once. Final must include all nine checklist IDs and a
 exactly once; a violated class creates a finding and open debt. Use the same exact row shapes as the
 census settlement; each debt update is {"id":"D1","status":"closed|open","evidence":["path:1"]}.
 Correction returns empty source/assessment dispositions. Final returns empty source dispositions
-and one assessment disposition per class."""
+and one assessment disposition per class. The task's checklist array is governing. The exact
+final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
+"summary":"why","evidence":["path:line"],"finding_ids":[]}],"class_assessments":[{
+"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}].
+A finding row names one or more findings, all other coverage rows name none, and every finding is
+named by coverage."""
 
 
 # ── class closure ─────────────────────────────────────────────────────────────

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -284,6 +284,34 @@ def compose(instructions: str, body: str) -> str:
     return f"{instructions}\n\n===== TASK INPUT =====\n\n{body}"
 
 
+STAGED_CENSUS_INSTRUCTIONS = """You are one independent lane in a cold structural review census.
+Read the complete supplied artifact and repository. Own every checklist item from your lane's
+perspective. Report all in-scope severities; do not defer issues to another lane. Evidence anchors
+must resolve to plan sections or repository path:line locations. Return only:
+=== REVIEW CENSUS JSON ===
+{"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
+Include all nine checklist IDs named in the task. Non-integrity lanes return an empty
+class_assessments array; integrity assesses every supplied active class exactly once and a violated
+assessment names one of its findings."""
+
+
+STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do not conduct a new
+review. Map every source finding and class assessment exactly once. Preserve the highest severity
+of merged findings. Every blocking governing finding needs exactly one open debt record. Return
+only === REVIEW SETTLEMENT JSON === followed by one JSON object with: role, source_dispositions,
+assessment_dispositions, findings, debt, debt_updates, and class_records. Class record op is one of
+new, close, reopen, reclassify, replace. Use replace as one atomic predecessor-to-open-successor
+operation. Do not emit prose."""
+
+
+STAGED_FOLLOWUP_INSTRUCTIONS = """Perform the staged structural role named in the task. Correction
+is targeted to every open debt item and effects of its repair. Final is a fresh cold whole-artifact
+review using the complete checklist and every active class. Return only === REVIEW SETTLEMENT JSON
+followed by one JSON object with role, source_dispositions, assessment_dispositions, findings,
+debt, debt_updates, and class_records. Account for every existing debt exactly once. Final must
+assess every active class exactly once; a violated class creates a finding and open debt."""
+
+
 # ── class closure ─────────────────────────────────────────────────────────────
 # The register is the ONLY channel by which a defect class becomes durable. Nothing in
 # the five prose sections is parsed: nine review rounds established that policing free

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -287,8 +287,9 @@ def compose(instructions: str, body: str) -> str:
 STAGED_CENSUS_INSTRUCTIONS = """You are one independent lane in a cold structural review census.
 Read the complete supplied artifact and repository. Own every checklist item from your lane's
 perspective. Report all in-scope severities; do not defer issues to another lane. Cite the reviewed
-plan itself only as `plan:<line>` (never by its repository path); cite other supplied files as
-repository path:line locations. Every evidence anchor must resolve. Return only:
+plan itself only as `plan:<line>` (never by its repository path); cite every other supplied file
+as `repository/<path>:<line>` (the literal `repository/` prefix is required). Every evidence
+anchor must resolve. Return only:
 === REVIEW CENSUS JSON ===
 {"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"],"finding_ids":[]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
 Include all nine checklist IDs named in the task. Non-integrity lanes return an empty
@@ -328,8 +329,9 @@ and one assessment disposition per class. The task's checklist array is governin
 final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
 "summary":"why","evidence":["path:line"],"finding_ids":[]}],"class_assessments":[{
 "class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}].
-A plan artifact must be cited only as `plan:<line>`, never by its repository path; other supplied
-files use repository path:line anchors. Every anchor must resolve.
+A plan artifact must be cited only as `plan:<line>`, never by its repository path; every other
+supplied file uses `repository/<path>:<line>` (the literal `repository/` prefix is required).
+Every anchor must resolve.
 A finding row names one or more findings, all other coverage rows name none, and every finding is
 named by coverage."""
 

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -307,7 +307,7 @@ class_id; reclassify additionally has severity. Use these exact row shapes:
 source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
-debt=[{"id":"D1","finding_id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"status":"open"}];
+debt=[{"id":"D1","finding_id":"G1","status":"open"}];
 debt_updates=[]; class_records=[]. Do not emit prose."""
 
 

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -301,15 +301,26 @@ of merged findings. Every blocking governing finding needs exactly one open debt
 only === REVIEW SETTLEMENT JSON === followed by one JSON object with: role, source_dispositions,
 assessment_dispositions, findings, debt, debt_updates, and class_records. Class record op is one of
 new, close, reopen, reclassify, replace. Use replace as one atomic predecessor-to-open-successor
-operation. Do not emit prose."""
+operation. A new/replace record has op, invariant, severity and either pattern+pathspec (branch)
+or procedure (plan), with class_id additionally required for replace. Close/reopen has only op and
+class_id; reclassify additionally has severity. Use these exact row shapes:
+source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
+assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
+findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
+debt=[{"id":"D1","finding_id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"status":"open"}];
+debt_updates=[]; class_records=[]. Do not emit prose."""
 
 
 STAGED_FOLLOWUP_INSTRUCTIONS = """Perform the staged structural role named in the task. Correction
 is targeted to every open debt item and effects of its repair. Final is a fresh cold whole-artifact
 review using the complete checklist and every active class. Return only === REVIEW SETTLEMENT JSON
 followed by one JSON object with role, source_dispositions, assessment_dispositions, findings,
-debt, debt_updates, and class_records. Account for every existing debt exactly once. Final must
-assess every active class exactly once; a violated class creates a finding and open debt."""
+debt, debt_updates, class_records and, for final, coverage plus class_assessments. Account for every
+existing debt exactly once. Final must include all nine checklist IDs and assess every active class
+exactly once; a violated class creates a finding and open debt. Use the same exact row shapes as the
+census settlement; each debt update is {"id":"D1","status":"closed|open","evidence":["path:1"]}.
+Correction returns empty source/assessment dispositions. Final returns empty source dispositions
+and one assessment disposition per class."""
 
 
 # ── class closure ─────────────────────────────────────────────────────────────

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -284,12 +284,31 @@ def compose(instructions: str, body: str) -> str:
     return f"{instructions}\n\n===== TASK INPUT =====\n\n{body}"
 
 
+PLAN_EVIDENCE_ANCHORS = """Cite the reviewed plan itself only as `plan:<line>`
+(never by its repository path); cite every other supplied file as `repository/<path>:<line>`
+(the literal `repository/` prefix is required)."""
+
+BRANCH_EVIDENCE_ANCHORS = """This is a branch review and there is no `plan:` evidence alias.
+Cite every supplied file as `repository/<path>:<line>` (the literal `repository/` prefix is
+required), including plans, contracts, and documentation stored in the repository."""
+
+
+def staged_census_instructions(mode: str, lane: str) -> str:
+    policy = PLAN_EVIDENCE_ANCHORS if mode == "plan" else BRANCH_EVIDENCE_ANCHORS
+    return STAGED_CENSUS_INSTRUCTIONS.replace("ANCHOR_POLICY", policy).replace(
+        "LANE", lane,
+    )
+
+
+def staged_followup_instructions(mode: str) -> str:
+    policy = PLAN_EVIDENCE_ANCHORS if mode == "plan" else BRANCH_EVIDENCE_ANCHORS
+    return STAGED_FOLLOWUP_INSTRUCTIONS.replace("ANCHOR_POLICY", policy)
+
+
 STAGED_CENSUS_INSTRUCTIONS = """You are one independent lane in a cold structural review census.
 Read the complete supplied artifact and repository. Own every checklist item from your lane's
-perspective. Report all in-scope severities; do not defer issues to another lane. Cite the reviewed
-plan itself only as `plan:<line>` (never by its repository path); cite every other supplied file
-as `repository/<path>:<line>` (the literal `repository/` prefix is required). Every evidence
-anchor must resolve. Return only:
+perspective. Report all in-scope severities; do not defer issues to another lane. ANCHOR_POLICY
+Every evidence anchor must resolve. Return only:
 === REVIEW CENSUS JSON ===
 {"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"],"finding_ids":[]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
 Include all nine checklist IDs named in the task. Non-integrity lanes return an empty
@@ -329,8 +348,7 @@ and one assessment disposition per class. The task's checklist array is governin
 final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
 "summary":"why","evidence":["path:line"],"finding_ids":[]}],"class_assessments":[{
 "class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}].
-A plan artifact must be cited only as `plan:<line>`, never by its repository path; every other
-supplied file uses `repository/<path>:<line>` (the literal `repository/` prefix is required).
+ANCHOR_POLICY
 Every anchor must resolve.
 A finding row names one or more findings, all other coverage rows name none, and every finding is
 named by coverage."""

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -289,10 +289,12 @@ Read the complete supplied artifact and repository. Own every checklist item fro
 perspective. Report all in-scope severities; do not defer issues to another lane. Evidence anchors
 must resolve to plan sections or repository path:line locations. Return only:
 === REVIEW CENSUS JSON ===
-{"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
+{"lane":"LANE","coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable","summary":"why","evidence":["path:line"],"finding_ids":[]}],"findings":[{"id":"LANE-1","severity":"FATAL|BLOCKER|MAJOR|MINOR|OUT-OF-SCOPE","summary":"atomic root issue","evidence":["path:line"],"remedy":"bounded repair"}],"class_assessments":[{"class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}]}
 Include all nine checklist IDs named in the task. Non-integrity lanes return an empty
 class_assessments array; integrity assesses every supplied active class exactly once and a violated
-assessment names one of its findings."""
+assessment names one of its findings. A coverage row with status finding names one or more lane
+finding IDs; all other rows use an empty finding_ids array, and every lane finding is named by at
+least one coverage row."""
 
 
 STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do not conduct a new
@@ -316,7 +318,7 @@ is targeted to every open debt item and effects of its repair. Final is a fresh 
 review using the complete checklist and every active class. Return only === REVIEW SETTLEMENT JSON
 followed by one JSON object with role, source_dispositions, assessment_dispositions, findings,
 debt, debt_updates, class_records and, for final, coverage plus class_assessments. Account for every
-existing debt exactly once. Final must include all nine checklist IDs and assess every active class
+supplied open debt exactly once. Final must include all nine checklist IDs and assess every active class
 exactly once; a violated class creates a finding and open debt. Use the same exact row shapes as the
 census settlement; each debt update is {"id":"D1","status":"closed|open","evidence":["path:1"]}.
 Correction returns empty source/assessment dispositions. Final returns empty source dispositions

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -57,6 +57,17 @@ def digest(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8", "surrogateescape")).hexdigest()
 
 
+def render_error_review(message: str) -> str:
+    safe = str(message).replace("\r", " ").replace("\n", " ")
+    return "\n\n".join((
+        "## What works\n\nNothing notable.",
+        f"## What doesn't work\n\n{safe}",
+        "## Risks\n\nNothing notable.",
+        "## Gaps\n\nNothing notable.",
+        "## Improvements\n\nNothing notable.",
+    ))
+
+
 def normalize_state(raw: Any, *, stakes: str, snapshot: str) -> dict[str, Any]:
     sd = digest(stakes)
     if not isinstance(raw, dict) or raw.get("version") != 1 or raw.get("stakes_digest") != sd:
@@ -229,13 +240,13 @@ def parse_settlement(
             if cid in operation_by_class:
                 raise CensusError("more than one class operation against one assessment")
             operation_by_class[cid] = record.get("op")
-            if role == "correction" and record.get("op") in {"reclassify", "replace"}:
+            if record.get("op") in {"reclassify", "replace"}:
                 replacement_severity = record.get("severity")
                 prior_severity = class_states[cid][2] if class_states else None
                 if replacement_severity not in rank:
                     raise CensusError("invalid class severity")
                 if prior_severity and rank[replacement_severity] < rank[prior_severity]:
-                    raise CensusError("correction cannot downgrade an active class")
+                    raise CensusError("staged settlement cannot downgrade an active class")
     for cid, verdict in (assessment_verdicts or {}).items():
         target = disposition_by_class.get(cid)
         if verdict == "violated" and target is None:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -90,13 +90,13 @@ def parse_lane(text: str, *, lane: str, class_ids: Sequence[str] = ()) -> dict[s
     got = [row.get("id") for row in coverage if isinstance(row, dict)]
     if sorted(got) != sorted(CHECKLIST) or len(got) != len(set(got)):
         raise CensusError("coverage must contain every checklist id exactly once")
-    finding_ids: set[str] = set()
     for row in coverage:
-        _exact(row, {"id", "status", "summary", "evidence"}, "coverage row")
+        _exact(row, {"id", "status", "summary", "evidence", "finding_ids"}, "coverage row")
         if row["status"] not in {"covered", "finding", "not_applicable"}:
             raise CensusError("invalid coverage status")
         _bounded(row["summary"], MAX_SUMMARY_CHARS, "coverage summary")
         _anchors(row["evidence"])
+    finding_ids: set[str] = set()
     for finding in _list(obj, "findings"):
         _exact(finding, {"id", "severity", "summary", "evidence", "remedy"}, "finding")
         fid = _bounded(finding["id"], 120, "finding id")
@@ -108,6 +108,18 @@ def parse_lane(text: str, *, lane: str, class_ids: Sequence[str] = ()) -> dict[s
         _bounded(finding["summary"], MAX_SUMMARY_CHARS, "finding summary")
         _bounded(finding["remedy"], MAX_SUMMARY_CHARS, "finding remedy")
         _anchors(finding["evidence"])
+    referenced: set[str] = set()
+    for row in coverage:
+        links = row["finding_ids"]
+        if not isinstance(links, list) or any(
+            not isinstance(fid, str) or fid not in finding_ids for fid in links
+        ) or len(links) != len(set(links)):
+            raise CensusError("coverage finding_ids must name unique lane findings")
+        if (row["status"] == "finding") != bool(links):
+            raise CensusError("finding coverage must name findings and other coverage must not")
+        referenced.update(links)
+    if referenced != finding_ids:
+        raise CensusError("every lane finding must be bound to checklist coverage")
     assessments = _list(obj, "class_assessments")
     expected = set(class_ids) if lane == "integrity" else set()
     seen: set[str] = set()
@@ -393,7 +405,15 @@ def resolve_anchors(value: Any, *, root: Any, plan_lines: int | None = None) -> 
                 raise CensusError(f"unresolvable repository anchor {anchor!r}")
             target = base / relative
             try:
-                count = sum(1 for _ in target.open("r", encoding="utf-8", errors="replace"))
+                cursor = base
+                for part in relative.parts:
+                    cursor = cursor / part
+                    if cursor.is_symlink():
+                        raise OSError("symlink evidence anchors are not snapshot paths")
+                resolved = target.resolve(strict=True)
+                if not resolved.is_relative_to(base):
+                    raise OSError("evidence anchor escapes snapshot")
+                count = sum(1 for _ in resolved.open("r", encoding="utf-8", errors="replace"))
             except (OSError, ValueError) as exc:
                 raise CensusError(f"unresolvable repository anchor {anchor!r}") from exc
             if line > count:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -145,6 +145,7 @@ def parse_settlement(
     text: str, *, source_ids: Sequence[str], assessment_ids: Sequence[str],
     source_severities: dict[str, str] | None = None,
     assessment_verdicts: dict[str, str] | None = None,
+    assessment_findings: dict[str, str | None] | None = None,
     class_states: dict[str, tuple[str, bool, str]] | None = None,
     class_mechanized: bool | None = None,
     known_debt: Sequence[str] = (), role: str = "census",
@@ -164,6 +165,9 @@ def parse_settlement(
         assessment_ids = [a["class_id"] for a in parsed_final["class_assessments"]]
         assessment_verdicts = {
             a["class_id"]: a["verdict"] for a in parsed_final["class_assessments"]
+        }
+        assessment_findings = {
+            a["class_id"]: a["finding_id"] for a in parsed_final["class_assessments"]
         }
     findings = _list(obj, "findings")
     finding_ids = _unique_ids(findings, "governing finding")
@@ -215,6 +219,7 @@ def parse_settlement(
         raise CensusError("every existing debt item must be updated exactly once")
     _list(obj, "class_records")
     disposition_by_class = {r["assessment_id"]: r["governing_id"] for r in assessment_rows}
+    governing_by_source = {r["source_id"]: r["governing_id"] for r in source_rows}
     operation_by_class: dict[str, str] = {}
     for record in obj["class_records"]:
         cid = record.get("class_id") if isinstance(record, dict) else None
@@ -237,6 +242,13 @@ def parse_settlement(
             raise CensusError("violated class assessment must map to a governing finding")
         if verdict == "satisfied" and target is not None:
             raise CensusError("satisfied class assessment cannot map to a finding")
+        cited = (assessment_findings or {}).get(cid)
+        if verdict == "violated" and assessment_findings is not None:
+            expected = governing_by_source.get(cited, cited if role == "final" else None)
+            if expected is None or target != expected:
+                raise CensusError(
+                    "violated class disposition must follow its cited finding"
+                )
         if class_states and cid in class_states:
             status, mechanized, prior_severity = class_states[cid]
             op = operation_by_class.get(cid)

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -179,17 +179,14 @@ def parse_settlement(
         if source_severity and rank[by_id[row["governing_id"]]["severity"]] < rank[source_severity]:
             raise CensusError("governing severity cannot downgrade a source finding")
     for item in debt:
-        _exact(item, {"id", "finding_id", "severity", "summary", "evidence", "status"}, "debt")
+        _exact(item, {"id", "finding_id", "status"}, "debt")
         if item["finding_id"] not in finding_ids or item["status"] not in {"open", "closed"}:
             raise CensusError("invalid debt mapping")
-        if item["severity"] != by_id[item["finding_id"]]["severity"]:
-            raise CensusError("debt severity must equal governing finding severity")
-        if (
-            item["summary"] != by_id[item["finding_id"]]["summary"]
-            or item["evidence"] != by_id[item["finding_id"]]["evidence"]
-        ):
-            raise CensusError("debt summary and evidence must equal its governing finding")
-        _anchors(item["evidence"])
+        governing = by_id[item["finding_id"]]
+        item.update(
+            severity=governing["severity"], summary=governing["summary"],
+            evidence=list(governing["evidence"]),
+        )
     updates = _list(obj, "debt_updates")
     seen_updates: set[str] = set()
     for item in updates:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -95,6 +95,13 @@ def class_context(blocks: Iterable[str]) -> str:
 
 
 def parse_lane(text: str, *, lane: str, class_ids: Sequence[str] = ()) -> dict[str, Any]:
+    # The same decorative-only omission observed on settlement markers also
+    # occurs on lane markers. Accept that exact first-line spelling so all
+    # three expensive census lanes are not predictably repeated.
+    stripped = text.strip()
+    short_marker = LANE_MARKER.removesuffix(" ===")
+    if stripped.startswith(short_marker + "\n"):
+        text = LANE_MARKER + stripped[len(short_marker):]
     obj = _object(text, LANE_MARKER, MAX_LANE_CHARS)
     if obj.get("lane") != lane:
         raise CensusError(f"lane must be {lane!r}")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -173,7 +173,9 @@ def parse_settlement(
             if len(matches) != 1:
                 raise CensusError("each blocking finding needs exactly one open debt record")
     by_id = {f["id"]: f for f in findings}
-    rank = {cc.OUT_OF_SCOPE: 0, cc.MINOR: 1, cc.MAJOR: 2, cc.BLOCKER: 3, cc.FATAL: 3}
+    # FATAL and BLOCKER both block, but they are not interchangeable labels: a
+    # plan-level impossibility must not be hidden by consolidating it as BLOCKER.
+    rank = {cc.OUT_OF_SCOPE: 0, cc.MINOR: 1, cc.MAJOR: 2, cc.BLOCKER: 3, cc.FATAL: 4}
     for row in source_rows:
         source_severity = (source_severities or {}).get(row["source_id"])
         if source_severity and rank[by_id[row["governing_id"]]["severity"]] < rank[source_severity]:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -129,11 +129,25 @@ def parse_lane(text: str, *, lane: str, class_ids: Sequence[str] = ()) -> dict[s
 
 def parse_settlement(
     text: str, *, source_ids: Sequence[str], assessment_ids: Sequence[str],
+    source_severities: dict[str, str] | None = None,
+    assessment_verdicts: dict[str, str] | None = None,
+    class_states: dict[str, tuple[str, bool, str]] | None = None,
+    class_mechanized: bool | None = None,
     known_debt: Sequence[str] = (), role: str = "census",
 ) -> dict[str, Any]:
     obj = _object(text, SETTLEMENT_MARKER, MAX_CONSOLIDATION_PROMPT_CHARS)
     if obj.get("role") != role:
         raise CensusError(f"settlement role must be {role!r}")
+    if role == "final":
+        parsed_final = parse_lane(json.dumps({
+            "lane": "integrity", "coverage": obj.get("coverage"),
+            "findings": obj.get("findings"),
+            "class_assessments": obj.get("class_assessments"),
+        }), lane="integrity", class_ids=assessment_ids)
+        assessment_ids = [a["class_id"] for a in parsed_final["class_assessments"]]
+        assessment_verdicts = {
+            a["class_id"]: a["verdict"] for a in parsed_final["class_assessments"]
+        }
     findings = _list(obj, "findings")
     finding_ids = _unique_ids(findings, "governing finding")
     debt = _list(obj, "debt")
@@ -153,10 +167,18 @@ def parse_settlement(
             matches = [d for d in debt if d.get("finding_id") == finding["id"] and d.get("status") == "open"]
             if len(matches) != 1:
                 raise CensusError("each blocking finding needs exactly one open debt record")
+    by_id = {f["id"]: f for f in findings}
+    rank = {cc.OUT_OF_SCOPE: 0, cc.MINOR: 1, cc.MAJOR: 2, cc.BLOCKER: 3, cc.FATAL: 3}
+    for row in source_rows:
+        source_severity = (source_severities or {}).get(row["source_id"])
+        if source_severity and rank[by_id[row["governing_id"]]["severity"]] < rank[source_severity]:
+            raise CensusError("governing severity cannot downgrade a source finding")
     for item in debt:
         _exact(item, {"id", "finding_id", "severity", "summary", "evidence", "status"}, "debt")
         if item["finding_id"] not in finding_ids or item["status"] not in {"open", "closed"}:
             raise CensusError("invalid debt mapping")
+        if item["severity"] != by_id[item["finding_id"]]["severity"]:
+            raise CensusError("debt severity must equal governing finding severity")
         _anchors(item["evidence"])
     updates = _list(obj, "debt_updates")
     seen_updates: set[str] = set()
@@ -171,6 +193,41 @@ def parse_settlement(
     if known_debt and seen_updates != set(known_debt):
         raise CensusError("every existing debt item must be updated exactly once")
     _list(obj, "class_records")
+    disposition_by_class = {r["assessment_id"]: r["governing_id"] for r in assessment_rows}
+    operation_by_class: dict[str, str] = {}
+    for record in obj["class_records"]:
+        cid = record.get("class_id") if isinstance(record, dict) else None
+        if cid:
+            if class_states is not None and cid not in class_states:
+                raise CensusError(f"class operation names unknown active class {cid!r}")
+            if cid in operation_by_class:
+                raise CensusError("more than one class operation against one assessment")
+            operation_by_class[cid] = record.get("op")
+    for cid, verdict in (assessment_verdicts or {}).items():
+        target = disposition_by_class.get(cid)
+        if verdict == "violated" and target is None:
+            raise CensusError("violated class assessment must map to a governing finding")
+        if verdict == "satisfied" and target is not None:
+            raise CensusError("satisfied class assessment cannot map to a finding")
+        if class_states and cid in class_states:
+            status, mechanized, prior_severity = class_states[cid]
+            op = operation_by_class.get(cid)
+            if verdict == "violated" and status == cc.CLOSED and op not in {"reopen", "replace"}:
+                raise CensusError("closed violated class must reopen or replace")
+            if verdict == "satisfied" and status in cc.UNPROVEN_STATUSES:
+                if mechanized:
+                    raise CensusError("mechanized open class cannot be model-closed")
+                if op != "close":
+                    raise CensusError("open satisfied class must close")
+            if verdict == "violated" and op in {"reclassify", "replace"}:
+                record = next(r for r in obj["class_records"] if r.get("class_id") == cid)
+                replacement_severity = record.get("severity")
+                if replacement_severity not in rank:
+                    raise CensusError("invalid class severity")
+                if rank[replacement_severity] < rank[prior_severity]:
+                    raise CensusError("violated class cannot be downgraded")
+    if class_mechanized is not None:
+        register_from_records(obj["class_records"], mechanized=class_mechanized)
     return obj
 
 
@@ -182,18 +239,53 @@ def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool
             raise CensusError("class record must be an object")
         op = row.get("op")
         if op == "new":
+            allowed = (
+                {"op", "invariant", "severity", "pattern", "pathspec"}
+                if mechanized else {"op", "invariant", "severity", "procedure"}
+            )
+            _exact(row, allowed, "new class record")
+            if row.get("severity") not in cc.SEVERITIES:
+                raise CensusError("invalid class severity")
             new.append(cc.NewClass(
                 invariant=_bounded(row.get("invariant"), 1000, "class invariant"),
-                severity=row.get("severity"), pattern=row.get("pattern") if mechanized else None,
-                pathspec=row.get("pathspec") if mechanized else None,
+                severity=row.get("severity"),
+                pattern=_bounded(row.get("pattern"), 2000, "pattern") if mechanized else None,
+                pathspec=_bounded(row.get("pathspec"), 1000, "pathspec") if mechanized else None,
                 procedure=None if mechanized else _bounded(row.get("procedure"), 2000, "procedure"),
             ))
         elif op in {"close", "reopen", "reclassify", "replace"}:
+            if op in {"close", "reopen"}:
+                _exact(row, {"op", "class_id"}, "class transition record")
+            elif op == "reclassify":
+                _exact(row, {"op", "class_id", "severity"}, "class transition record")
+            else:
+                allowed = (
+                    {"op", "class_id", "invariant", "severity", "pattern", "pathspec"}
+                    if mechanized else {"op", "class_id", "invariant", "severity", "procedure"}
+                )
+                _exact(row, allowed, "class replacement record")
+            if op in {"reclassify", "replace"} and row.get("severity") not in cc.SEVERITIES:
+                raise CensusError("invalid class severity")
             kind = {"close":"CLOSED", "reopen":"REOPEN", "reclassify":"RECLASSIFY", "replace":"REPLACE"}[op]
             transitions.append(cc.Transition(
-                kind=kind, class_id=row.get("class_id"), severity=row.get("severity"),
-                invariant=row.get("invariant"), pattern=row.get("pattern"),
-                pathspec=row.get("pathspec"), procedure=row.get("procedure"),
+                kind=kind, class_id=_bounded(row.get("class_id"), 120, "class id"),
+                severity=row.get("severity"),
+                invariant=(
+                    _bounded(row.get("invariant"), 1000, "class invariant")
+                    if op == "replace" else None
+                ),
+                pattern=(
+                    _bounded(row.get("pattern"), 2000, "pattern")
+                    if op == "replace" and mechanized else None
+                ),
+                pathspec=(
+                    _bounded(row.get("pathspec"), 1000, "pathspec")
+                    if op == "replace" and mechanized else None
+                ),
+                procedure=(
+                    _bounded(row.get("procedure"), 2000, "procedure")
+                    if op == "replace" and not mechanized else None
+                ),
             ))
         else:
             raise CensusError(f"unknown class operation {op!r}")
@@ -213,6 +305,7 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     next_phase = "correction" if active else ("clear" if phase == "census" else "final" if phase == "correction" else "clear")
     out = dict(state)
     out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
+    out.pop("format_debt", None)
     return out
 
 
@@ -220,7 +313,10 @@ def trailer(state: dict[str, Any]) -> str:
     debt = [d for d in state.get("debt", []) if d.get("status") == "open" and d.get("severity") in BLOCKING]
     phase = state.get("phase", "census")
     lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
-    if phase == "final":
+    if state.get("format_debt"):
+        lines.append(f"STRUCTURAL-ERROR: {state['format_debt']}")
+        lines.append("CONVERGENCE: BLOCKED — staged format debt remains open.")
+    elif phase == "final":
         lines.append("FINAL-REGRESSION: required")
         lines.append("CONVERGENCE: BLOCKED — cold final regression is required.")
     elif phase == "clear" and not debt:
@@ -228,6 +324,65 @@ def trailer(state: dict[str, Any]) -> str:
     else:
         lines.append("CONVERGENCE: BLOCKED — staged structural debt remains open.")
     return "\n".join(lines)
+
+
+def render_review(settlement: dict[str, Any]) -> str:
+    """Restore the stable human response while JSON remains in Review.raw/audit state."""
+    findings = settlement.get("findings", [])
+
+    def rows(items: list[dict[str, Any]]) -> str:
+        if not items:
+            return "Nothing notable."
+        return "\n".join(
+            f"- [{f['severity']}] {f['summary']} ({', '.join(f['evidence'])})"
+            for f in items
+        )
+
+    improvements = [f"- [{f['severity']}] {f['remedy']}" for f in findings]
+    return "\n\n".join((
+        "## What works\n\nNothing notable.",
+        "## What doesn't work\n\n" + rows(findings),
+        "## Risks\n\nNothing notable.",
+        "## Gaps\n\nNothing notable.",
+        "## Improvements\n\n" + ("\n".join(improvements) if improvements else "Nothing notable."),
+    ))
+
+
+def resolve_anchors(value: Any, *, root: Any, plan_lines: int | None = None) -> None:
+    """Resolve every evidence array in a parsed staged object against the snapshot."""
+    from pathlib import Path
+    base = Path(root).resolve()
+    for row in _walk_dicts(value):
+        evidence = row.get("evidence")
+        if not isinstance(evidence, list):
+            continue
+        for anchor in evidence:
+            path, sep, raw_line = anchor.rpartition(":")
+            if not sep or not raw_line.isdigit() or int(raw_line) < 1:
+                raise CensusError(f"unresolvable evidence anchor {anchor!r}")
+            line = int(raw_line)
+            if path == "plan":
+                if plan_lines is None or line > plan_lines:
+                    raise CensusError(f"unresolvable plan anchor {anchor!r}")
+                continue
+            target = (base / path).resolve()
+            try:
+                target.relative_to(base)
+                count = sum(1 for _ in target.open("r", encoding="utf-8", errors="replace"))
+            except (OSError, ValueError) as exc:
+                raise CensusError(f"unresolvable repository anchor {anchor!r}") from exc
+            if line > count:
+                raise CensusError(f"out-of-range repository anchor {anchor!r}")
+
+
+def _walk_dicts(value: Any):
+    if isinstance(value, dict):
+        yield value
+        for child in value.values():
+            yield from _walk_dicts(child)
+    elif isinstance(value, list):
+        for child in value:
+            yield from _walk_dicts(child)
 
 
 def _object(text: str, marker: str, cap: int) -> dict[str, Any]:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -46,6 +46,8 @@ class Attempt:
     outcome: str
     duration_ms: int | None
     usage: dict[str, Any] | None
+    response_sha256: str | None = None
+    response_excerpt: str | None = None
 
     def json(self) -> dict[str, Any]:
         return vars(self)
@@ -139,11 +141,14 @@ def parse_settlement(
     if obj.get("role") != role:
         raise CensusError(f"settlement role must be {role!r}")
     if role == "final":
-        parsed_final = parse_lane(json.dumps({
-            "lane": "integrity", "coverage": obj.get("coverage"),
-            "findings": obj.get("findings"),
-            "class_assessments": obj.get("class_assessments"),
-        }), lane="integrity", class_ids=assessment_ids)
+        parsed_final = parse_lane(
+            LANE_MARKER + "\n" + json.dumps({
+                "lane": "integrity", "coverage": obj.get("coverage"),
+                "findings": obj.get("findings"),
+                "class_assessments": obj.get("class_assessments"),
+            }),
+            lane="integrity", class_ids=assessment_ids,
+        )
         assessment_ids = [a["class_id"] for a in parsed_final["class_assessments"]]
         assessment_verdicts = {
             a["class_id"]: a["verdict"] for a in parsed_final["class_assessments"]
@@ -179,6 +184,11 @@ def parse_settlement(
             raise CensusError("invalid debt mapping")
         if item["severity"] != by_id[item["finding_id"]]["severity"]:
             raise CensusError("debt severity must equal governing finding severity")
+        if (
+            item["summary"] != by_id[item["finding_id"]]["summary"]
+            or item["evidence"] != by_id[item["finding_id"]]["evidence"]
+        ):
+            raise CensusError("debt summary and evidence must equal its governing finding")
         _anchors(item["evidence"])
     updates = _list(obj, "debt_updates")
     seen_updates: set[str] = set()
@@ -203,6 +213,13 @@ def parse_settlement(
             if cid in operation_by_class:
                 raise CensusError("more than one class operation against one assessment")
             operation_by_class[cid] = record.get("op")
+            if role == "correction" and record.get("op") in {"reclassify", "replace"}:
+                replacement_severity = record.get("severity")
+                prior_severity = class_states[cid][2] if class_states else None
+                if replacement_severity not in rank:
+                    raise CensusError("invalid class severity")
+                if prior_severity and rank[replacement_severity] < rank[prior_severity]:
+                    raise CensusError("correction cannot downgrade an active class")
     for cid, verdict in (assessment_verdicts or {}).items():
         target = disposition_by_class.get(cid)
         if verdict == "violated" and target is None:
@@ -299,7 +316,14 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
         item = old[update["id"]]
         item.update(status=update["status"], evidence=update["evidence"], last_round=round_no)
     for item in settlement.get("debt", []):
-        row = dict(item); row["first_round"] = round_no; row["last_round"] = round_no
+        if item["id"] in old:
+            raise CensusError(f"new debt reuses durable id {item['id']!r}")
+        row = dict(item)
+        row["source_ids"] = [
+            source["source_id"] for source in settlement.get("source_dispositions", [])
+            if source["governing_id"] == item["finding_id"]
+        ]
+        row["first_round"] = round_no; row["last_round"] = round_no
         old[row["id"]] = row
     active = [d for d in old.values() if d.get("status") == "open" and d.get("severity") in BLOCKING]
     next_phase = "correction" if active else ("clear" if phase == "census" else "final" if phase == "correction" else "clear")
@@ -365,9 +389,11 @@ def resolve_anchors(value: Any, *, root: Any, plan_lines: int | None = None) -> 
                 if plan_lines is None or line > plan_lines:
                     raise CensusError(f"unresolvable plan anchor {anchor!r}")
                 continue
-            target = (base / path).resolve()
+            relative = Path(path)
+            if relative.is_absolute() or ".." in relative.parts:
+                raise CensusError(f"unresolvable repository anchor {anchor!r}")
+            target = base / relative
             try:
-                target.relative_to(base)
                 count = sum(1 for _ in target.open("r", encoding="utf-8", errors="replace"))
             except (OSError, ValueError) as exc:
                 raise CensusError(f"unresolvable repository anchor {anchor!r}") from exc
@@ -388,8 +414,10 @@ def _walk_dicts(value: Any):
 def _object(text: str, marker: str, cap: int) -> dict[str, Any]:
     if len(text) > cap:
         raise CensusError(f"reply exceeds {cap} characters")
-    pos = text.rfind(marker)
-    raw = text[pos + len(marker):].strip() if pos >= 0 else text.strip()
+    stripped = text.strip()
+    if text.count(marker) != 1 or not stripped.startswith(marker):
+        raise CensusError(f"reply must begin with exactly one {marker!r} marker")
+    raw = stripped[len(marker):].strip()
     try: obj = json.loads(raw)
     except json.JSONDecodeError as exc: raise CensusError(f"invalid JSON: {exc}") from exc
     if not isinstance(obj, dict): raise CensusError("JSON result must be an object")
@@ -407,7 +435,10 @@ def _exact(row: Any, keys: set[str], label: str) -> None:
 
 
 def _bounded(value: Any, cap: int, label: str) -> str:
-    if not isinstance(value, str) or not value.strip() or len(value) > cap:
+    if (
+        not isinstance(value, str) or not value.strip() or len(value) > cap
+        or "\n" in value or "\r" in value
+    ):
         raise CensusError(f"{label} must be 1..{cap} characters")
     return value
 

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -489,7 +489,14 @@ def _list(obj: dict[str, Any], key: str) -> list[Any]:
 
 
 def _exact(row: Any, keys: set[str], label: str) -> None:
-    if not isinstance(row, dict) or set(row) != keys: raise CensusError(f"invalid {label} fields")
+    if not isinstance(row, dict):
+        raise CensusError(f"invalid {label} fields: expected an object with {sorted(keys)}")
+    actual = set(row)
+    if actual != keys:
+        raise CensusError(
+            f"invalid {label} fields: missing {sorted(keys - actual)}, "
+            f"unexpected {sorted(actual - keys)}; expected exactly {sorted(keys)}"
+        )
 
 
 def _bounded(value: Any, cap: int, label: str) -> str:

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -162,6 +162,14 @@ def parse_settlement(
     class_mechanized: bool | None = None,
     known_debt: Sequence[str] = (), role: str = "census",
 ) -> dict[str, Any]:
+    # Codex reliably emits the uniquely framed settlement object but sometimes
+    # drops only the marker's decorative trailing equals signs.  Normalizing
+    # that exact first-line variant avoids an otherwise identical second model
+    # turn; prose prefixes, duplicate markers, and malformed JSON still fail.
+    stripped = text.strip()
+    short_marker = SETTLEMENT_MARKER.removesuffix(" ===")
+    if stripped.startswith(short_marker + "\n"):
+        text = SETTLEMENT_MARKER + stripped[len(short_marker):]
     obj = _object(text, SETTLEMENT_MARKER, MAX_CONSOLIDATION_PROMPT_CHARS)
     if obj.get("role") != role:
         raise CensusError(f"settlement role must be {role!r}")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -48,6 +48,7 @@ class Attempt:
     usage: dict[str, Any] | None
     response_sha256: str | None = None
     response_excerpt: str | None = None
+    sequence: int | None = None
 
     def json(self) -> dict[str, Any]:
         return vars(self)

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -1,0 +1,285 @@
+"""Pure protocol for staged structural review.
+
+The model discovers findings; this module only proves that every reported item and
+tracked class received one coherent, durable disposition before state can clear.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+from dataclasses import dataclass
+from typing import Any, Iterable, Sequence
+
+from . import class_closure as cc
+
+CHECKLIST = (
+    "artifact-complete", "repository-premises", "transformations", "consumers",
+    "failure-recovery", "tests-acceptance", "docs-operations", "consistency",
+    "proportionality",
+)
+LANES = {
+    cc.PLAN_MODE: ("domain", "execution", "integrity"),
+    cc.BRANCH_MODE: ("behaviour", "execution", "integrity"),
+}
+BLOCKING = frozenset({cc.FATAL, cc.BLOCKER, cc.MAJOR})
+LANE_MARKER = "=== REVIEW CENSUS JSON ==="
+SETTLEMENT_MARKER = "=== REVIEW SETTLEMENT JSON ==="
+MAX_LANE_CHARS = 48_000
+MAX_SUMMARY_CHARS = 2_000
+MAX_ANCHOR_CHARS = 512
+MAX_CLASS_CONTEXT_CHARS = 64_000
+MAX_STAGED_PROMPT_CHARS = 5_000_000
+MAX_CONSOLIDATION_PROMPT_CHARS = 400_000
+PHASES = frozenset({"census", "correction", "final", "clear"})
+
+
+class CensusError(ValueError):
+    pass
+
+
+@dataclass(frozen=True)
+class Attempt:
+    role: str
+    engine: str
+    session_ref: str | None
+    outcome: str
+    duration_ms: int | None
+    usage: dict[str, Any] | None
+
+    def json(self) -> dict[str, Any]:
+        return vars(self)
+
+
+def digest(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8", "surrogateescape")).hexdigest()
+
+
+def normalize_state(raw: Any, *, stakes: str, snapshot: str) -> dict[str, Any]:
+    sd = digest(stakes)
+    if not isinstance(raw, dict) or raw.get("version") != 1 or raw.get("stakes_digest") != sd:
+        return {
+            "version": 1, "stakes_digest": sd, "stakes": stakes,
+            "phase": "census", "snapshot_digest": snapshot, "debt": [],
+        }
+    out = dict(raw)
+    if out.get("phase") not in PHASES or not isinstance(out.get("debt"), list):
+        raise CensusError("invalid persisted review_state")
+    if out["phase"] == "clear" and out.get("snapshot_digest") != snapshot:
+        out.update(phase="census", snapshot_digest=snapshot, debt=[])
+    return out
+
+
+def class_context(blocks: Iterable[str]) -> str:
+    text = "\n\n".join(x for x in blocks if x)
+    if len(text) > MAX_CLASS_CONTEXT_CHARS:
+        raise CensusError(
+            f"STATE-OVERSIZED: rendered class context is {len(text)} characters; "
+            f"supported maximum is {MAX_CLASS_CONTEXT_CHARS}"
+        )
+    return text
+
+
+def parse_lane(text: str, *, lane: str, class_ids: Sequence[str] = ()) -> dict[str, Any]:
+    obj = _object(text, LANE_MARKER, MAX_LANE_CHARS)
+    if obj.get("lane") != lane:
+        raise CensusError(f"lane must be {lane!r}")
+    coverage = _list(obj, "coverage")
+    got = [row.get("id") for row in coverage if isinstance(row, dict)]
+    if sorted(got) != sorted(CHECKLIST) or len(got) != len(set(got)):
+        raise CensusError("coverage must contain every checklist id exactly once")
+    finding_ids: set[str] = set()
+    for row in coverage:
+        _exact(row, {"id", "status", "summary", "evidence"}, "coverage row")
+        if row["status"] not in {"covered", "finding", "not_applicable"}:
+            raise CensusError("invalid coverage status")
+        _bounded(row["summary"], MAX_SUMMARY_CHARS, "coverage summary")
+        _anchors(row["evidence"])
+    for finding in _list(obj, "findings"):
+        _exact(finding, {"id", "severity", "summary", "evidence", "remedy"}, "finding")
+        fid = _bounded(finding["id"], 120, "finding id")
+        if fid in finding_ids:
+            raise CensusError(f"duplicate finding id {fid}")
+        finding_ids.add(fid)
+        if finding["severity"] not in cc.SEVERITIES:
+            raise CensusError("invalid finding severity")
+        _bounded(finding["summary"], MAX_SUMMARY_CHARS, "finding summary")
+        _bounded(finding["remedy"], MAX_SUMMARY_CHARS, "finding remedy")
+        _anchors(finding["evidence"])
+    assessments = _list(obj, "class_assessments")
+    expected = set(class_ids) if lane == "integrity" else set()
+    seen: set[str] = set()
+    for row in assessments:
+        _exact(row, {"class_id", "verdict", "evidence", "finding_id"}, "class assessment")
+        cid = row["class_id"]
+        if cid in seen or cid not in expected:
+            raise CensusError(f"unexpected or duplicate class assessment {cid!r}")
+        seen.add(cid)
+        if row["verdict"] not in {"satisfied", "violated"}:
+            raise CensusError("invalid class verdict")
+        _anchors(row["evidence"])
+        if row["verdict"] == "violated" and row.get("finding_id") not in finding_ids:
+            raise CensusError("violated class must name a lane finding")
+        if row["verdict"] == "satisfied" and row.get("finding_id") is not None:
+            raise CensusError("satisfied class cannot name a finding")
+    if seen != expected:
+        raise CensusError("integrity lane must assess every active class exactly once")
+    return obj
+
+
+def parse_settlement(
+    text: str, *, source_ids: Sequence[str], assessment_ids: Sequence[str],
+    known_debt: Sequence[str] = (), role: str = "census",
+) -> dict[str, Any]:
+    obj = _object(text, SETTLEMENT_MARKER, MAX_CONSOLIDATION_PROMPT_CHARS)
+    if obj.get("role") != role:
+        raise CensusError(f"settlement role must be {role!r}")
+    findings = _list(obj, "findings")
+    finding_ids = _unique_ids(findings, "governing finding")
+    debt = _list(obj, "debt")
+    debt_ids = _unique_ids(debt, "debt")
+    source_rows = _list(obj, "source_dispositions")
+    _exact_dispositions(source_rows, source_ids, finding_ids, "source_id")
+    assessment_rows = _list(obj, "assessment_dispositions")
+    _exact_dispositions(assessment_rows, assessment_ids, finding_ids, "assessment_id", allow_null=True)
+    for finding in findings:
+        _exact(finding, {"id", "severity", "summary", "evidence", "remedy"}, "governing finding")
+        if finding["severity"] not in cc.SEVERITIES:
+            raise CensusError("invalid governing severity")
+        _bounded(finding["summary"], MAX_SUMMARY_CHARS, "governing summary")
+        _bounded(finding["remedy"], MAX_SUMMARY_CHARS, "governing remedy")
+        _anchors(finding["evidence"])
+        if finding["severity"] in BLOCKING:
+            matches = [d for d in debt if d.get("finding_id") == finding["id"] and d.get("status") == "open"]
+            if len(matches) != 1:
+                raise CensusError("each blocking finding needs exactly one open debt record")
+    for item in debt:
+        _exact(item, {"id", "finding_id", "severity", "summary", "evidence", "status"}, "debt")
+        if item["finding_id"] not in finding_ids or item["status"] not in {"open", "closed"}:
+            raise CensusError("invalid debt mapping")
+        _anchors(item["evidence"])
+    updates = _list(obj, "debt_updates")
+    seen_updates: set[str] = set()
+    for item in updates:
+        _exact(item, {"id", "status", "evidence"}, "debt update")
+        if item["id"] in seen_updates or item["id"] not in set(known_debt):
+            raise CensusError("unexpected or duplicate debt update")
+        seen_updates.add(item["id"])
+        if item["status"] not in {"open", "closed"}:
+            raise CensusError("invalid debt-update status")
+        _anchors(item["evidence"])
+    if known_debt and seen_updates != set(known_debt):
+        raise CensusError("every existing debt item must be updated exactly once")
+    _list(obj, "class_records")
+    return obj
+
+
+def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool) -> cc.Register:
+    new: list[cc.NewClass] = []
+    transitions: list[cc.Transition] = []
+    for row in records:
+        if not isinstance(row, dict):
+            raise CensusError("class record must be an object")
+        op = row.get("op")
+        if op == "new":
+            new.append(cc.NewClass(
+                invariant=_bounded(row.get("invariant"), 1000, "class invariant"),
+                severity=row.get("severity"), pattern=row.get("pattern") if mechanized else None,
+                pathspec=row.get("pathspec") if mechanized else None,
+                procedure=None if mechanized else _bounded(row.get("procedure"), 2000, "procedure"),
+            ))
+        elif op in {"close", "reopen", "reclassify", "replace"}:
+            kind = {"close":"CLOSED", "reopen":"REOPEN", "reclassify":"RECLASSIFY", "replace":"REPLACE"}[op]
+            transitions.append(cc.Transition(
+                kind=kind, class_id=row.get("class_id"), severity=row.get("severity"),
+                invariant=row.get("invariant"), pattern=row.get("pattern"),
+                pathspec=row.get("pathspec"), procedure=row.get("procedure"),
+            ))
+        else:
+            raise CensusError(f"unknown class operation {op!r}")
+    return cc.Register(tuple(new), tuple(transitions))
+
+
+def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: str,
+                 snapshot: str, round_no: int) -> dict[str, Any]:
+    old = {d["id"]: dict(d) for d in state.get("debt", []) if isinstance(d, dict) and d.get("id")}
+    for update in settlement.get("debt_updates", []):
+        item = old[update["id"]]
+        item.update(status=update["status"], evidence=update["evidence"], last_round=round_no)
+    for item in settlement.get("debt", []):
+        row = dict(item); row["first_round"] = round_no; row["last_round"] = round_no
+        old[row["id"]] = row
+    active = [d for d in old.values() if d.get("status") == "open" and d.get("severity") in BLOCKING]
+    next_phase = "correction" if active else ("clear" if phase == "census" else "final" if phase == "correction" else "clear")
+    out = dict(state)
+    out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
+    return out
+
+
+def trailer(state: dict[str, Any]) -> str:
+    debt = [d for d in state.get("debt", []) if d.get("status") == "open" and d.get("severity") in BLOCKING]
+    phase = state.get("phase", "census")
+    lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
+    if phase == "final":
+        lines.append("FINAL-REGRESSION: required")
+        lines.append("CONVERGENCE: BLOCKED — cold final regression is required.")
+    elif phase == "clear" and not debt:
+        lines.append("CONVERGENCE: NOT-BLOCKED — staged structural debt is clear.")
+    else:
+        lines.append("CONVERGENCE: BLOCKED — staged structural debt remains open.")
+    return "\n".join(lines)
+
+
+def _object(text: str, marker: str, cap: int) -> dict[str, Any]:
+    if len(text) > cap:
+        raise CensusError(f"reply exceeds {cap} characters")
+    pos = text.rfind(marker)
+    raw = text[pos + len(marker):].strip() if pos >= 0 else text.strip()
+    try: obj = json.loads(raw)
+    except json.JSONDecodeError as exc: raise CensusError(f"invalid JSON: {exc}") from exc
+    if not isinstance(obj, dict): raise CensusError("JSON result must be an object")
+    return obj
+
+
+def _list(obj: dict[str, Any], key: str) -> list[Any]:
+    value = obj.get(key)
+    if not isinstance(value, list): raise CensusError(f"{key} must be a list")
+    return value
+
+
+def _exact(row: Any, keys: set[str], label: str) -> None:
+    if not isinstance(row, dict) or set(row) != keys: raise CensusError(f"invalid {label} fields")
+
+
+def _bounded(value: Any, cap: int, label: str) -> str:
+    if not isinstance(value, str) or not value.strip() or len(value) > cap:
+        raise CensusError(f"{label} must be 1..{cap} characters")
+    return value
+
+
+def _anchors(value: Any) -> None:
+    if not isinstance(value, list) or not value: raise CensusError("evidence anchors cannot be empty")
+    for anchor in value: _bounded(anchor, MAX_ANCHOR_CHARS, "evidence anchor")
+
+
+def _unique_ids(rows: Sequence[Any], label: str) -> set[str]:
+    ids: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict) or not isinstance(row.get("id"), str) or row["id"] in ids:
+            raise CensusError(f"invalid or duplicate {label} id")
+        ids.add(row["id"])
+    return ids
+
+
+def _exact_dispositions(rows: Sequence[Any], expected: Sequence[str], targets: set[str], key: str,
+                        allow_null: bool = False) -> None:
+    seen: set[str] = set()
+    for row in rows:
+        if not isinstance(row, dict) or set(row) != {key, "governing_id"}:
+            raise CensusError(f"invalid {key} disposition")
+        target = row["governing_id"]
+        if (row[key] in seen or row[key] not in set(expected)
+                or (target not in targets and not (allow_null and target is None))):
+            raise CensusError(f"invalid or duplicate {key} disposition")
+        seen.add(row[key])
+    if seen != set(expected): raise CensusError(f"every {key} must be dispositioned exactly once")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -261,6 +261,12 @@ def parse_settlement(
                 raise CensusError(
                     "violated class disposition must follow its cited finding"
                 )
+            matches = [
+                item for item in debt
+                if item.get("finding_id") == target and item.get("status") == "open"
+            ]
+            if len(matches) != 1:
+                raise CensusError("every violated class needs exactly one open debt record")
         if class_states and cid in class_states:
             status, mechanized, prior_severity = class_states[cid]
             op = operation_by_class.get(cid)
@@ -407,7 +413,10 @@ def render_review(settlement: dict[str, Any]) -> str:
     ))
 
 
-def resolve_anchors(value: Any, *, root: Any, plan_lines: int | None = None) -> None:
+def resolve_anchors(
+    value: Any, *, root: Any, plan_lines: int | None = None,
+    trusted_roots: dict[str, Any] | None = None,
+) -> None:
     """Resolve every evidence array in a parsed staged object against the snapshot."""
     from pathlib import Path
     base = Path(root).resolve()
@@ -427,15 +436,21 @@ def resolve_anchors(value: Any, *, root: Any, plan_lines: int | None = None) -> 
             relative = Path(path)
             if relative.is_absolute() or ".." in relative.parts:
                 raise CensusError(f"unresolvable repository anchor {anchor!r}")
-            target = base / relative
+            anchor_base = base
+            if trusted_roots and relative.parts and relative.parts[0] in trusted_roots:
+                anchor_base = Path(trusted_roots[relative.parts[0]]).resolve()
+                relative = Path(*relative.parts[1:])
+                if not relative.parts:
+                    raise CensusError(f"unresolvable repository anchor {anchor!r}")
+            target = anchor_base / relative
             try:
-                cursor = base
+                cursor = anchor_base
                 for part in relative.parts:
                     cursor = cursor / part
                     if cursor.is_symlink():
                         raise OSError("symlink evidence anchors are not snapshot paths")
                 resolved = target.resolve(strict=True)
-                if not resolved.is_relative_to(base):
+                if not resolved.is_relative_to(anchor_base):
                     raise OSError("evidence anchor escapes snapshot")
                 count = sum(1 for _ in resolved.open("r", encoding="utf-8", errors="replace"))
             except (OSError, ValueError) as exc:
@@ -494,9 +509,9 @@ def _anchors(value: Any) -> None:
 def _unique_ids(rows: Sequence[Any], label: str) -> set[str]:
     ids: set[str] = set()
     for row in rows:
-        if not isinstance(row, dict) or not isinstance(row.get("id"), str) or row["id"] in ids:
+        if not isinstance(row, dict) or row.get("id") in ids:
             raise CensusError(f"invalid or duplicate {label} id")
-        ids.add(row["id"])
+        ids.add(_bounded(row.get("id"), 120, f"{label} id"))
     return ids
 
 

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -124,7 +124,7 @@ TOOLS: list[Tool] = [
                 },
                 "converge": {
                     "type": "boolean",
-                    "description": "Convergence mode (default TRUE): pre-gather a deterministic evidence packet (touched files in full + diff) so the reviewer skips re-reading them every round, and review it against an immutable materialized worktree. Cheaper repeated rounds; always materializes (overrides isolate). Pass false (with class_closure: false) to fall back to the legacy in-place review. Class closure runs ONLY on this path, so `converge: false` is REFUSED unless you also pass `class_closure: false` — otherwise the review would look gated and emit no CONVERGENCE trailer.",
+                    "description": "Convergence mode (default TRUE): review an immutable evidence packet through a broad three-lane census, targeted correction debt, and one cold final regression. A clear census may converge immediately. Pass false with class_closure:false for the legacy one-shot path.",
                 },
                 "max_packet_chars": {
                     "type": "integer",
@@ -139,11 +139,10 @@ TOOLS: list[Tool] = [
                 "class_closure": {
                     "type": "boolean",
                     "description": (
-                        "Track defect CLASSES across rounds (default true). The reviewer registers "
-                        "each class with a regex matching violations only; every later round re-runs "
-                        "it and a computed CONVERGENCE trailer reports BLOCKED while any BLOCKER/MAJOR "
-                        "class still matches. This is what stops a loop fixing one spelling of a "
-                        "defect per round. Set false to restore the pre-closure behaviour exactly."
+                        "Enable tracked staged review (default true): concrete census findings, "
+                        "reusable classes, targeted correction, and a mandatory cold final. Branch "
+                        "class predicates are still swept against each reviewed snapshot. Set false "
+                        "for the legacy one-shot review."
                     ),
                 },
                 "lineage": {
@@ -213,7 +212,7 @@ TOOLS: list[Tool] = [
                 "class_closure": {
                     "type": "boolean",
                     "description": (
-                        "Track defect CLASSES across plan rounds (default TRUE, as for "
+                        "Enable tracked staged plan review (default TRUE, as for "
                         "critique_branch). Requires `lineage` and `round`. Pass FALSE for a "
                         "ONE-SHOT review — a design sketch with no convergence loop behind "
                         "it — which is the single explicit escape, drops the `round` "

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -78,14 +78,10 @@ _ROUND = {
     "minimum": 1,
     "description": (
         "REQUIRED unless you pass class_closure: false (the one-shot mode). "
-        "Convergence-loop round number (1-based). Increment it on each cold review round you run. "
-        "At round >=3 the reviewer restricts itself to merge-blocking in-scope findings — MAJOR "
-        "or higher ([BLOCKER]/[MAJOR] for code review, [FATAL]/[MAJOR] for plan review) — and "
-        "withholds [MINOR] and [OUT-OF-SCOPE], declaring 'CONVERGED' when none remain. This is "
-        "the lever to STOP a loop instead of chasing marginal/hardening findings across many "
-        "rounds. Start at 1 and raise as the design stabilises. It is required while class "
-        "closure is tracking a loop because without it the reviewer never reaches the "
-        "round-3 floor, so the loop has no terminating pressure at all."
+        "Convergence-loop sequence number (1-based); increment it after each settled attempt. "
+        "Tracked review uses it for lineage ordering while its cold census/final always cover "
+        "every in-scope severity and correction targets durable debt. The legacy one-shot "
+        "review retains the round-3 MAJOR-or-higher floor."
     ),
 }
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -37,6 +37,29 @@ class TestFactory:
         assert "fable" in engines.get_engine("claude").default_model
 
 
+def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:
+    review = engines.CodexEngine().parse_output(
+        '{"type":"thread.started","thread_id":"recovered"}\n'
+        '{"type":"error","message":"transient stream failure"}\n'
+        '{"type":"item.completed","item":{"type":"agent_message",'
+        '"text":"settled"}}\n'
+        '{"type":"turn.completed","usage":{"input_tokens":10}}\n'
+    )
+
+    assert review.error is False
+    assert review.text == "settled"
+
+
+def test_codex_terminal_error_remains_a_failure() -> None:
+    review = engines.CodexEngine().parse_output(
+        '{"type":"thread.started","thread_id":"failed"}\n'
+        '{"type":"item.completed","item":{"type":"agent_message",'
+        '"text":"partial"}}\n'
+        '{"type":"turn.failed","error":{"message":"terminal"}}\n'
+    )
+
+    assert review.error is True
+
 class TestCodexArgv:
     def test_build_argv_read_only_and_model_and_effort(self) -> None:
         e = engines.get_engine("codex")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -80,7 +80,8 @@ class TestDispatchEndToEnd:
     def test_critique_branch_runs_in_worktree(self, repo_with_branch, tmp_path, fake_bins):
         out = server.dispatch(
             "critique_branch",
-            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature", "round": 1},
+            {"repo_path": str(repo_with_branch), "base_ref": "main", "head_ref": "feature",
+             "round": 1, "class_closure": False},
             default_engine_name="codex", log_dir=tmp_path / "logs", now=lambda: "t1",
         )
         assert "FAKE CODEX REVIEW" in out

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1482,12 +1482,16 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
                  "evidence": ["repository/README.md:1"]}
                 for key in handlers.rc.CHECKLIST
             ]
-            text = json.dumps({"lane": lane, "coverage": coverage, "findings": [],
-                               "class_assessments": []})
+            text = handlers.rc.LANE_MARKER + "\n" + json.dumps({
+                "lane": lane, "coverage": coverage, "findings": [],
+                "class_assessments": [],
+            })
         else:
-            text = json.dumps({"role": "census", "source_dispositions": [],
-                               "assessment_dispositions": [], "findings": [], "debt": [],
-                               "debt_updates": [], "class_records": []})
+            text = handlers.rc.SETTLEMENT_MARKER + "\n" + json.dumps({
+                "role": "census", "source_dispositions": [],
+                "assessment_dispositions": [], "findings": [], "debt": [],
+                "debt_updates": [], "class_records": [],
+            })
         return Review(text=text, session_ref="structural", raw=text)
 
     monkeypatch.setattr(handlers, "_verify_plan_claims", deadline_debt)
@@ -1496,7 +1500,6 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
     monkeypatch.setattr(
         handlers.eng.CodexEngine, "run", structural_review,
     )
-
     result = handlers.critique_plan(
         {
             "plan_text": PLAN, "repo_path": str(repo), "lineage": lineage_id,

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -11,6 +11,7 @@ from paranoia_local import (
     external_sources,
     handlers,
     plan_claims as pc,
+    prompts,
 )
 from paranoia_local.engines import Review
 
@@ -1473,7 +1474,21 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
 
     def structural_review(self, *args, **kwargs):
         observed["structural_timeout"] = kwargs.get("timeout")
-        return Review(text=STRUCTURAL_CLEAR, session_ref="structural", raw="structural")
+        prompt = args[0]
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane = next(x.split()[-1] for x in prompt.splitlines() if x.startswith("ROLE: census lane"))
+            coverage = [
+                {"id": key, "status": "covered", "summary": "checked",
+                 "evidence": ["repository/README.md:1"]}
+                for key in handlers.rc.CHECKLIST
+            ]
+            text = json.dumps({"lane": lane, "coverage": coverage, "findings": [],
+                               "class_assessments": []})
+        else:
+            text = json.dumps({"role": "census", "source_dispositions": [],
+                               "assessment_dispositions": [], "findings": [], "debt": [],
+                               "debt_updates": [], "class_records": []})
+        return Review(text=text, session_ref="structural", raw=text)
 
     monkeypatch.setattr(handlers, "_verify_plan_claims", deadline_debt)
     monkeypatch.setattr(handlers.inert_git, "require_supported_version", lambda: (2, 50, 1))
@@ -1494,7 +1509,7 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
     )
 
     assert observed["deadline"] is not None
-    assert observed["structural_timeout"] == handlers.PLAN_STRUCTURAL_PHASE_TIMEOUT_SEC
+    assert observed["structural_timeout"] in {900, 600}
     assert lineage.claim_state["debt"]["reason"] == "evidence deadline exhausted"
     assert "CLAIM-AUDIT-DEBT" in result
 

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1490,7 +1490,7 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
             lane = next(x.split()[-1] for x in prompt.splitlines() if x.startswith("ROLE: census lane"))
             coverage = [
                 {"id": key, "status": "covered", "summary": "checked",
-                 "evidence": ["repository/README.md:1"]}
+                 "evidence": ["repository/README.md:1"], "finding_ids": []}
                 for key in handlers.rc.CHECKLIST
             ]
             text = handlers.rc.LANE_MARKER + "\n" + json.dumps({

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1137,8 +1137,10 @@ def test_captured_claim_retry_cannot_bypass_capture_validation(
         "evidence-binding": [binding, changed],
         "evidence-text": [attestation],
     })
+    ledger: list[dict] = []
     adapter = handlers._CapturedClaimEngine(
         engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+        attempt_ledger=ledger,
     )
     try:
         first = adapter.run("audit", tmp_path, "m", "high", True)
@@ -1146,6 +1148,10 @@ def test_captured_claim_retry_cannot_bypass_capture_validation(
         retry = adapter.resume("session", "correct", tmp_path, "m", "high", True)
         assert retry.error
         assert "binding changed immutable source metadata" in retry.text
+        assert [row["role"] for row in ledger] == [
+            "claim-discovery", "claim-binding", "claim-attestation",
+            "claim-binding-outer-retry",
+        ]
     finally:
         adapter.close()
 
@@ -1283,15 +1289,20 @@ def test_retained_inventory_is_corrected_before_capture(
         ]
 
     monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    ledger: list[dict] = []
     adapter = handlers._CapturedClaimEngine(
         engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
-        prior_state=prior, frozen_ids=frozenset(),
+        prior_state=prior, frozen_ids=frozenset(), attempt_ledger=ledger,
     )
     try:
         result = adapter.run("audit", tmp_path, "m", "high", True)
         assert not result.error
         assert capture_sizes == [2]
         assert [role for role, _ in engine.calls].count("evidence-discovery") == 2
+        assert [row["role"] for row in ledger] == [
+            "claim-discovery", "claim-discovery-retry", "claim-binding",
+            "claim-attestation",
+        ]
     finally:
         adapter.close()
 

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -116,6 +116,8 @@ class TestStagedReviewInstructions:
         ):
             assert "`plan:<line>`" in text
             assert "never by its repository path" in text
+            assert "`repository/<path>:<line>`" in text
+            assert "literal `repository/` prefix is required" in text
 
 
 class TestCompose:

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -108,6 +108,16 @@ class TestRebutInstructions:
         assert "hold" in t
 
 
+class TestStagedReviewInstructions:
+    def test_plan_anchors_have_one_unambiguous_spelling(self) -> None:
+        for text in (
+            prompts.STAGED_CENSUS_INSTRUCTIONS,
+            prompts.STAGED_FOLLOWUP_INSTRUCTIONS,
+        ):
+            assert "`plan:<line>`" in text
+            assert "never by its repository path" in text
+
+
 class TestCompose:
     def test_joins_instructions_and_body(self) -> None:
         out = prompts.compose("INSTRUCTIONS", "BODY")

--- a/tests/test_prompts.py
+++ b/tests/test_prompts.py
@@ -111,13 +111,24 @@ class TestRebutInstructions:
 class TestStagedReviewInstructions:
     def test_plan_anchors_have_one_unambiguous_spelling(self) -> None:
         for text in (
-            prompts.STAGED_CENSUS_INSTRUCTIONS,
-            prompts.STAGED_FOLLOWUP_INSTRUCTIONS,
+            prompts.staged_census_instructions("plan", "domain"),
+            prompts.staged_followup_instructions("plan"),
         ):
             assert "`plan:<line>`" in text
             assert "never by its repository path" in text
             assert "`repository/<path>:<line>`" in text
             assert "literal `repository/` prefix is required" in text
+
+
+def test_branch_staged_prompts_forbid_the_plan_alias():
+    for text in (
+        prompts.staged_census_instructions("branch", "behaviour"),
+        prompts.staged_followup_instructions("branch"),
+    ):
+        assert "there is no `plan:` evidence alias" in text
+        assert "including plans, contracts, and documentation" in text
+        assert "Cite the reviewed plan itself" not in text
+        assert "ANCHOR_POLICY" not in text
 
 
 class TestCompose:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1,0 +1,100 @@
+import json
+
+import pytest
+
+from paranoia_local import class_closure as cc, review_census as rc
+
+
+def lane(lane="domain", findings=None, assessments=None):
+    return json.dumps({
+        "lane": lane,
+        "coverage": [
+            {"id": key, "status": "covered", "summary": "checked",
+             "evidence": ["plan:1"]} for key in rc.CHECKLIST
+        ],
+        "findings": findings or [], "class_assessments": assessments or [],
+    })
+
+
+def finding(fid="domain-1", severity="MAJOR"):
+    return {"id": fid, "severity": severity, "summary": "broken",
+            "evidence": ["a.py:1"], "remedy": "fix it"}
+
+
+def settlement(**overrides):
+    value = {
+        "role": "census",
+        "source_dispositions": [{"source_id": "domain-1", "governing_id": "C1"}],
+        "assessment_dispositions": [],
+        "findings": [finding("C1")],
+        "debt": [{"id": "D1", "finding_id": "C1", "severity": "MAJOR",
+                  "summary": "broken", "evidence": ["a.py:1"], "status": "open"}],
+        "debt_updates": [], "class_records": [],
+    }
+    value.update(overrides)
+    return json.dumps(value)
+
+
+def test_lane_requires_every_checklist_item_exactly_once():
+    parsed = json.loads(lane())
+    parsed["coverage"].pop()
+    with pytest.raises(rc.CensusError, match="every checklist"):
+        rc.parse_lane(json.dumps(parsed), lane="domain")
+
+
+def test_integrity_requires_every_class_and_violated_names_a_finding():
+    text = lane("integrity", [finding("integrity-1")], [{
+        "class_id": "abc", "verdict": "violated", "evidence": ["a.py:1"],
+        "finding_id": "integrity-1",
+    }])
+    assert rc.parse_lane(text, lane="integrity", class_ids=["abc"])["lane"] == "integrity"
+    with pytest.raises(rc.CensusError, match="every active class"):
+        rc.parse_lane(lane("integrity"), lane="integrity", class_ids=["abc"])
+
+
+def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
+    with pytest.raises(rc.CensusError, match="every source_id"):
+        rc.parse_settlement(settlement(source_dispositions=[]), source_ids=["domain-1"],
+                            assessment_ids=[])
+    with pytest.raises(rc.CensusError, match="open debt"):
+        rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
+
+
+def test_correction_cannot_clear_without_updating_every_existing_debt():
+    value = json.loads(settlement())
+    value.update(role="correction", source_dispositions=[], findings=[], debt=[], debt_updates=[])
+    with pytest.raises(rc.CensusError, match="every existing debt"):
+        rc.parse_settlement(json.dumps(value), source_ids=[], assessment_ids=[],
+                            known_debt=["D1"], role="correction")
+
+
+def test_replace_carries_corrected_severity_in_one_transition():
+    register = rc.register_from_records([{
+        "op": "replace", "class_id": "old", "invariant": "better invariant",
+        "severity": "MINOR", "procedure": "check all sites",
+    }], mechanized=False)
+    lineage = cc.Lineage("x", classes={
+        "old": cc.TrackedClass("old", "old invariant", "MAJOR", 1, cc.CLOSED,
+                               procedure="old check")
+    }, next_seq=2, mode=cc.PLAN_MODE)
+    minted = cc.apply_register(lineage, register, round_no=3)
+    assert lineage.classes["old"].status == cc.SUPERSEDED
+    assert lineage.classes[minted[0]].severity == "MINOR"
+    assert lineage.classes[minted[0]].status == cc.OPEN
+
+
+def test_correction_requires_a_final_before_clearance():
+    state = rc.normalize_state({}, stakes="s", snapshot="p")
+    first = rc.parse_settlement(settlement(), source_ids=["domain-1"], assessment_ids=[])
+    state = rc.settle_state(state, first, phase="census", snapshot="p", round_no=1)
+    assert state["phase"] == "correction"
+    close = json.loads(settlement())
+    close.update(role="correction", source_dispositions=[], findings=[], debt=[],
+                 debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}])
+    state = rc.settle_state(
+        state, rc.parse_settlement(json.dumps(close), source_ids=[], assessment_ids=[],
+                                   known_debt=["D1"], role="correction"),
+        phase="correction", snapshot="p2", round_no=2,
+    )
+    assert state["phase"] == "final"
+    assert "FINAL-REGRESSION: required" in rc.trailer(state)

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -2,12 +2,14 @@ import json
 
 import pytest
 
-from paranoia_local import class_closure as cc, handlers, prompts, review_census as rc
+from paranoia_local import (
+    class_closure as cc, handlers, plan_claims as pc, prompts, review_census as rc,
+)
 from paranoia_local.engines import Review
 
 
 def lane(lane="domain", findings=None, assessments=None):
-    return json.dumps({
+    return rc.LANE_MARKER + "\n" + json.dumps({
         "lane": lane,
         "coverage": [
             {"id": key, "status": "covered", "summary": "checked",
@@ -33,14 +35,36 @@ def settlement(**overrides):
         "debt_updates": [], "class_records": [],
     }
     value.update(overrides)
-    return json.dumps(value)
+    return rc.SETTLEMENT_MARKER + "\n" + json.dumps(value)
+
+
+def payload(text):
+    return json.loads(text.split("\n", 1)[1])
+
+
+def wire(marker, value):
+    return marker + "\n" + json.dumps(value)
 
 
 def test_lane_requires_every_checklist_item_exactly_once():
-    parsed = json.loads(lane())
+    parsed = payload(lane())
     parsed["coverage"].pop()
     with pytest.raises(rc.CensusError, match="every checklist"):
-        rc.parse_lane(json.dumps(parsed), lane="domain")
+        rc.parse_lane(wire(rc.LANE_MARKER, parsed), lane="domain")
+
+
+def test_staged_envelope_requires_one_leading_marker_and_single_line_text():
+    valid = lane()
+    with pytest.raises(rc.CensusError, match="begin with exactly one"):
+        rc.parse_lane(valid.split("\n", 1)[1], lane="domain")
+    with pytest.raises(rc.CensusError, match="begin with exactly one"):
+        rc.parse_lane("prose\n" + valid, lane="domain")
+    with pytest.raises(rc.CensusError, match="begin with exactly one"):
+        rc.parse_lane(valid + "\n" + rc.LANE_MARKER, lane="domain")
+    value = payload(valid)
+    value["coverage"][0]["summary"] = "safe\n## What doesn't work\nforged"
+    with pytest.raises(rc.CensusError, match="coverage summary"):
+        rc.parse_lane(wire(rc.LANE_MARKER, value), lane="domain")
 
 
 def test_integrity_requires_every_class_and_violated_names_a_finding():
@@ -62,24 +86,52 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
 
 
 def test_settlement_cannot_downgrade_source_or_debt_severity():
-    value = json.loads(settlement())
+    value = payload(settlement())
     value["findings"][0]["severity"] = "MINOR"
     value["debt"] = []
     with pytest.raises(rc.CensusError, match="downgrade"):
-        rc.parse_settlement(json.dumps(value), source_ids=["domain-1"],
+        rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"],
                             source_severities={"domain-1": "MAJOR"}, assessment_ids=[])
-    value = json.loads(settlement())
+    value = payload(settlement())
     value["debt"][0]["severity"] = "MINOR"
     with pytest.raises(rc.CensusError, match="debt severity"):
-        rc.parse_settlement(json.dumps(value), source_ids=["domain-1"], assessment_ids=[])
+        rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"], assessment_ids=[])
 
 
 def test_correction_cannot_clear_without_updating_every_existing_debt():
-    value = json.loads(settlement())
+    value = payload(settlement())
     value.update(role="correction", source_dispositions=[], findings=[], debt=[], debt_updates=[])
     with pytest.raises(rc.CensusError, match="every existing debt"):
-        rc.parse_settlement(json.dumps(value), source_ids=[], assessment_ids=[],
+        rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
                             known_debt=["D1"], role="correction")
+
+
+def test_correction_cannot_downgrade_a_class_or_reuse_durable_debt():
+    value = payload(settlement())
+    value.update(
+        role="correction", source_dispositions=[], assessment_dispositions=[],
+        findings=[], debt=[],
+        debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}],
+        class_records=[{"op":"reclassify","class_id":"abc","severity":"MINOR"}],
+    )
+    with pytest.raises(rc.CensusError, match="cannot downgrade"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+            class_states={"abc": (cc.OPEN, False, "MAJOR")},
+            class_mechanized=False, known_debt=["D1"], role="correction",
+        )
+
+    first = rc.parse_settlement(settlement(), source_ids=["domain-1"], assessment_ids=[])
+    state = rc.settle_state(
+        rc.normalize_state({}, stakes="s", snapshot="p"), first,
+        phase="census", snapshot="p", round_no=1,
+    )
+    duplicate = payload(settlement())
+    duplicate.update(source_dispositions=[], findings=[finding("C2")])
+    duplicate["debt"][0].update(finding_id="C2")
+    with pytest.raises(rc.CensusError, match="reuses durable id"):
+        rc.settle_state(state, duplicate, phase="correction", snapshot="p2", round_no=2)
+    assert state["debt"][0]["source_ids"] == ["domain-1"]
 
 
 def test_replace_carries_corrected_severity_in_one_transition():
@@ -102,11 +154,11 @@ def test_correction_requires_a_final_before_clearance():
     first = rc.parse_settlement(settlement(), source_ids=["domain-1"], assessment_ids=[])
     state = rc.settle_state(state, first, phase="census", snapshot="p", round_no=1)
     assert state["phase"] == "correction"
-    close = json.loads(settlement())
+    close = payload(settlement())
     close.update(role="correction", source_dispositions=[], findings=[], debt=[],
                  debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}])
     state = rc.settle_state(
-        state, rc.parse_settlement(json.dumps(close), source_ids=[], assessment_ids=[],
+        state, rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, close), source_ids=[], assessment_ids=[],
                                    known_debt=["D1"], role="correction"),
         phase="correction", snapshot="p2", round_no=2,
     )
@@ -115,12 +167,12 @@ def test_correction_requires_a_final_before_clearance():
 
 
 def test_final_requires_complete_checklist_and_class_verdict():
-    value = json.loads(settlement())
+    value = payload(settlement())
     value.update(role="final", source_dispositions=[], findings=[], debt=[], debt_updates=[],
                  assessment_dispositions=[{"assessment_id":"abc","governing_id":None}],
                  class_assessments=[], coverage=[])
     with pytest.raises(rc.CensusError, match="every checklist"):
-        rc.parse_settlement(json.dumps(value), source_ids=[], assessment_ids=["abc"], role="final")
+        rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"], role="final")
 
 
 def test_evidence_anchors_resolve_against_snapshot(tmp_path):
@@ -135,7 +187,7 @@ def test_evidence_anchors_resolve_against_snapshot(tmp_path):
 
 
 def test_violated_class_cannot_be_replaced_at_lower_severity():
-    value = json.loads(settlement())
+    value = payload(settlement())
     value.update(
         source_dispositions=[], findings=[], debt=[],
         assessment_dispositions=[{"assessment_id":"abc","governing_id":"C1"}],
@@ -151,7 +203,7 @@ def test_violated_class_cannot_be_replaced_at_lower_severity():
     }]
     with pytest.raises(rc.CensusError, match="cannot be downgraded"):
         rc.parse_settlement(
-            json.dumps(value), source_ids=[], assessment_ids=["abc"],
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
             assessment_verdicts={"abc":"violated"},
             class_states={"abc": (cc.CLOSED, False, "MAJOR")},
         )
@@ -170,6 +222,54 @@ def test_class_records_require_the_exact_mode_specific_shape():
         }], mechanized=True)
 
 
+def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path):
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            value = payload(lane())
+            value["coverage"][0]["evidence"] = ["missing.py:1"]
+            text = wire(rc.LANE_MARKER, value)
+            return Review(text=text, session_ref="session", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert session_ref == "session"
+            assert "unresolvable repository anchor" in prompt
+            (tmp_path / "ok.py").write_text("ok\n")
+            value = payload(lane())
+            for row in value["coverage"]:
+                row["evidence"] = ["ok.py:1"]
+            text = wire(rc.LANE_MARKER, value)
+            return Review(text=text, session_ref="session", raw=text)
+
+    def parse(text):
+        value = rc.parse_lane(text, lane="domain")
+        rc.resolve_anchors(value, root=tmp_path)
+        return value
+
+    _, _, attempts = handlers._staged_call(
+        role="census-domain", engine=Engine(), prompt="review", cwd=tmp_path,
+        model="m", effort="high", timeout=10, parser=parse, on_progress=None,
+    )
+    assert [attempt.outcome for attempt in attempts] == ["format-invalid", "completed"]
+    assert all(attempt.response_sha256 and attempt.response_excerpt for attempt in attempts)
+
+
+def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_path):
+    closure = handlers._PlanClassClosure(
+        "pending-plan", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    review, trailer, attempts = handlers._structural_pending_review(
+        closure, mode=cc.PLAN_MODE, claim_state=pc.empty_state(),
+        reason="not enough bounded time",
+    )
+    closure.release()
+    assert review.error and attempts == []
+    assert "STRUCTURAL-PENDING" in trailer and "CONVERGENCE: BLOCKED" in trailer
+    assert not (cc.lineage_dir(tmp_path) / "pending-plan.pending").exists()
+
+
 def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, monkeypatch):
     calls = []
 
@@ -182,7 +282,7 @@ def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, m
             )
             text = lane(lane_name)
         else:
-            text = json.dumps({
+            text = rc.SETTLEMENT_MARKER + "\n" + json.dumps({
                 "role":"census", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
                 "debt_updates":[], "class_records":[],
@@ -197,3 +297,157 @@ def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, m
     assert len(calls) == 4
     assert "## What works" in out
     assert "STRUCTURAL-PHASE: clear" in out
+    (repo / "app.py").write_text("changed = True\n")
+    out = handlers.critique_plan({
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo), "lineage":"structural-only",
+        "round":2, "claim_verification":False, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs")
+    assert len(calls) == 8
+    assert "STRUCTURAL-PHASE: clear" in out
+
+
+def test_unknown_legacy_calibration_resets_claims_and_reopens_classes(
+    repo, tmp_path, monkeypatch,
+):
+    claim_state = pc.empty_state()
+    claim_state["claims"] = {"C1": {"scope":"external"}}
+    lineage = cc.Lineage(
+        "legacy-calibration", rounds=2, mode=cc.PLAN_MODE,
+        claim_state=claim_state, review_state={},
+        classes={
+            "old": cc.TrackedClass(
+                "old", "inspect the invariant", "MAJOR", 1, cc.CLOSED,
+                procedure="inspect it",
+            ),
+        },
+    )
+    cc.save_lineage(cc.default_state_root(), lineage)
+    observed = {}
+
+    def staged(**kwargs):
+        closure = kwargs["closure"]
+        observed["claims"] = closure.lineage.claim_state["claims"]
+        observed["status"] = closure.lineage.classes["old"].status
+        closure._settled = True
+        review = Review(text="ok", session_ref="s", raw="ok")
+        return review, "CONVERGENCE: BLOCKED — test", []
+
+    monkeypatch.setattr(handlers, "_staged_structural_review", staged)
+    handlers.critique_plan({
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo),
+        "lineage":"legacy-calibration", "round":3,
+        "claim_verification":False, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs")
+    assert observed == {"claims": {}, "status": cc.OPEN}
+
+
+def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monkeypatch):
+    calls = []
+
+    def run(self, prompt, *args, **kwargs):
+        calls.append(prompt)
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            findings = ([{
+                "id":"F1", "severity":"MAJOR", "summary":"repair the plan",
+                "evidence":["plan:1"], "remedy":"edit the plan",
+            }] if lane_name == "domain" else [])
+            text = lane(lane_name, findings=findings)
+        elif prompts.STAGED_CONSOLIDATION_INSTRUCTIONS.splitlines()[0] in prompt:
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"census",
+                "source_dispositions":[{"source_id":"domain:F1","governing_id":"G1"}],
+                "assessment_dispositions":[],
+                "findings":[{
+                    "id":"G1", "severity":"MAJOR", "summary":"repair the plan",
+                    "evidence":["plan:1"], "remedy":"edit the plan",
+                }],
+                "debt":[{
+                    "id":"D1", "finding_id":"G1", "severity":"MAJOR",
+                    "summary":"repair the plan", "evidence":["plan:1"], "status":"open",
+                }],
+                "debt_updates":[], "class_records":[],
+            })
+        elif '"role": "correction"' in prompt:
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"correction", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                "class_records":[],
+            })
+        else:
+            assert '"role": "final"' in prompt
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"final", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[], "class_records":[],
+                "coverage": payload(lane())["coverage"], "class_assessments":[],
+            })
+        return Review(text=text, session_ref=f"s{len(calls)}", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    args = {
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo),
+        "lineage":"three-phase-plan", "claim_verification":False,
+        "stakes":"trusted local tool",
+    }
+    first = handlers.critique_plan(
+        {**args, "round":1}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda: "T1",
+    )
+    second = handlers.critique_plan(
+        {**args, "round":2}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda: "T2",
+    )
+    third = handlers.critique_plan(
+        {**args, "round":3}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda: "T3",
+    )
+
+    assert "STRUCTURAL-PHASE: correction" in first
+    assert "STRUCTURAL-PHASE: final" in second
+    assert "STRUCTURAL-PHASE: clear" in third
+    assert "CONVERGENCE: NOT-BLOCKED" in third
+    assert len(calls) == 6
+    assert third.count("## What works") == 1
+    audit = json.loads(next((tmp_path / "logs").glob("T1-critique_plan-*.json")).read_text())
+    assert len(audit["staged_manifests"]) == 3
+    assert [row["role"] for row in audit["attempt_ledger"]] == [
+        "census-domain", "census-execution", "census-integrity", "consolidation",
+    ]
+
+
+def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_path, monkeypatch):
+    calls = []
+
+    def run(self, prompt, *args, **kwargs):
+        calls.append(prompt)
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            value = payload(lane(lane_name))
+            for row in value["coverage"]:
+                row["evidence"] = ["README.md:1"]
+            text = wire(rc.LANE_MARKER, value)
+        else:
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"census", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[], "class_records":[],
+            })
+        return Review(text=text, session_ref=f"b{len(calls)}", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    result = handlers.critique_branch({
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"four-call-branch", "round":1, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B1")
+    assert len(calls) == 4
+    assert "STRUCTURAL-PHASE: clear" in result
+    audit = json.loads(next((tmp_path / "logs").glob("B1-critique_branch-*.json")).read_text())
+    assert len(audit["staged_manifests"]) == 3

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -230,6 +230,10 @@ def test_final_requires_complete_checklist_and_class_verdict():
 def test_evidence_anchors_resolve_against_snapshot(tmp_path):
     (tmp_path / "a.py").write_text("one\ntwo\n")
     rc.resolve_anchors({"evidence":["a.py:2"]}, root=tmp_path)
+    rc.resolve_anchors(
+        {"evidence":["repository/a.py:2"]}, root=tmp_path,
+        trusted_roots={"repository":tmp_path},
+    )
     with pytest.raises(rc.CensusError, match="out-of-range"):
         rc.resolve_anchors({"evidence":["a.py:3"]}, root=tmp_path)
     with pytest.raises(rc.CensusError, match="unresolvable plan"):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -2,7 +2,8 @@ import json
 
 import pytest
 
-from paranoia_local import class_closure as cc, review_census as rc
+from paranoia_local import class_closure as cc, handlers, prompts, review_census as rc
+from paranoia_local.engines import Review
 
 
 def lane(lane="domain", findings=None, assessments=None):
@@ -60,6 +61,19 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
         rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
 
 
+def test_settlement_cannot_downgrade_source_or_debt_severity():
+    value = json.loads(settlement())
+    value["findings"][0]["severity"] = "MINOR"
+    value["debt"] = []
+    with pytest.raises(rc.CensusError, match="downgrade"):
+        rc.parse_settlement(json.dumps(value), source_ids=["domain-1"],
+                            source_severities={"domain-1": "MAJOR"}, assessment_ids=[])
+    value = json.loads(settlement())
+    value["debt"][0]["severity"] = "MINOR"
+    with pytest.raises(rc.CensusError, match="debt severity"):
+        rc.parse_settlement(json.dumps(value), source_ids=["domain-1"], assessment_ids=[])
+
+
 def test_correction_cannot_clear_without_updating_every_existing_debt():
     value = json.loads(settlement())
     value.update(role="correction", source_dispositions=[], findings=[], debt=[], debt_updates=[])
@@ -98,3 +112,88 @@ def test_correction_requires_a_final_before_clearance():
     )
     assert state["phase"] == "final"
     assert "FINAL-REGRESSION: required" in rc.trailer(state)
+
+
+def test_final_requires_complete_checklist_and_class_verdict():
+    value = json.loads(settlement())
+    value.update(role="final", source_dispositions=[], findings=[], debt=[], debt_updates=[],
+                 assessment_dispositions=[{"assessment_id":"abc","governing_id":None}],
+                 class_assessments=[], coverage=[])
+    with pytest.raises(rc.CensusError, match="every checklist"):
+        rc.parse_settlement(json.dumps(value), source_ids=[], assessment_ids=["abc"], role="final")
+
+
+def test_evidence_anchors_resolve_against_snapshot(tmp_path):
+    (tmp_path / "a.py").write_text("one\ntwo\n")
+    rc.resolve_anchors({"evidence":["a.py:2"]}, root=tmp_path)
+    with pytest.raises(rc.CensusError, match="out-of-range"):
+        rc.resolve_anchors({"evidence":["a.py:3"]}, root=tmp_path)
+    with pytest.raises(rc.CensusError, match="unresolvable plan"):
+        rc.resolve_anchors({"evidence":["plan:3"]}, root=tmp_path, plan_lines=2)
+    with pytest.raises(rc.CensusError, match="unresolvable repository"):
+        rc.resolve_anchors({"evidence":["../outside.py:1"]}, root=tmp_path)
+
+
+def test_violated_class_cannot_be_replaced_at_lower_severity():
+    value = json.loads(settlement())
+    value.update(
+        source_dispositions=[], findings=[], debt=[],
+        assessment_dispositions=[{"assessment_id":"abc","governing_id":"C1"}],
+        class_records=[{
+            "op":"replace", "class_id":"abc", "invariant":"narrower invariant",
+            "severity":"MINOR", "procedure":"inspect it",
+        }],
+    )
+    value["findings"] = [finding("C1", "MAJOR")]
+    value["debt"] = [{
+        "id":"D1", "finding_id":"C1", "severity":"MAJOR", "summary":"broken",
+        "evidence":["a.py:1"], "status":"open",
+    }]
+    with pytest.raises(rc.CensusError, match="cannot be downgraded"):
+        rc.parse_settlement(
+            json.dumps(value), source_ids=[], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"violated"},
+            class_states={"abc": (cc.CLOSED, False, "MAJOR")},
+        )
+
+
+def test_class_records_require_the_exact_mode_specific_shape():
+    with pytest.raises(rc.CensusError, match="new class record"):
+        rc.register_from_records([{
+            "op":"new", "invariant":"x", "severity":"MAJOR", "procedure":"inspect",
+            "extra":"ignored",
+        }], mechanized=False)
+    with pytest.raises(rc.CensusError, match="pattern"):
+        rc.register_from_records([{
+            "op":"new", "invariant":"x", "severity":"MAJOR",
+            "pattern":"", "pathspec":".",
+        }], mechanized=True)
+
+
+def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, monkeypatch):
+    calls = []
+
+    def run(self, prompt, *args, **kwargs):
+        calls.append(prompt)
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            text = lane(lane_name)
+        else:
+            text = json.dumps({
+                "role":"census", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[], "class_records":[],
+            })
+        return Review(text=text, session_ref="s", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    out = handlers.critique_plan({
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo), "lineage":"structural-only",
+        "round":1, "claim_verification":False, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs")
+    assert len(calls) == 4
+    assert "## What works" in out
+    assert "STRUCTURAL-PHASE: clear" in out

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -434,6 +434,16 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
     assert all(attempt.response_sha256 and attempt.response_excerpt for attempt in attempts)
 
 
+def test_new_debt_labels_are_rekeyed_when_durable_history_owns_them():
+    debt = [
+        {"id":"D1", "finding_id":"G1", "status":"open"},
+        {"id":"local", "finding_id":"G2", "status":"open"},
+        {"id":"D3", "finding_id":"G3", "status":"open"},
+    ]
+    handlers._allocate_fresh_debt_ids(debt, {"D1", "D2", "local"})
+    assert [item["id"] for item in debt] == ["D4", "D5", "D3"]
+
+
 def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_path):
     closure = handlers._PlanClassClosure(
         "pending-plan", round_no=1, state_root=tmp_path, stamp="T",

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -108,6 +108,18 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
         rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
 
 
+def test_settlement_accepts_only_the_observed_decorative_marker_variant():
+    short = rc.SETTLEMENT_MARKER.removesuffix(" ===")
+    text = settlement().replace(rc.SETTLEMENT_MARKER, short, 1)
+    assert rc.parse_settlement(
+        text, source_ids=["domain-1"], assessment_ids=[],
+    )["role"] == "census"
+    with pytest.raises(rc.CensusError, match="begin with exactly one"):
+        rc.parse_settlement(
+            "prose\n" + text, source_ids=["domain-1"], assessment_ids=[],
+        )
+
+
 def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
     value = payload(settlement())
     value["findings"][0]["severity"] = "MINOR"

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -9,13 +9,19 @@ from paranoia_local.engines import Review
 
 
 def lane(lane="domain", findings=None, assessments=None):
+    findings = findings or []
+    coverage = [
+        {"id": key, "status": "covered", "summary": "checked",
+         "evidence": ["plan:1"], "finding_ids": []} for key in rc.CHECKLIST
+    ]
+    if findings:
+        coverage[0].update(
+            status="finding", finding_ids=[item["id"] for item in findings],
+        )
     return rc.LANE_MARKER + "\n" + json.dumps({
         "lane": lane,
-        "coverage": [
-            {"id": key, "status": "covered", "summary": "checked",
-             "evidence": ["plan:1"]} for key in rc.CHECKLIST
-        ],
-        "findings": findings or [], "class_assessments": assessments or [],
+        "coverage": coverage,
+        "findings": findings, "class_assessments": assessments or [],
     })
 
 
@@ -50,6 +56,15 @@ def test_lane_requires_every_checklist_item_exactly_once():
     parsed["coverage"].pop()
     with pytest.raises(rc.CensusError, match="every checklist"):
         rc.parse_lane(wire(rc.LANE_MARKER, parsed), lane="domain")
+
+
+def test_lane_binds_every_finding_to_checklist_coverage():
+    value = payload(lane(findings=[finding()]))
+    value["coverage"][0].update(status="covered", finding_ids=[])
+    with pytest.raises(rc.CensusError, match="bound to checklist"):
+        rc.parse_lane(wire(rc.LANE_MARKER, value), lane="domain")
+    value["coverage"][0].update(status="finding", finding_ids=["domain-1"])
+    assert rc.parse_lane(wire(rc.LANE_MARKER, value), lane="domain")["findings"][0]["id"] == "domain-1"
 
 
 def test_staged_envelope_requires_one_leading_marker_and_single_line_text():
@@ -196,6 +211,11 @@ def test_evidence_anchors_resolve_against_snapshot(tmp_path):
         rc.resolve_anchors({"evidence":["plan:3"]}, root=tmp_path, plan_lines=2)
     with pytest.raises(rc.CensusError, match="unresolvable repository"):
         rc.resolve_anchors({"evidence":["../outside.py:1"]}, root=tmp_path)
+    outside = tmp_path.parent / "outside-anchor.py"
+    outside.write_text("outside\n")
+    (tmp_path / "linked.py").symlink_to(outside)
+    with pytest.raises(rc.CensusError, match="unresolvable repository"):
+        rc.resolve_anchors({"evidence":["linked.py:1"]}, root=tmp_path)
 
 
 def test_violated_class_cannot_be_replaced_at_lower_severity():
@@ -421,6 +441,7 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert "STRUCTURAL-PHASE: clear" in third
     assert "CONVERGENCE: NOT-BLOCKED" in third
     assert len(calls) == 6
+    assert '"existing_debt": []' in calls[5]
     assert third.count("## What works") == 1
     audit = json.loads(next((tmp_path / "logs").glob("T1-critique_plan-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
@@ -442,6 +463,18 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
 
 def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_path, monkeypatch):
     calls = []
+    cc.save_lineage(
+        cc.default_state_root(),
+        cc.Lineage(
+            "four-call-branch", mode=cc.BRANCH_MODE, next_seq=2,
+            classes={
+                "abc": cc.TrackedClass(
+                    "abc", "needle must remain absent", "MAJOR", 1, cc.CLOSED,
+                    pattern="needle", pathspec="README.md",
+                ),
+            },
+        ),
+    )
 
     def run(self, prompt, *args, **kwargs):
         calls.append(prompt)
@@ -450,14 +483,19 @@ def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_pat
                 row.split()[-1] for row in prompt.splitlines()
                 if row.startswith("ROLE: census lane")
             )
-            value = payload(lane(lane_name))
+            assessments = ([{
+                "class_id":"abc", "verdict":"satisfied",
+                "evidence":["README.md:1"], "finding_id":None,
+            }] if lane_name == "integrity" else [])
+            value = payload(lane(lane_name, assessments=assessments))
             for row in value["coverage"]:
                 row["evidence"] = ["README.md:1"]
             text = wire(rc.LANE_MARKER, value)
         else:
             text = wire(rc.SETTLEMENT_MARKER, {
                 "role":"census", "source_dispositions":[],
-                "assessment_dispositions":[], "findings":[], "debt":[],
+                "assessment_dispositions":[{"assessment_id":"abc","governing_id":None}],
+                "findings":[], "debt":[],
                 "debt_updates":[], "class_records":[],
             })
         return Review(text=text, session_ref=f"b{len(calls)}", raw=text)
@@ -468,6 +506,12 @@ def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_pat
         "lineage":"four-call-branch", "round":1, "stakes":"trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B1")
     assert len(calls) == 4
+    integrity_prompt = next(
+        prompt for prompt in calls if "ROLE: census lane integrity" in prompt
+    )
+    assert '"invariant": "needle must remain absent"' in integrity_prompt
+    assert '"pattern": "needle"' in integrity_prompt
+    assert '"pathspec": "README.md"' in integrity_prompt
     assert "STRUCTURAL-PHASE: clear" in result
     audit = json.loads(next((tmp_path / "logs").glob("B1-critique_branch-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -260,6 +260,9 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
         role="census-domain", engine=Engine(), prompt="review", cwd=tmp_path,
         model="m", effort="high", timeout=10, parser=parse, on_progress=None,
     )
+    assert [attempt.role for attempt in attempts] == [
+        "census-domain", "census-domain-format-retry",
+    ]
     assert [attempt.outcome for attempt in attempts] == ["format-invalid", "completed"]
     assert all(attempt.response_sha256 and attempt.response_excerpt for attempt in attempts)
 
@@ -431,6 +434,10 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
         cc.default_state_root(), "three-phase-plan", stamp="T4", mode=cc.PLAN_MODE,
     )
     assert lineage.review_state["debt"][0]["source_ids"] == ["domain:F1"]
+    second_audit = json.loads(next((tmp_path / "logs").glob("T2-critique_plan-*.json")).read_text())
+    third_audit = json.loads(next((tmp_path / "logs").glob("T3-critique_plan-*.json")).read_text())
+    assert [row["role"] for row in second_audit["attempt_ledger"]] == ["correction"]
+    assert [row["role"] for row in third_audit["attempt_ledger"]] == ["final"]
 
 
 def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_path, monkeypatch):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -814,196 +814,28 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert [row["role"] for row in third_audit["attempt_ledger"]] == ["final"]
 
 
-def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_path, monkeypatch):
+def test_branch_codex_keeps_the_single_broad_review_path(
+    repo_with_branch, tmp_path, monkeypatch,
+):
     calls = []
-    cc.save_lineage(
-        cc.default_state_root(),
-        cc.Lineage(
-            "four-call-branch", mode=cc.BRANCH_MODE, next_seq=2,
-            classes={
-                "abc": cc.TrackedClass(
-                    "abc", "needle must remain absent", "MAJOR", 1, cc.CLOSED,
-                    pattern="needle", pathspec="README.md",
-                ),
-            },
-        ),
-    )
 
     def run(self, prompt, *args, **kwargs):
         calls.append(prompt)
-        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
-            lane_name = next(
-                row.split()[-1] for row in prompt.splitlines()
-                if row.startswith("ROLE: census lane")
-            )
-            assessments = ([{
-                "class_id":"abc", "verdict":"satisfied",
-                "evidence":["README.md:1"], "finding_id":None,
-            }] if lane_name == "integrity" else [])
-            value = payload(lane(lane_name, assessments=assessments))
-            for row in value["coverage"]:
-                row["evidence"] = ["README.md:1"]
-            text = wire(rc.LANE_MARKER, value)
-        else:
-            text = wire(rc.SETTLEMENT_MARKER, {
-                "role":"census", "source_dispositions":[],
-                "assessment_dispositions":[{"assessment_id":"abc","governing_id":None}],
-                "findings":[], "debt":[],
-                "debt_updates":[], "class_records":[],
-            })
-        return Review(text=text, session_ref=f"b{len(calls)}", raw=text)
+        text = "## What works\nNothing notable.\n\n=== CLASS REGISTER ===\nNONE"
+        return Review(text=text, session_ref="branch-session", raw=text)
 
     monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
     result = handlers.critique_branch({
-        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
-        "lineage":"four-call-branch", "round":1, "stakes":"trusted local tool",
+        "repo_path": str(repo_with_branch),
+        "base_ref": "main",
+        "head_ref": "feature",
+        "lineage": "single-broad-branch",
+        "round": 1,
+        "stakes": "trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B1")
-    assert len(calls) == 4
-    integrity_prompt = next(
-        prompt for prompt in calls if "ROLE: census lane integrity" in prompt
-    )
-    assert '"invariant": "needle must remain absent"' in integrity_prompt
-    assert '"pattern": "needle"' in integrity_prompt
-    assert '"pathspec": "README.md"' in integrity_prompt
-    assert "STRUCTURAL-PHASE: clear" in result
+
+    assert len(calls) == 1
+    assert prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] not in calls[0]
+    assert "CLASS-CLOSURE: 0 open, 0 closed" in result
     audit = json.loads(next((tmp_path / "logs").glob("B1-critique_branch-*.json")).read_text())
-    assert len(audit["staged_manifests"]) == 3
-
-
-def test_failed_consolidation_audit_retains_lane_and_retry_attempts(
-    repo_with_branch, tmp_path, monkeypatch,
-):
-    calls = []
-
-    def run(self, prompt, *args, **kwargs):
-        calls.append(("run", prompt))
-        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
-            lane_name = next(
-                row.split()[-1] for row in prompt.splitlines()
-                if row.startswith("ROLE: census lane")
-            )
-            value = payload(lane(lane_name))
-            for row in value["coverage"]:
-                row["evidence"] = ["README.md:1"]
-            text = wire(rc.LANE_MARKER, value)
-            return Review(text=text, session_ref=lane_name, raw=text)
-        return Review(text="malformed", session_ref="consolidation", raw="malformed")
-
-    def resume(self, session_ref, prompt, *args, **kwargs):
-        calls.append(("resume", prompt))
-        assert session_ref == "consolidation"
-        return Review(text="still malformed", session_ref=session_ref, raw="still malformed")
-
-    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
-    monkeypatch.setattr(handlers.eng.CodexEngine, "resume", resume)
-    result = handlers.critique_branch({
-        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
-        "lineage":"failed-consolidation", "round":1, "stakes":"trusted local tool",
-    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "BF")
-    assert "CONVERGENCE: BLOCKED" in result
-    assert_five_headings(result)
-    assert len(calls) == 5
-    audit = json.loads(next((tmp_path / "logs").glob("BF-critique_branch-*.json")).read_text())
-    assert len(audit["staged_manifests"]) == 3
-    rows = audit["attempt_ledger"]
-    invoked_lanes = [
-        next(
-            line.split()[-1] for line in prompt.splitlines()
-            if line.startswith("ROLE: census lane")
-        )
-        for kind, prompt in calls[:3] if kind == "run"
-    ]
-    assert [row["role"] for row in rows[:3]] == [
-        f"census-{lane_name}" for lane_name in invoked_lanes
-    ]
-    assert {row["role"] for row in rows[:3]} == {
-        "census-behaviour", "census-execution", "census-integrity",
-    }
-    assert [row["role"] for row in rows[3:]] == [
-        "consolidation", "consolidation-format-retry",
-    ]
-    assert [row["outcome"] for row in rows] == [
-        "completed", "completed", "completed", "format-invalid", "format-invalid",
-    ]
-    assert [row["sequence"] for row in rows] == [1, 2, 3, 4, 5]
-
-
-def test_branch_handler_runs_census_correction_and_cold_final(
-    repo_with_branch, tmp_path, monkeypatch,
-):
-    calls = []
-
-    def run(self, prompt, *args, **kwargs):
-        calls.append(prompt)
-        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
-            lane_name = next(
-                row.split()[-1] for row in prompt.splitlines()
-                if row.startswith("ROLE: census lane")
-            )
-            findings = ([finding("F1", "MAJOR")] if lane_name == "behaviour" else [])
-            value = payload(lane(lane_name, findings=findings))
-            for row in value["coverage"]:
-                row["evidence"] = ["README.md:1"]
-            for item in value["findings"]:
-                item["evidence"] = ["README.md:1"]
-            text = wire(rc.LANE_MARKER, value)
-        elif prompts.STAGED_CONSOLIDATION_INSTRUCTIONS.splitlines()[0] in prompt:
-            text = wire(rc.SETTLEMENT_MARKER, {
-                "role":"census",
-                "source_dispositions":[{"source_id":"behaviour:F1","governing_id":"G1"}],
-                "assessment_dispositions":[],
-                "findings":[{
-                    "id":"G1", "severity":"MAJOR", "summary":"repair it",
-                    "evidence":["README.md:1"], "remedy":"edit it",
-                }],
-                "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
-                "debt_updates":[], "class_records":[],
-            })
-        elif '"role": "correction"' in prompt:
-            text = wire(rc.SETTLEMENT_MARKER, {
-                "role":"correction", "source_dispositions":[],
-                "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[{"id":"D1","status":"closed","evidence":["README.md:1"]}],
-                "class_records":[],
-            })
-        else:
-            assert '"role": "final"' in prompt
-            coverage = payload(lane())["coverage"]
-            for row in coverage:
-                row["evidence"] = ["README.md:1"]
-            text = wire(rc.SETTLEMENT_MARKER, {
-                "role":"final", "source_dispositions":[],
-                "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[], "class_records":[],
-                "coverage":coverage, "class_assessments":[],
-            })
-        return Review(text=text, session_ref=f"branch-{len(calls)}", raw=text)
-
-    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
-    args = {
-        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
-        "lineage":"three-phase-branch", "stakes":"trusted local tool",
-    }
-    first = handlers.critique_branch(
-        {**args, "round":1}, engine=handlers.eng.CodexEngine(),
-        log_dir=tmp_path / "logs", now=lambda:"BC1",
-    )
-    second = handlers.critique_branch(
-        {**args, "round":2}, engine=handlers.eng.CodexEngine(),
-        log_dir=tmp_path / "logs", now=lambda:"BC2",
-    )
-    third = handlers.critique_branch(
-        {**args, "round":3}, engine=handlers.eng.CodexEngine(),
-        log_dir=tmp_path / "logs", now=lambda:"BC3",
-    )
-    assert "STRUCTURAL-PHASE: correction" in first
-    assert "STRUCTURAL-PHASE: final" in second
-    assert "STRUCTURAL-PHASE: clear" in third
-    assert "CONVERGENCE: NOT-BLOCKED" in third
-    assert len(calls) == 6
-    assert [row["role"] for row in json.loads(
-        next((tmp_path / "logs").glob("BC2-critique_branch-*.json")).read_text()
-    )["attempt_ledger"]] == ["correction"]
-    assert [row["role"] for row in json.loads(
-        next((tmp_path / "logs").glob("BC3-critique_branch-*.json")).read_text()
-    )["attempt_ledger"]] == ["final"]
+    assert audit["staged_manifests"] is None

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -471,3 +471,46 @@ def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_pat
     assert "STRUCTURAL-PHASE: clear" in result
     audit = json.loads(next((tmp_path / "logs").glob("B1-critique_branch-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
+
+
+def test_failed_consolidation_audit_retains_lane_and_retry_attempts(
+    repo_with_branch, tmp_path, monkeypatch,
+):
+    calls = []
+
+    def run(self, prompt, *args, **kwargs):
+        calls.append(("run", prompt))
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            value = payload(lane(lane_name))
+            for row in value["coverage"]:
+                row["evidence"] = ["README.md:1"]
+            text = wire(rc.LANE_MARKER, value)
+            return Review(text=text, session_ref=lane_name, raw=text)
+        return Review(text="malformed", session_ref="consolidation", raw="malformed")
+
+    def resume(self, session_ref, prompt, *args, **kwargs):
+        calls.append(("resume", prompt))
+        assert session_ref == "consolidation"
+        return Review(text="still malformed", session_ref=session_ref, raw="still malformed")
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    monkeypatch.setattr(handlers.eng.CodexEngine, "resume", resume)
+    result = handlers.critique_branch({
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"failed-consolidation", "round":1, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "BF")
+    assert "CONVERGENCE: BLOCKED" in result
+    assert len(calls) == 5
+    audit = json.loads(next((tmp_path / "logs").glob("BF-critique_branch-*.json")).read_text())
+    assert len(audit["staged_manifests"]) == 3
+    assert [row["role"] for row in audit["attempt_ledger"]] == [
+        "census-behaviour", "census-execution", "census-integrity",
+        "consolidation", "consolidation-format-retry",
+    ]
+    assert [row["outcome"] for row in audit["attempt_ledger"]] == [
+        "completed", "completed", "completed", "format-invalid", "format-invalid",
+    ]

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -8,6 +8,15 @@ from paranoia_local import (
 from paranoia_local.engines import Review
 
 
+HEADINGS = (
+    "## What works", "## What doesn't work", "## Risks", "## Gaps", "## Improvements",
+)
+
+
+def assert_five_headings(text):
+    assert [line for line in text.splitlines() if line.startswith("## ")] == list(HEADINGS)
+
+
 def lane(lane="domain", findings=None, assessments=None):
     findings = findings or []
     coverage = [
@@ -161,6 +170,22 @@ def test_correction_cannot_downgrade_a_class_or_reuse_durable_debt():
     assert state["debt"][0]["source_ids"] == ["domain-1"]
 
 
+def test_every_staged_role_rejects_a_satisfied_class_downgrade():
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[], findings=[], debt=[],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":None}],
+        class_records=[{"op":"reclassify", "class_id":"abc", "severity":"MINOR"}],
+    )
+    with pytest.raises(rc.CensusError, match="cannot downgrade"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"satisfied"},
+            assessment_findings={"abc":None},
+            class_states={"abc": (cc.CLOSED, False, "MAJOR")}, role="census",
+        )
+
+
 def test_replace_carries_corrected_severity_in_one_transition():
     register = rc.register_from_records([{
         "op": "replace", "class_id": "old", "invariant": "better invariant",
@@ -230,7 +255,7 @@ def test_violated_class_cannot_be_replaced_at_lower_severity():
     )
     value["findings"] = [finding("C1", "MAJOR")]
     value["debt"] = [{"id":"D1", "finding_id":"C1", "status":"open"}]
-    with pytest.raises(rc.CensusError, match="cannot be downgraded"):
+    with pytest.raises(rc.CensusError, match="downgrade"):
         rc.parse_settlement(
             wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
             assessment_verdicts={"abc":"violated"},
@@ -328,8 +353,90 @@ def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_pa
     )
     closure.release()
     assert review.error and attempts == []
+    assert_five_headings(review.text)
     assert "STRUCTURAL-PENDING" in trailer and "CONVERGENCE: BLOCKED" in trailer
     assert not (cc.lineage_dir(tmp_path) / "pending-plan.pending").exists()
+
+
+def test_state_unavailable_result_has_five_headings(tmp_path):
+    closure = handlers._PlanClassClosure(
+        "unavailable-plan", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.unavailable = "cannot read state"
+    review, trailer, attempts = handlers._state_unavailable_review(
+        closure, mode=cc.PLAN_MODE, claim_state=pc.empty_state(),
+    )
+    assert review.error and attempts == [] and "STATE-UNAVAILABLE" in trailer
+    assert_five_headings(review.text)
+
+
+def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
+    tmp_path, monkeypatch,
+):
+    state = rc.normalize_state({}, stakes="s", snapshot="p")
+    state.update(phase="correction", debt=[{
+        "id":"D1", "finding_id":"G1", "status":"open", "severity":"MAJOR",
+        "summary":"fix", "evidence":["plan:1"], "source_ids":[],
+        "first_round":1, "last_round":1,
+    }])
+    cc.save_lineage(
+        tmp_path,
+        cc.Lineage("save-fail", rounds=1, mode=cc.PLAN_MODE, review_state=state),
+    )
+    closure = handlers._PlanClassClosure(
+        "save-fail", round_no=2, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"correction", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                "class_records":[],
+            })
+            return Review(text=text, session_ref="s", raw=text)
+
+    monkeypatch.setattr(
+        cc, "save_lineage",
+        lambda *args, **kwargs: (_ for _ in ()).throw(cc.StateUnavailable("ambiguous write")),
+    )
+    review, trailer, attempts = handlers._staged_structural_review(
+        engine=Engine(), cwd=tmp_path, model="m", effort="high", mode=cc.PLAN_MODE,
+        body="artifact", closure=closure, stakes="s", snapshot="p", round_no=2,
+        on_progress=None, plan_lines=1,
+    )
+    closure.release()
+    assert review.error and [row["role"] for row in attempts] == ["correction"]
+    assert_five_headings(review.text)
+    assert "STATE-UNAVAILABLE" in trailer
+    assert (cc.lineage_dir(tmp_path) / "save-fail.pending").exists()
+    cc.clear_latch(tmp_path, "save-fail")
+
+
+def test_staged_format_debt_save_failure_also_retains_latch(tmp_path, monkeypatch):
+    cc.save_lineage(tmp_path, cc.Lineage("format-save-fail", mode=cc.PLAN_MODE))
+    closure = handlers._PlanClassClosure(
+        "format-save-fail", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    monkeypatch.setattr(
+        cc, "save_lineage",
+        lambda *args, **kwargs: (_ for _ in ()).throw(cc.StateUnavailable("ambiguous write")),
+    )
+    review, trailer, attempts = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=rc.CensusError("bad format"),
+        mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert review.error and attempts == []
+    assert_five_headings(review.text)
+    assert "STATE-UNAVAILABLE" in trailer
+    assert (cc.lineage_dir(tmp_path) / "format-save-fail.pending").exists()
+    cc.clear_latch(tmp_path, "format-save-fail")
 
 
 def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, monkeypatch):
@@ -472,6 +579,8 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert "CONVERGENCE: NOT-BLOCKED" in third
     assert len(calls) == 6
     assert '"existing_debt": []' in calls[5]
+    assert all(key in calls[5] for key in rc.CHECKLIST)
+    assert '"finding_ids"' in calls[5] and '"class_assessments"' in calls[5]
     assert third.count("## What works") == 1
     audit = json.loads(next((tmp_path / "logs").glob("T1-critique_plan-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
@@ -578,6 +687,7 @@ def test_failed_consolidation_audit_retains_lane_and_retry_attempts(
         "lineage":"failed-consolidation", "round":1, "stakes":"trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "BF")
     assert "CONVERGENCE: BLOCKED" in result
+    assert_five_headings(result)
     assert len(calls) == 5
     audit = json.loads(next((tmp_path / "logs").glob("BF-critique_branch-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
@@ -588,3 +698,84 @@ def test_failed_consolidation_audit_retains_lane_and_retry_attempts(
     assert [row["outcome"] for row in audit["attempt_ledger"]] == [
         "completed", "completed", "completed", "format-invalid", "format-invalid",
     ]
+
+
+def test_branch_handler_runs_census_correction_and_cold_final(
+    repo_with_branch, tmp_path, monkeypatch,
+):
+    calls = []
+
+    def run(self, prompt, *args, **kwargs):
+        calls.append(prompt)
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            findings = ([finding("F1", "MAJOR")] if lane_name == "behaviour" else [])
+            value = payload(lane(lane_name, findings=findings))
+            for row in value["coverage"]:
+                row["evidence"] = ["README.md:1"]
+            for item in value["findings"]:
+                item["evidence"] = ["README.md:1"]
+            text = wire(rc.LANE_MARKER, value)
+        elif prompts.STAGED_CONSOLIDATION_INSTRUCTIONS.splitlines()[0] in prompt:
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"census",
+                "source_dispositions":[{"source_id":"behaviour:F1","governing_id":"G1"}],
+                "assessment_dispositions":[],
+                "findings":[{
+                    "id":"G1", "severity":"MAJOR", "summary":"repair it",
+                    "evidence":["README.md:1"], "remedy":"edit it",
+                }],
+                "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
+                "debt_updates":[], "class_records":[],
+            })
+        elif '"role": "correction"' in prompt:
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"correction", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[{"id":"D1","status":"closed","evidence":["README.md:1"]}],
+                "class_records":[],
+            })
+        else:
+            assert '"role": "final"' in prompt
+            coverage = payload(lane())["coverage"]
+            for row in coverage:
+                row["evidence"] = ["README.md:1"]
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"final", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[], "class_records":[],
+                "coverage":coverage, "class_assessments":[],
+            })
+        return Review(text=text, session_ref=f"branch-{len(calls)}", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    args = {
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"three-phase-branch", "stakes":"trusted local tool",
+    }
+    first = handlers.critique_branch(
+        {**args, "round":1}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda:"BC1",
+    )
+    second = handlers.critique_branch(
+        {**args, "round":2}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda:"BC2",
+    )
+    third = handlers.critique_branch(
+        {**args, "round":3}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda:"BC3",
+    )
+    assert "STRUCTURAL-PHASE: correction" in first
+    assert "STRUCTURAL-PHASE: final" in second
+    assert "STRUCTURAL-PHASE: clear" in third
+    assert "CONVERGENCE: NOT-BLOCKED" in third
+    assert len(calls) == 6
+    assert [row["role"] for row in json.loads(
+        next((tmp_path / "logs").glob("BC2-critique_branch-*.json")).read_text()
+    )["attempt_ledger"]] == ["correction"]
+    assert [row["role"] for row in json.loads(
+        next((tmp_path / "logs").glob("BC3-critique_branch-*.json")).read_text()
+    )["attempt_ledger"]] == ["final"]

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -99,6 +99,14 @@ def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
         "summary":"broken", "evidence":["a.py:1"],
     }
 
+    fatal = payload(settlement())
+    fatal["findings"][0]["severity"] = "BLOCKER"
+    with pytest.raises(rc.CensusError, match="downgrade"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, fatal), source_ids=["domain-1"],
+            source_severities={"domain-1": "FATAL"}, assessment_ids=[],
+        )
+
 
 def test_correction_cannot_clear_without_updating_every_existing_debt():
     value = payload(settlement())
@@ -413,9 +421,16 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert third.count("## What works") == 1
     audit = json.loads(next((tmp_path / "logs").glob("T1-critique_plan-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
+    assert audit["staged_settlement"]["source_dispositions"] == [
+        {"source_id":"domain:F1", "governing_id":"G1"},
+    ]
     assert [row["role"] for row in audit["attempt_ledger"]] == [
         "census-domain", "census-execution", "census-integrity", "consolidation",
     ]
+    lineage = cc.load_lineage(
+        cc.default_state_root(), "three-phase-plan", stamp="T4", mode=cc.PLAN_MODE,
+    )
+    assert lineage.review_state["debt"][0]["source_ids"] == ["domain:F1"]
 
 
 def test_branch_handler_runs_the_four_call_cold_census(repo_with_branch, tmp_path, monkeypatch):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -277,6 +277,39 @@ def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
     assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
 
 
+def test_staged_retry_repeats_exact_shapes_after_multirow_schema_drift(tmp_path):
+    invalid = payload(settlement())
+    invalid["findings"][0].pop("remedy")
+    invalid["findings"][0]["class_id"] = "wrong"
+    invalid["class_records"] = [{
+        "class_id":"wrong", "status":"open", "finding_ids":["C1"],
+        "debt_ids":["D1"],
+    }]
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, invalid)
+            return Review(text=text, session_ref="s", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert "missing ['remedy']" in prompt
+            assert "Finding rows have exactly id,severity,summary,evidence,remedy" in prompt
+            assert "They never contain status,finding_ids,debt_ids" in prompt
+            return Review(text=settlement(), session_ref=session_ref, raw=settlement())
+
+    _, parsed, attempts = handlers._staged_call(
+        role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+        model="m", effort="high", timeout=10, on_progress=None,
+        parser=lambda text: rc.parse_settlement(
+            text, source_ids=["domain-1"], assessment_ids=[],
+        ),
+    )
+    assert parsed["findings"][0]["remedy"] == "fix it"
+    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+
+
 def test_violated_class_cannot_be_replaced_at_lower_severity():
     value = payload(settlement())
     value.update(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -241,6 +241,40 @@ def test_evidence_anchors_resolve_against_snapshot(tmp_path):
     (tmp_path / "linked.py").symlink_to(outside)
     with pytest.raises(rc.CensusError, match="unresolvable repository"):
         rc.resolve_anchors({"evidence":["linked.py:1"]}, root=tmp_path)
+    materialized = tmp_path.parent / "materialized-repository"
+    materialized.mkdir()
+    (materialized / "README.md").write_text("snapshot\n")
+    (tmp_path / "repository").symlink_to(materialized, target_is_directory=True)
+    rc.resolve_anchors(
+        {"evidence":["repository/README.md:1"]}, root=tmp_path,
+        trusted_roots={"repository":materialized},
+    )
+
+
+def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
+    invalid = payload(settlement())
+    invalid["debt"][0]["id"] = ""
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, invalid)
+            return Review(text=text, session_ref="s", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert "debt id must be" in prompt
+            return Review(text=settlement(), session_ref=session_ref, raw=settlement())
+
+    _, parsed, attempts = handlers._staged_call(
+        role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+        model="m", effort="high", timeout=10, on_progress=None,
+        parser=lambda text: rc.parse_settlement(
+            text, source_ids=["domain-1"], assessment_ids=[],
+        ),
+    )
+    assert parsed["debt"][0]["id"] == "D1"
+    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
 
 
 def test_violated_class_cannot_be_replaced_at_lower_severity():
@@ -291,6 +325,30 @@ def test_violated_class_mapping_follows_cited_finding_and_reopens_atomically():
             wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
             class_states={"abc": (cc.CLOSED, False, "BLOCKER")}, role="final",
         )
+
+
+def test_violated_advisory_class_still_requires_concrete_debt():
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[{"source_id":"integrity:F1","governing_id":"G1"}],
+        findings=[finding("G1", "MINOR")], debt=[],
+        assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
+        class_records=[{"op":"reopen", "class_id":"abc"}],
+    )
+    with pytest.raises(rc.CensusError, match="violated class needs exactly one open debt"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=["integrity:F1"],
+            assessment_ids=["abc"], assessment_verdicts={"abc":"violated"},
+            assessment_findings={"abc":"integrity:F1"},
+            class_states={"abc": (cc.CLOSED, False, "MINOR")}, role="census",
+        )
+    value["debt"] = [{"id":"D1", "finding_id":"G1", "status":"open"}]
+    assert rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=["integrity:F1"],
+        assessment_ids=["abc"], assessment_verdicts={"abc":"violated"},
+        assessment_findings={"abc":"integrity:F1"},
+        class_states={"abc": (cc.CLOSED, False, "MINOR")}, role="census",
+    )["debt"][0]["severity"] == "MINOR"
 
 
 def test_class_records_require_the_exact_mode_specific_shape():
@@ -476,6 +534,52 @@ def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, m
     assert "STRUCTURAL-PHASE: clear" in out
 
 
+def test_disabled_claims_do_not_gate_or_render_stale_claim_debt(tmp_path):
+    claim_state = pc.with_debt(
+        pc.empty_state(), pc.AuditError("stale external debt"), round_no=1,
+        plan_text="# Plan\n",
+    )
+    cc.save_lineage(
+        tmp_path,
+        cc.Lineage(
+            "dormant-claims", mode=cc.PLAN_MODE, claim_state=claim_state,
+            review_state=rc.normalize_state({}, stakes="s", snapshot="p"),
+        ),
+    )
+    closure = handlers._PlanClassClosure(
+        "dormant-claims", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    closure.claims_enabled = False
+
+    class Engine:
+        name = "fake"
+
+        def run(self, prompt, *args, **kwargs):
+            if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+                lane_name = next(
+                    row.split()[-1] for row in prompt.splitlines()
+                    if row.startswith("ROLE: census lane")
+                )
+                text = lane(lane_name)
+            else:
+                text = wire(rc.SETTLEMENT_MARKER, {
+                    "role":"census", "source_dispositions":[],
+                    "assessment_dispositions":[], "findings":[], "debt":[],
+                    "debt_updates":[], "class_records":[],
+                })
+            return Review(text=text, session_ref="s", raw=text)
+
+    _, trailer, _ = handlers._staged_structural_review(
+        engine=Engine(), cwd=tmp_path, model="m", effort="high", mode=cc.PLAN_MODE,
+        body="artifact", closure=closure, stakes="s", snapshot="p", round_no=1,
+        on_progress=None, plan_lines=1,
+    )
+    closure.release()
+    assert "STRUCTURAL-PHASE: clear" in trailer
+    assert "CLAIM-" not in trailer
+
+
 def test_unknown_legacy_calibration_resets_claims_and_reopens_classes(
     repo, tmp_path, monkeypatch,
 ):
@@ -588,6 +692,8 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert audit["staged_settlement"]["source_dispositions"] == [
         {"source_id":"domain:F1", "governing_id":"G1"},
     ]
+    domain = next(row for row in audit["staged_manifests"] if row["lane"] == "domain")
+    assert domain["coverage"][0]["finding_ids"] == ["domain:F1"]
     rows = audit["attempt_ledger"]
     assert {row["role"] for row in rows[:3]} == {
         "census-domain", "census-execution", "census-integrity",

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -580,7 +580,7 @@ def test_disabled_claims_do_not_gate_or_render_stale_claim_debt(tmp_path):
     assert "CLAIM-" not in trailer
 
 
-def test_unknown_legacy_calibration_resets_claims_and_reopens_classes(
+def test_unknown_legacy_calibration_preserves_disabled_claims_and_reverifies_on_enable(
     repo, tmp_path, monkeypatch,
 ):
     claim_state = pc.empty_state()
@@ -600,8 +600,14 @@ def test_unknown_legacy_calibration_resets_claims_and_reopens_classes(
 
     def staged(**kwargs):
         closure = kwargs["closure"]
-        observed["claims"] = closure.lineage.claim_state["claims"]
+        observed["claims"] = dict(closure.lineage.claim_state["claims"])
         observed["status"] = closure.lineage.classes["old"].status
+        observed["reverify"] = closure.lineage.claim_reverify_required
+        closure.lineage.review_state = rc.normalize_state(
+            closure.lineage.review_state, stakes=kwargs["stakes"],
+            snapshot=kwargs["snapshot"],
+        )
+        cc.save_lineage(closure.state_root, closure.lineage)
         closure._settled = True
         review = Review(text="ok", session_ref="s", raw="ok")
         return review, "CONVERGENCE: BLOCKED — test", []
@@ -612,7 +618,38 @@ def test_unknown_legacy_calibration_resets_claims_and_reopens_classes(
         "lineage":"legacy-calibration", "round":3,
         "claim_verification":False, "stakes":"trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs")
-    assert observed == {"claims": {}, "status": cc.OPEN}
+    assert observed == {
+        "claims": {"C1": {"scope":"external"}},
+        "status": cc.OPEN, "reverify": True,
+    }
+    preserved = cc.load_lineage(
+        cc.default_state_root(), "legacy-calibration", stamp="later", mode=cc.PLAN_MODE,
+    )
+    assert preserved.claim_state == claim_state
+    assert preserved.claim_reverify_required is True
+
+    verify = {}
+
+    def verify_claims(plan_text, prior_state, **kwargs):
+        verify["prior"] = prior_state
+        verify["force"] = kwargs["force_exhaustive"]
+        return prior_state, "parsed 1 full current packet"
+
+    monkeypatch.setattr(handlers, "_verify_plan_claims", verify_claims)
+    monkeypatch.setattr(handlers.inert_git, "require_supported_version", lambda: None)
+    monkeypatch.setattr(handlers.eng, "require_evidence_profile", lambda engine: None)
+    handlers.critique_plan({
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo),
+        "lineage":"legacy-calibration", "round":4,
+        "claim_verification":True, "web_search":True,
+        "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs")
+    assert verify == {"prior": claim_state, "force": True}
+    refreshed = cc.load_lineage(
+        cc.default_state_root(), "legacy-calibration", stamp="later", mode=cc.PLAN_MODE,
+    )
+    assert refreshed.claim_state == claim_state
+    assert refreshed.claim_reverify_required is False
 
 
 def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monkeypatch):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -120,6 +120,14 @@ def test_settlement_accepts_only_the_observed_decorative_marker_variant():
         )
 
 
+def test_lane_accepts_only_the_observed_decorative_marker_variant():
+    short = rc.LANE_MARKER.removesuffix(" ===")
+    text = lane().replace(rc.LANE_MARKER, short, 1)
+    assert rc.parse_lane(text, lane="domain")["lane"] == "domain"
+    with pytest.raises(rc.CensusError, match="begin with exactly one"):
+        rc.parse_lane("prose\n" + text, lane="domain")
+
+
 def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
     value = payload(settlement())
     value["findings"][0]["severity"] = "MINOR"

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -30,8 +30,7 @@ def settlement(**overrides):
         "source_dispositions": [{"source_id": "domain-1", "governing_id": "C1"}],
         "assessment_dispositions": [],
         "findings": [finding("C1")],
-        "debt": [{"id": "D1", "finding_id": "C1", "severity": "MAJOR",
-                  "summary": "broken", "evidence": ["a.py:1"], "status": "open"}],
+        "debt": [{"id": "D1", "finding_id": "C1", "status": "open"}],
         "debt_updates": [], "class_records": [],
     }
     value.update(overrides)
@@ -85,17 +84,20 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
         rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
 
 
-def test_settlement_cannot_downgrade_source_or_debt_severity():
+def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
     value = payload(settlement())
     value["findings"][0]["severity"] = "MINOR"
     value["debt"] = []
     with pytest.raises(rc.CensusError, match="downgrade"):
         rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"],
                             source_severities={"domain-1": "MAJOR"}, assessment_ids=[])
-    value = payload(settlement())
-    value["debt"][0]["severity"] = "MINOR"
-    with pytest.raises(rc.CensusError, match="debt severity"):
-        rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"], assessment_ids=[])
+    parsed = rc.parse_settlement(
+        settlement(), source_ids=["domain-1"], assessment_ids=[],
+    )
+    assert parsed["debt"][0] == {
+        "id":"D1", "finding_id":"C1", "status":"open", "severity":"MAJOR",
+        "summary":"broken", "evidence":["a.py:1"],
+    }
 
 
 def test_correction_cannot_clear_without_updating_every_existing_debt():
@@ -126,7 +128,9 @@ def test_correction_cannot_downgrade_a_class_or_reuse_durable_debt():
         rc.normalize_state({}, stakes="s", snapshot="p"), first,
         phase="census", snapshot="p", round_no=1,
     )
-    duplicate = payload(settlement())
+    duplicate = rc.parse_settlement(
+        settlement(), source_ids=["domain-1"], assessment_ids=[],
+    )
     duplicate.update(source_dispositions=[], findings=[finding("C2")])
     duplicate["debt"][0].update(finding_id="C2")
     with pytest.raises(rc.CensusError, match="reuses durable id"):
@@ -197,10 +201,7 @@ def test_violated_class_cannot_be_replaced_at_lower_severity():
         }],
     )
     value["findings"] = [finding("C1", "MAJOR")]
-    value["debt"] = [{
-        "id":"D1", "finding_id":"C1", "severity":"MAJOR", "summary":"broken",
-        "evidence":["a.py:1"], "status":"open",
-    }]
+    value["debt"] = [{"id":"D1", "finding_id":"C1", "status":"open"}]
     with pytest.raises(rc.CensusError, match="cannot be downgraded"):
         rc.parse_settlement(
             wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
@@ -365,10 +366,7 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
                     "id":"G1", "severity":"MAJOR", "summary":"repair the plan",
                     "evidence":["plan:1"], "remedy":"edit the plan",
                 }],
-                "debt":[{
-                    "id":"D1", "finding_id":"G1", "severity":"MAJOR",
-                    "summary":"repair the plan", "evidence":["plan:1"], "status":"open",
-                }],
+                "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
                 "debt_updates":[], "class_records":[],
             })
         elif '"role": "correction"' in prompt:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -238,6 +238,36 @@ def test_violated_class_cannot_be_replaced_at_lower_severity():
         )
 
 
+def test_violated_class_mapping_follows_cited_finding_and_reopens_atomically():
+    value = payload(settlement())
+    value.update(
+        role="final", source_dispositions=[],
+        assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
+        findings=[finding("G1", "BLOCKER")],
+        debt=[{"id":"D1", "finding_id":"G1", "status":"open"}],
+        debt_updates=[], class_records=[{"op":"reopen", "class_id":"abc"}],
+        coverage=payload(lane(findings=[finding("G1", "BLOCKER")]))["coverage"],
+        class_assessments=[{
+            "class_id":"abc", "verdict":"violated", "evidence":["a.py:1"],
+            "finding_id":"G1",
+        }],
+    )
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+        class_states={"abc": (cc.CLOSED, False, "BLOCKER")}, role="final",
+    )
+    assert parsed["class_records"] == [{"op":"reopen", "class_id":"abc"}]
+    value["assessment_dispositions"][0]["governing_id"] = "G2"
+    value["findings"].append(finding("G2", "BLOCKER"))
+    value["debt"].append({"id":"D2", "finding_id":"G2", "status":"open"})
+    value["coverage"][0]["finding_ids"].append("G2")
+    with pytest.raises(rc.CensusError, match="follow its cited finding"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+            class_states={"abc": (cc.CLOSED, False, "BLOCKER")}, role="final",
+        )
+
+
 def test_class_records_require_the_exact_mode_specific_shape():
     with pytest.raises(rc.CensusError, match="new class record"):
         rc.register_from_records([{

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -338,6 +338,7 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
     assert [attempt.role for attempt in attempts] == [
         "census-domain", "census-domain-format-retry",
     ]
+    assert [attempt.sequence for attempt in attempts] == [None, None]
     assert [attempt.outcome for attempt in attempts] == ["format-invalid", "completed"]
     assert all(attempt.response_sha256 and attempt.response_excerpt for attempt in attempts)
 
@@ -587,9 +588,12 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert audit["staged_settlement"]["source_dispositions"] == [
         {"source_id":"domain:F1", "governing_id":"G1"},
     ]
-    assert [row["role"] for row in audit["attempt_ledger"]] == [
-        "census-domain", "census-execution", "census-integrity", "consolidation",
-    ]
+    rows = audit["attempt_ledger"]
+    assert {row["role"] for row in rows[:3]} == {
+        "census-domain", "census-execution", "census-integrity",
+    }
+    assert rows[3]["role"] == "consolidation"
+    assert [row["sequence"] for row in rows] == [1, 2, 3, 4]
     lineage = cc.load_lineage(
         cc.default_state_root(), "three-phase-plan", stamp="T4", mode=cc.PLAN_MODE,
     )
@@ -691,13 +695,27 @@ def test_failed_consolidation_audit_retains_lane_and_retry_attempts(
     assert len(calls) == 5
     audit = json.loads(next((tmp_path / "logs").glob("BF-critique_branch-*.json")).read_text())
     assert len(audit["staged_manifests"]) == 3
-    assert [row["role"] for row in audit["attempt_ledger"]] == [
+    rows = audit["attempt_ledger"]
+    invoked_lanes = [
+        next(
+            line.split()[-1] for line in prompt.splitlines()
+            if line.startswith("ROLE: census lane")
+        )
+        for kind, prompt in calls[:3] if kind == "run"
+    ]
+    assert [row["role"] for row in rows[:3]] == [
+        f"census-{lane_name}" for lane_name in invoked_lanes
+    ]
+    assert {row["role"] for row in rows[:3]} == {
         "census-behaviour", "census-execution", "census-integrity",
+    }
+    assert [row["role"] for row in rows[3:]] == [
         "consolidation", "consolidation-format-retry",
     ]
-    assert [row["outcome"] for row in audit["attempt_ledger"]] == [
+    assert [row["outcome"] for row in rows] == [
         "completed", "completed", "completed", "format-invalid", "format-invalid",
     ]
+    assert [row["sequence"] for row in rows] == [1, 2, 3, 4, 5]
 
 
 def test_branch_handler_runs_census_correction_and_cold_final(


### PR DESCRIPTION
## Summary
- front-load tracked plan structural review into three independent cold lanes and a governing consolidation
- retain concrete debt across targeted correction rounds, then require one cold final regression
- preserve existing broad cold branch-review behavior while branch staging is validated separately
- document the representative real-plan replay and its measured quality/cost comparison

## Validation
- focused protocol and closure suite: 244 passed
- full suite: 728 passed
- representative plan replay: 5 rounds, 9 observed calls (8 with the landed parser behavior) versus 16 historical calls; all historical material roots plus 3 additional defects; final CONVERGENCE: NOT-BLOCKED
- branch staged comparison did not pass the efficiency gate and is explicitly deferred