### PR TITLE
Fix staged census advisory debt guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -31,6 +31,12 @@ reporting implementation progress. Label every run in commentary as PLAN or CODE
 Before review, update public documentation and these agent instructions. Before opening a PR,
 run the primary capability end to end; fake-backed tests alone do not establish usability.
 
+For staged census settlement, preserve one concrete debt record for every blocking governing
+finding and every governing finding referenced by a violated class assessment, including
+`MINOR` and `OUT-OF-SCOPE`. Advisory debt is tracked but excluded from phase gating and the
+computed blocking-debt count; do not weaken the validator or inflate severity to reconcile a
+prompt mismatch.
+
 ## Classes are architectural hypotheses
 
 An open class is not a patch instruction. Triage all open/reopened classes together: concrete

--- a/README.md
+++ b/README.md
@@ -224,6 +224,12 @@ A class closes when its predicate returns zero matches and reopens the moment it
 matches again. `MINOR` and `OUT-OF-SCOPE` classes are tracked but advisory — they
 never block.
 
+Staged census settlements preserve that distinction: exactly one concrete debt
+record is required for every blocking governing finding and for every governing
+finding cited by a violated class assessment, including advisory assessments.
+Advisory debt remains durable review context but is excluded from phase gating and
+the computed blocking-debt count.
+
 Where no regex can express the invariant, the reviewer registers a `PROCEDURE:`
 instead. Those are **unmechanized**: nothing re-runs them, they are shown to every
 later reviewer, and they close only when a reviewer explicitly writes

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -122,8 +122,9 @@ groups shared root causes without conducting another broad review. Its one stage
 contains every source-finding disposition, integrity-assessment disposition, governing finding,
 concrete-debt record, and class registration/transition in structured form. Every source finding
 of every severity and every integrity assessment is mapped exactly once; the governing severity
-cannot be lower than any merged source; every blocking governing finding maps to exactly one open
-concrete-debt record. The server parses the complete envelope into the existing
+cannot be lower than any merged source; every blocking governing finding and every governing
+finding referenced by a violated class assessment maps to exactly one open concrete-debt record,
+including advisory findings whose debt does not gate convergence. The server parses the complete envelope into the existing
 `Register`/lineage types, validates all fields, then applies finding and class state atomically. A
 missing source or assessment ID, dangling merge, missing blocking debt, unsupported class
 transition, or prose-only blocker rejects the whole envelope. The legacy terminal text class block

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -88,6 +88,7 @@ def _attempt(
 def _staged_call(
     *, role: str, engine: Engine, prompt: str, cwd: Path, model: str, effort: str,
     timeout: int, parser: Callable[[str], dict[str, Any]],
+    retry_guidance: str,
     on_progress: Callable[[str], None] | None,
     next_sequence: Callable[[], int] | None = None,
 ) -> tuple[Review, dict[str, Any], list[rc.Attempt]]:
@@ -113,13 +114,7 @@ def _staged_call(
             review.session_ref,
             "Your staged JSON was rejected: " + str(first) +
             "\nFix every schema violation in the complete object, not only the first one. "
-            "Finding rows have exactly id,severity,summary,evidence,remedy (never class_id). "
-            "Debt rows have exactly id,finding_id,status. Debt updates have exactly "
-            "id,status,evidence. Class records are operations: close/reopen have only "
-            "op,class_id; reclassify adds severity; new/replace use the exact invariant, "
-            "severity and mode-specific procedure or pattern/pathspec shape from the original "
-            "prompt. They never contain status,finding_ids,debt_ids. Return only the required "
-            "marker and complete JSON object.",
+            + retry_guidance + " Return only the required marker and complete JSON object.",
             cwd, model, effort, False, timeout=min(300, timeout),
             **_progress_kwargs(on_progress),
         )
@@ -327,6 +322,7 @@ def _staged_structural_review(
             result, parsed, lane_attempts = _staged_call(
                 role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=900, on_progress=on_progress,
+                retry_guidance=prompts.STAGED_LANE_RETRY_GUIDANCE,
                 parser=lambda text: validate_lane(text, lane), next_sequence=next_sequence,
             )
             renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
@@ -383,6 +379,7 @@ def _staged_structural_review(
             review, settlement, call_attempts = _staged_call(
                 role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=600, on_progress=on_progress,
+                retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
                 next_sequence=next_sequence,
                 parser=lambda text: validate_settlement(
                     text, source_ids=source_ids, source_severities=source_severities,
@@ -414,6 +411,7 @@ def _staged_structural_review(
         review, settlement, call_attempts = _staged_call(
             role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
             timeout=1200, on_progress=on_progress, next_sequence=next_sequence,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
             parser=lambda text: validate_settlement(
                 text, source_ids=[],
                 assessment_ids=active_ids if role == "final" else [],

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -320,9 +320,11 @@ least one coverage row."""
 
 STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do not conduct a new
 review. Map every source finding and class assessment exactly once. Preserve the highest severity
-of merged findings. Every blocking governing finding needs exactly one open debt record. Return
-only === REVIEW SETTLEMENT JSON === followed by one JSON object with: role, source_dispositions,
-assessment_dispositions, findings, debt, debt_updates, and class_records. Class record op is one of
+of merged findings. Every blocking governing finding and every governing finding referenced by a
+violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
+is tracked but does not block convergence. Return only === REVIEW SETTLEMENT JSON === followed by
+one JSON object with: role, source_dispositions, assessment_dispositions, findings, debt,
+debt_updates, and class_records. Class record op is one of
 new, close, reopen, reclassify, replace. Use replace as one atomic predecessor-to-open-successor
 operation. A new/replace record has op, invariant, severity and either pattern+pathspec (branch)
 or procedure (plan), with class_id additionally required for replace. Close/reopen has only op and
@@ -352,6 +354,26 @@ ANCHOR_POLICY
 Every anchor must resolve.
 A finding row names one or more findings, all other coverage rows name none, and every finding is
 named by coverage."""
+
+
+STAGED_LANE_RETRY_GUIDANCE = (
+    "Coverage rows have exactly id,status,summary,evidence,finding_ids. Lane finding rows have "
+    "exactly id,severity,summary,evidence,remedy. Class assessment rows have exactly "
+    "class_id,verdict,evidence,finding_id. Lane manifests never contain settlement debt, debt "
+    "updates, dispositions, or class records."
+)
+
+
+STAGED_SETTLEMENT_RETRY_GUIDANCE = (
+    "Every blocking finding and every governing finding referenced by a violated class "
+    "assessment needs exactly one open debt row, including MINOR and OUT-OF-SCOPE; advisory "
+    "debt is tracked but does not block convergence. Finding rows have exactly "
+    "id,severity,summary,evidence,remedy (never class_id). Debt rows have exactly "
+    "id,finding_id,status. Debt updates have exactly id,status,evidence. Class records are "
+    "operations: close/reopen have only op,class_id; reclassify adds severity; new/replace use "
+    "the exact invariant, severity and mode-specific procedure or pattern/pathspec shape from "
+    "the original prompt. They never contain status,finding_ids,debt_ids."
+)
 
 
 # ── class closure ─────────────────────────────────────────────────────────────

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -293,6 +293,7 @@ def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
     _, parsed, attempts = handlers._staged_call(
         role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
         model="m", effort="high", timeout=10, on_progress=None,
+        retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
         parser=lambda text: rc.parse_settlement(
             text, source_ids=["domain-1"], assessment_ids=[],
         ),
@@ -326,11 +327,49 @@ def test_staged_retry_repeats_exact_shapes_after_multirow_schema_drift(tmp_path)
     _, parsed, attempts = handlers._staged_call(
         role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
         model="m", effort="high", timeout=10, on_progress=None,
+        retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
         parser=lambda text: rc.parse_settlement(
             text, source_ids=["domain-1"], assessment_ids=[],
         ),
     )
     assert parsed["findings"][0]["remedy"] == "fix it"
+    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+
+
+def test_staged_retry_names_advisory_class_debt_invariant(tmp_path):
+    invalid = payload(settlement())
+    invalid.update(
+        source_dispositions=[{"source_id":"integrity:F1","governing_id":"G1"}],
+        findings=[finding("G1", "OUT-OF-SCOPE")], debt=[],
+        assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
+    )
+    repaired = dict(invalid)
+    repaired["debt"] = [{"id":"D1","finding_id":"G1","status":"open"}]
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, invalid)
+            return Review(text=text, session_ref="s", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert "every violated class needs exactly one open debt record" in prompt
+            assert "including MINOR and OUT-OF-SCOPE" in prompt
+            text = wire(rc.SETTLEMENT_MARKER, repaired)
+            return Review(text=text, session_ref=session_ref, raw=text)
+
+    _, parsed, attempts = handlers._staged_call(
+        role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+        model="m", effort="high", timeout=10, on_progress=None,
+        retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+        parser=lambda text: rc.parse_settlement(
+            text, source_ids=["integrity:F1"], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"violated"},
+            assessment_findings={"abc":"integrity:F1"},
+        ),
+    )
+    assert parsed["debt"][0]["severity"] == "OUT-OF-SCOPE"
     assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
 
 
@@ -385,6 +424,9 @@ def test_violated_class_mapping_follows_cited_finding_and_reopens_atomically():
 
 
 def test_violated_advisory_class_still_requires_concrete_debt():
+    assert "every governing finding referenced by a\nviolated class assessment" in (
+        prompts.STAGED_CONSOLIDATION_INSTRUCTIONS
+    )
     value = payload(settlement())
     value.update(
         source_dispositions=[{"source_id":"integrity:F1","governing_id":"G1"}],
@@ -426,18 +468,22 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
         name = "fake"
 
         def run(self, *args, **kwargs):
-            value = payload(lane())
+            value = payload(lane(findings=[finding("F1")]))
             value["coverage"][0]["evidence"] = ["missing.py:1"]
+            value["findings"][0]["evidence"] = ["missing.py:1"]
             text = wire(rc.LANE_MARKER, value)
             return Review(text=text, session_ref="session", raw=text)
 
         def resume(self, session_ref, prompt, *args, **kwargs):
             assert session_ref == "session"
             assert "unresolvable repository anchor" in prompt
+            assert "Lane manifests never contain settlement debt" in prompt
+            assert "open debt" not in prompt
             (tmp_path / "ok.py").write_text("ok\n")
-            value = payload(lane())
+            value = payload(lane(findings=[finding("F1")]))
             for row in value["coverage"]:
                 row["evidence"] = ["ok.py:1"]
+            value["findings"][0]["evidence"] = ["ok.py:1"]
             text = wire(rc.LANE_MARKER, value)
             return Review(text=text, session_ref="session", raw=text)
 
@@ -449,6 +495,7 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
     _, _, attempts = handlers._staged_call(
         role="census-domain", engine=Engine(), prompt="review", cwd=tmp_path,
         model="m", effort="high", timeout=10, parser=parse, on_progress=None,
+        retry_guidance=prompts.STAGED_LANE_RETRY_GUIDANCE,
     )
     assert [attempt.role for attempt in attempts] == [
         "census-domain", "census-domain-format-retry",


### PR DESCRIPTION
## Summary
- require concrete debt for governing findings referenced by violated class assessments at every severity
- keep advisory debt tracked but excluded from convergence gating
- split lane and settlement format-retry guidance
- document and test both schema paths

## Verification
- 729 tests passed
- paranoia-local CODE review converged in round 2 with CONVERGENCE: NOT-BLOCKED