### PR TITLE
Activate staged census for branch reviews

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -125,8 +125,8 @@ state and reviewer-native capabilities meet the supported model.
   the preserved inventory when verification is next enabled. For tracked plan structural review,
   a new plan snapshot's census and the final regression are broad and cold; intervening correction
   rounds are deliberately targeted to open findings/classes, the claimed corrections, and their
-  transitive effects. Tracked branch review remains broad and cold on every convergence round while
-  its staged lifecycle is validated separately. Do not reopen external inventory for repository
+  transitive effects. Tracked branch review uses the same broad cold census, targeted correction,
+  and broad cold final lifecycle; its external claim register remains out of scope. Do not reopen external inventory for repository
   mechanics or “missing atomic bridges,” and do not repeatedly hunt unrelated unchanged material
   for novelty between the census and final regression.
 - Model omission and ID reuse are not removal: exact propositions alone preserve identity;

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,9 +8,8 @@
 - after plan approval, review the implementation branch—not the plan—unless design is explicitly
   reopened, and label runs PLAN versus CODE;
 - treat recurring classes as an architecture checkpoint, not permission for another patch;
-- use broad cold structural coverage for a tracked plan snapshot's census and final regression, while
-  targeting its intervening correction rounds to open debt and correction effects; keep branch
-  convergence broad and cold until its staged lifecycle is separately accepted;
+- use broad cold structural coverage for tracked plan and branch census/final regression, while
+  targeting intervening correction rounds to open debt and correction effects;
 - prioritize accurate, fast, workable behavior and a small architecture over out-of-scope
   hardening;
 - keep plan claim verification on by default with reviewer-native search used only for URL

--- a/README.md
+++ b/README.md
@@ -138,8 +138,11 @@ independent cold lanes and one consolidation call. Their complete finding census
 debt. Later correction rounds target that debt and correction effects; once it closes, one fresh
 whole-artifact final regression is mandatory. A clear initial census may converge immediately.
 This preserves broad first-pass/final coverage without paying for novelty hunting over unchanged
-material on every correction round. Tracked branch reviews retain the established broad, cold
-single-review path while the branch census is validated separately.
+material on every correction round. Tracked branch reviews use the same lifecycle: a broad, cold
+three-lane census, targeted correction rounds over durable debt and changed code, and a mandatory
+broad, cold final regression before clearance. Every staged branch role retains the established
+code-review investigation, packet-use, proportionality, and warranted-web-search profile; only its
+structured output contract changes. One-shot reviews retain the single broad review.
 
 Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
 claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and
@@ -148,10 +151,10 @@ provider, parsing, deadline, or oversized-state failures block visibly rather th
 
 ### `round` — lineage ordering
 
-The 1-based round number. **Increment it every round.** In tracked staged plan review, census and final
-remain complete at every in-scope severity while correction is limited to durable debt and repair
-effects; convergence comes from that phase boundary. Branch and other legacy single-review paths
-retain their broad review and round-3 severity floor.
+The 1-based round number. **Increment it every round.** In tracked staged plan and branch review,
+census and final remain complete at every in-scope severity while correction is limited to durable
+debt and repair effects; convergence comes from that phase boundary. One-shot and injected-engine
+legacy paths retain their single broad review and round-3 severity floor.
 
 `round` is required on `critique_branch` and `critique_plan` unless you pass
 `class_closure: false`.
@@ -680,9 +683,10 @@ Accepted by the four review tools:
 
 ### Review output
 
-Every review returns exactly five headings, in this order. Legacy and tracked branch reviews populate
-their natural categories; tracked staged plan reviews put governing findings in `What doesn't work`, bounded remedies
-in `Improvements`, and write `Nothing notable.` in categories the settlement does not represent.
+Every review returns exactly five headings, in this order. One-shot reviews populate their natural
+categories; tracked staged plan and branch reviews put governing findings in `What doesn't work`,
+bounded remedies in `Improvements`, and write `Nothing notable.` in categories the settlement does
+not represent.
 
 | Section | Contains |
 |---|---|
@@ -708,7 +712,7 @@ The footer carries the `session_ref` for [`rebut`](#rebut).
 
 ### Tracked convergence trailer
 
-Appended below a staged tracked plan review:
+Appended below a staged tracked plan or branch review:
 
 ```
 STRUCTURAL-PHASE: correction
@@ -725,8 +729,9 @@ CONVERGENCE: BLOCKED — staged structural debt remains open.
 | `STRUCTURAL-ERROR` / `STRUCTURAL-PENDING` | A bounded format/deadline path did not produce a settled review |
 | `STATE-UNAVAILABLE` | Lineage state is unreadable, unwritable, or a previous write may not have completed. The message names the absolute path; repair or delete it, then re-run |
 
-Tracked branch, one-shot, and injected-engine trailers retain `CLASS-REGISTER`, `CLASS-CLOSURE`,
-match, and unmechanized-class detail.
+One-shot and injected-engine trailers retain `CLASS-REGISTER`, `CLASS-CLOSURE`, match, and
+unmechanized-class detail. Staged branch class state is incorporated into `STRUCTURAL-DEBT` and the
+computed convergence line.
 
 `NOT-BLOCKED` asserts only that the computed structural-debt, class, and (for verified plans)
 external-claim gates are clear. It is a review result, not a proof that the change is correct.

--- a/docs/exhaustive_census_acceptance_evidence.md
+++ b/docs/exhaustive_census_acceptance_evidence.md
@@ -1,8 +1,8 @@
 # Plan staged-census acceptance evidence
 
 This record freezes the real-provider acceptance evidence for activating the staged structural
-review lifecycle in tracked plan review. The branch lifecycle remains disabled: it is being
-validated separately and is not implied by this evidence.
+review lifecycle in tracked plan review and records the separate, qualified evidence used to
+activate the same lifecycle for tracked branch review.
 
 The replay used Codex at high reasoning with live web search disabled. Its frozen stakes assumed
 one trusted operator and OS and first-party repositories. Correct domain behaviour, provenance,
@@ -36,7 +36,7 @@ alter the default-on external-claim pipeline. Plan claim acceptance and real cap
 tests cover that pipeline separately; when enabled, staged structural lanes consume the retained
 claim register and evidence packets.
 
-## Branch status: deferred
+## Branch status: activated with qualified evidence
 
 The strict same-start branch comparison did converge and found additional material defects, but it
 did not pass the all-metrics efficiency gate: eight rounds plus one rebuttal, 14 provider calls,
@@ -44,9 +44,28 @@ did not pass the all-metrics efficiency gate: eight rounds plus one rebuttal, 14
 lineage's 10 rounds/calls, 27,907,358 processed input tokens, and approximately 1,901,974
 uncached-input-plus-output tokens. Stronger quality does not justify claiming an efficiency win.
 
-Consequently this change activates staged census only for tracked plans. Tracked branch review
-continues to use the established broad, cold single-review/class-register path until a separate
-implementation proves both review quality and representative convergence efficiency.
+The first comparison established stronger review quality but did not establish an all-metrics
+efficiency win. Branch activation therefore must not be described as guaranteed to use fewer calls
+or tokens.
+
+A second representative replay against the debt-reconciliation branch clarified that tradeoff.
+The staged lifecycle reached round 9 without convergence, using 18 provider calls, 62,127,846
+processed input tokens and 219,059 output tokens. Its mandatory cold finals correctly found three
+material roots that the initial census and intervening targeted corrections had missed: loss of a
+discharged supersede, stale acceptance-ledger governance, and a regenerated transition whose live
+predecessor identity and owner were not checked exactly. This is strong fail-closed review
+behaviour, but not evidence that branch convergence is cheaper: deep code defects remained
+path-dependent, and each newly corrected root required another cold final. The historical lineage
+contains 13 identifiable broad reviews, but different executor/model behaviour and correction
+choices make that round count directional rather than a controlled performance comparison.
+
+The replay nevertheless supports activation on intrinsic review merits: the cold final prevented a
+false clear, correction rounds were scoped to durable debt and changed code, and the implementation
+reuses the existing plan lifecycle rather than adding another subsystem. The reusable settlement
+improvement also requires any open update to state the concrete remaining condition and renders the
+complete durable open-debt set rather than incorrectly saying that nothing is notable. The product
+claim is stronger controlled coverage and targeted correction—not guaranteed first-pass
+exhaustiveness or guaranteed lower cost.
 
 ## Acceptance conclusion
 

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -1,7 +1,7 @@
 # Staged census for tracked plan review
 
-Status: the plan lifecycle is accepted and activated. The branch lifecycle remains a design under
-separate validation and is not activated by this change.
+Status: the plan and branch lifecycles are activated. The plan replay proved a material efficiency
+win; branch replay proved stronger controlled coverage but not a comparable efficiency win.
 
 ## 1. Outcome and proportionate stakes
 
@@ -10,9 +10,8 @@ coverage, correct one consolidated finding set, and converge through targeted cl
 full regression. They should stop using every correction round as another novelty-maximising review
 of unchanged material.
 
-The same architecture may later serve `critique_branch`, but only after a representative strict
-same-start comparison proves both material review quality and convergence efficiency. Until then,
-tracked branch review retains its established broad, cold single-review/class-register path.
+The same architecture serves tracked `critique_branch` without the external-claim phase. It uses a
+broad cold census, targeted correction, and a mandatory broad cold final regression.
 
 Operating model: one trusted operator and OS; first-party repositories; plan/repository bytes and
 model replies are untrusted data. There is no hostile same-user race, compromised OS or provider,
@@ -92,10 +91,12 @@ mechanised classes, with its invariant, severity, state, and procedure or patter
 assess each as `satisfied|violated` with a resolved anchor. Each `violated` assessment must
 name a source finding. Settlement maps every assessment ID exactly once: `violated` requires open
 concrete debt through the same governing finding as that cited lane finding and, when the class was
-closed, either `REOPEN` or one atomic `REPLACE` that retires
+closed, either `REOPEN` for an unmechanised class or one atomic `REPLACE` that retires
 the predecessor and creates an open successor with the corrected invariant, severity and procedure.
 `REPLACE` is the staged representation of existing supersession semantics; it never emits a second
-transition against the predecessor. A satisfied open unmechanised class requires `CLOSED`; a
+transition against the predecessor. Its successor may use either supported mechanism independently
+of the predecessor, and any governing debt binding moves atomically to the live successor before
+phase calculation. A satisfied open unmechanised class requires `CLOSED`; a
 mechanised class remains governed by its snapshot predicate. No transition is needed for an already
 closed satisfied class. Omission, contradiction, or two operations against one class
 rejects the whole settlement. This makes recurrence mechanically blocking before a blocker-free
@@ -193,8 +194,9 @@ Extend the existing atomically replaced lineage JSON; do not add a state store. 
 
 - frozen stakes text/digest;
 - `census|correction|final|clear` phase;
-- last census/final snapshot digest;
-- concrete review debt: ID, severity, summary, evidence, source IDs, status and round metadata.
+- last census/final artifact digest; for branches this covers the complete packet, including both
+  resolved endpoints and material packet-defining inputs, rather than the head commit alone;
+- concrete review debt: ID, severity, summary, evidence, source/class IDs, status and round metadata.
 
 Concrete debt carries exact census findings until correction. The existing class register continues
 to carry reusable invariants; claim state continues to carry external evidence. Clearance requires
@@ -206,6 +208,9 @@ final with blockers → correction; final clear → clear. `clear` plus a change
 census. Artifact changes during correction remain correction because edits are expected there.
 
 A legacy lineage without `review_state` has unknown calibration and starts a new inventory+census.
+Any durable legacy register failure is included verbatim in that cold re-audit and is cleared only
+by its successfully settled census. A reopened blocking class without bound staged debt likewise
+forces the broad integrity census instead of entering an empty targeted correction.
 Plan claim verification still runs before structural review. Valid claim-evidence progress may
 persist when structural work later fails or lacks deadline; structural phase does not advance until
 a valid structural settlement. Audit logs record phase, stakes/snapshot digests, validated
@@ -224,6 +229,8 @@ sequence immediately before each provider run/resume boundary and are serialized
   atomically; this is not encoded as `REOPEN` plus another transition.
 - Add census, correction and final instruction blocks in `prompts.py`; retain the existing review
   sections, claim packets and class-register semantics.
+- Branch staged roles retain the resolved code-review web-search capability; plan structural roles
+  remain web-disabled because their external claims use the separate captured-evidence pipeline.
 - Add one shared handler runner for three parallel calls plus consolidation and for the targeted
   correction/final calls.
 - Thread the same small attempt-ledger collector through plan discovery, capture binding,
@@ -295,7 +302,7 @@ Plan activation gates:
    reviewed snapshot and make that statement self-referentially stale;
 8. only then open a PR, pass CI, merge, and update the primary `main` worktree.
 
-Branch activation has a separate gate: a strict same-start representative replay must be materially
-better than the established path in quality, rounds, provider calls, processed input, and
-uncached-input-plus-output. The first comparison improved quality but used 14 calls versus 10 and
-more tokens, so branch staging is deliberately deferred.
+Branch activation rests on stronger controlled coverage rather than an all-metrics efficiency
+claim. The first comparison improved quality but used 14 calls versus 10 and more tokens; a later
+representative replay likewise found additional material defects without proving a comparable cost
+win. Branch staging therefore must not be described as guaranteed to use fewer calls or tokens.

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -604,11 +604,11 @@ def _apply_transition(lineage: Lineage, t: Transition, *, round_no: int, minted:
     if t.kind == "REPLACE":
         if t.target is not None:
             raise RegisterError("REPLACE creates a successor and cannot name BY")
-        if cls.mechanized:
-            if not t.pattern or not t.pathspec:
-                raise RegisterError("mechanized REPLACE needs pattern and pathspec")
-        elif not t.procedure:
-            raise RegisterError("unmechanized REPLACE needs procedure")
+        successor_mechanized = bool(t.pattern or t.pathspec)
+        if successor_mechanized == bool(t.procedure):
+            raise RegisterError("REPLACE needs exactly pattern plus pathspec or procedure")
+        if successor_mechanized and (not t.pattern or not t.pathspec):
+            raise RegisterError("mechanized REPLACE needs pattern and pathspec")
         new_id = _add(
             lineage, t.invariant or cls.invariant, t.severity or cls.severity,
             cls.first_round, t.pattern, t.pathspec, t.procedure,

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -91,10 +91,11 @@ def _staged_call(
     retry_guidance: str,
     on_progress: Callable[[str], None] | None,
     next_sequence: Callable[[], int] | None = None,
+    web_search: bool = False,
 ) -> tuple[Review, dict[str, Any], list[rc.Attempt]]:
     """One staged call plus exactly one same-session schema correction."""
     sequence = next_sequence() if next_sequence else None
-    review = engine.run(prompt, cwd, model, effort, False, timeout=timeout,
+    review = engine.run(prompt, cwd, model, effort, web_search, timeout=timeout,
                         **_progress_kwargs(on_progress))
     attempts = [_attempt(role, engine, review, sequence=sequence)]
     if review.error:
@@ -115,7 +116,7 @@ def _staged_call(
             "Your staged JSON was rejected: " + str(first) +
             "\nFix every schema violation in the complete object, not only the first one. "
             + retry_guidance + " Return only the required marker and complete JSON object.",
-            cwd, model, effort, False, timeout=min(300, timeout),
+            cwd, model, effort, web_search, timeout=min(300, timeout),
             **_progress_kwargs(on_progress),
         )
         attempts.append(_attempt(
@@ -226,12 +227,31 @@ def _staged_structural_review(
     *, engine: Engine, cwd: Path, model: str, effort: str, mode: str, body: str,
     closure: "_ClosureRound", stakes: str, snapshot: str, round_no: int,
     on_progress: Callable[[str], None] | None, plan_lines: int | None = None,
+    web_search: bool = False,
 ) -> tuple[Review, str, list[dict[str, Any]]]:
     """Run census/correction/final and atomically settle it into the open lineage."""
     assert closure.lineage is not None
     lineage = closure.lineage
     rc.class_context(closure._blocks())
     state = rc.normalize_state(lineage.review_state, stakes=stakes, snapshot=snapshot)
+    if lineage.debt:
+        # A pre-staging malformed-register round is not silently normalized into an
+        # empty verified register. Its only autonomous recovery is a fresh cold census
+        # that sees the exact durable failure it supersedes.
+        state = rc.normalize_state(None, stakes=stakes, snapshot=snapshot)
+        state["debt"] = [{
+            "id":"legacy-register", "finding_id":"legacy-register",
+            "status":"open", "severity":cc.BLOCKER,
+            "summary":"A pre-staging review left unresolved class-register debt.",
+            "reason":str(lineage.debt.get("reason", "unresolved register failure")),
+            "remedy":"Use the cold census to explicitly retain or discharge this debt.",
+            "evidence":[], "source_ids":[], "class_ids":[],
+            "first_round":lineage.debt.get("round", 0),
+            "last_round":lineage.debt.get("round", 0),
+        }]
+        body += "\n\nLEGACY REGISTER DEBT REQUIRING COLD RE-AUDIT:\n" + json.dumps(
+            lineage.debt, ensure_ascii=False,
+        )
     phase = state["phase"]
     active_classes = [
         {
@@ -245,6 +265,25 @@ def _staged_structural_review(
     class_states = {
         c.class_id: (c.status, c.mechanized, c.severity) for c in lineage.active()
     }
+    debt_class_ids = {
+        cid for debt in state.get("debt", []) if debt.get("status") == "open"
+        for cid in debt.get("class_ids", [])
+    }
+    unbound_blocking = {
+        c.class_id for c in lineage.blocking() if c.class_id not in debt_class_ids
+    }
+    has_blocking_debt = any(
+        d.get("status") == "open" and d.get("severity") in rc.BLOCKING
+        for d in state.get("debt", [])
+    )
+    if phase == "census" and state.get("unbound_classes") and has_blocking_debt:
+        # State written by the earlier over-broad gate already has actionable debt;
+        # resume targeted correction rather than paying for a redundant census.
+        state["phase"] = phase = "correction"
+    if phase != "census" and unbound_blocking and not has_blocking_debt:
+        # A reopened or migrated class without governing staged debt needs the broad
+        # integrity lane, not an empty targeted correction that can never settle it.
+        state["phase"] = phase = "census"
     attempts: list[rc.Attempt] = []
     sequence_lock = Lock()
     sequence_value = 0
@@ -281,7 +320,8 @@ def _staged_structural_review(
             text, source_ids=source_ids, source_severities=source_severities,
             assessment_ids=assessment_ids, assessment_verdicts=assessment_verdicts,
             assessment_findings=assessment_findings,
-            class_states=class_states, class_mechanized=mode == cc.BRANCH_MODE,
+            class_states=class_states,
+            class_mechanized=None if mode == cc.BRANCH_MODE else False,
             known_debt=known_debt or (), role=role,
         )
         trusted_roots = None
@@ -299,7 +339,7 @@ def _staged_structural_review(
         _allocate_fresh_debt_ids(parsed["debt"], reserved_debt)
         try:
             register = rc.register_from_records(
-                parsed["class_records"], mechanized=mode == cc.BRANCH_MODE,
+                parsed["class_records"], mechanized=None if mode == cc.BRANCH_MODE else False,
             )
             cc.apply_register(cc.copy_lineage(lineage), register, round_no=round_no)
         except cc.RegisterError as exc:
@@ -323,6 +363,7 @@ def _staged_structural_review(
                 role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=900, on_progress=on_progress,
                 retry_guidance=prompts.STAGED_LANE_RETRY_GUIDANCE,
+                web_search=web_search,
                 parser=lambda text: validate_lane(text, lane), next_sequence=next_sequence,
             )
             renamed = {f["id"]: f"{lane}:{f['id']}" for f in parsed["findings"]}
@@ -371,6 +412,9 @@ def _staged_structural_review(
         consolidation_body = json.dumps({
             "role": "census", "stakes": stakes, "manifests": manifests,
             "active_classes": active_classes,
+            "existing_debt": [
+                d for d in state.get("debt", []) if d.get("status") == "open"
+            ],
         }, ensure_ascii=False)
         try:
             prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
@@ -380,12 +424,17 @@ def _staged_structural_review(
                 role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=600, on_progress=on_progress,
                 retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+                web_search=web_search,
                 next_sequence=next_sequence,
                 parser=lambda text: validate_settlement(
                     text, source_ids=source_ids, source_severities=source_severities,
                     assessment_ids=assessment_ids,
                     assessment_verdicts=assessment_verdicts,
-                    assessment_findings=assessment_findings, role="census",
+                    assessment_findings=assessment_findings,
+                    known_debt=[
+                        d["id"] for d in state.get("debt", []) if d.get("status") == "open"
+                    ],
+                    role="census",
                 ),
             )
         except rc.CensusError as error:
@@ -412,6 +461,7 @@ def _staged_structural_review(
             role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
             timeout=1200, on_progress=on_progress, next_sequence=next_sequence,
             retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            web_search=web_search,
             parser=lambda text: validate_settlement(
                 text, source_ids=[],
                 assessment_ids=active_ids if role == "final" else [],
@@ -422,7 +472,7 @@ def _staged_structural_review(
 
     draft = cc.copy_lineage(lineage)
     register = rc.register_from_records(
-        settlement["class_records"], mechanized=mode == cc.BRANCH_MODE,
+        settlement["class_records"], mechanized=None if mode == cc.BRANCH_MODE else False,
     )
     minted = cc.apply_register(draft, register, round_no=round_no)
     lineage.classes, lineage.next_seq, lineage.exemptions = (
@@ -431,11 +481,39 @@ def _staged_structural_review(
     if mode == cc.BRANCH_MODE:
         closure._sweep(only=minted)
     state = rc.settle_state(state, settlement, phase=phase, snapshot=snapshot, round_no=round_no)
+    replacements = {
+        cid: cls.superseded_by for cid, cls in lineage.classes.items()
+        if cls.status == cc.SUPERSEDED and cls.superseded_by
+    }
+    for debt in state.get("debt", []):
+        debt["class_ids"] = [replacements.get(cid, cid) for cid in debt.get("class_ids", [])]
     claim_blocked = (
         mode == cc.PLAN_MODE and closure.claims_enabled
         and pc.is_blocked(lineage.claim_state)
     )
-    if lineage.blocking() or claim_blocked:
+    mapped_classes = {
+        cid for debt in state.get("debt", []) if debt.get("status") == "open"
+        for cid in debt.get("class_ids", [])
+    }
+    unbound = [c for c in lineage.blocking() if c.class_id not in mapped_classes]
+    has_blocking_debt = any(
+        d.get("status") == "open" and d.get("severity") in rc.BLOCKING
+        for d in state.get("debt", [])
+    )
+    if unbound:
+        state["phase"] = "correction" if has_blocking_debt else "census"
+        state["unbound_classes"] = [{
+            "class_id":c.class_id, "severity":c.severity, "summary":c.invariant,
+            "reason":(
+                f"{c.status}: {len(c.matches)} surviving match(es)"
+                if c.mechanized else f"{c.status}: unmechanized review required"
+            ),
+            "evidence":[
+                f"repository/{m.path}:{m.line}" for m in c.matches
+            ],
+            "remedy":"Re-audit this class in the broad integrity census.",
+        } for c in unbound]
+    elif lineage.blocking() or claim_blocked:
         state["phase"] = "correction"
     lineage.review_state = state
     lineage.debt = None
@@ -460,7 +538,7 @@ def _staged_structural_review(
     closure._settled = True
     closure.register_status = f"staged {phase} parsed"
     closure.staged_settlement = settlement
-    review = replace(review, text=rc.render_review(settlement))
+    review = replace(review, text=rc.render_review(settlement, state))
     trailer = rc.trailer(state)
     if mode == cc.PLAN_MODE and closure.claims_enabled:
         trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
@@ -782,6 +860,22 @@ def _converge_branch_review(
                 review, trailer, attempt_ledger = _state_unavailable_review(
                     closure, mode=cc.BRANCH_MODE,
                 )
+            elif closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
+                try:
+                    review, trailer, attempt_ledger = _staged_structural_review(
+                        engine=engine, cwd=wt, model=model,
+                        effort=effort, mode=cc.BRANCH_MODE,
+                        body=f"=== REVIEW STAKES ===\n{stakes}\n\n{packet}",
+                        closure=closure, stakes=stakes,
+                        snapshot=rc.digest(f"{base_id}\0{head_id}\0{packet}"),
+                        round_no=review_round or 1, on_progress=on_progress,
+                        web_search=web_search,
+                    )
+                except rc.CensusError as error:
+                    review, trailer, attempt_ledger = _settle_staged_failure(
+                        closure, stakes=stakes, snapshot=head_id, error=error,
+                        mode=cc.BRANCH_MODE,
+                    )
             else:
                 review = engine.run(prompt, wt, model, effort, web_search,
                                     **_progress_kwargs(on_progress))

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -84,6 +84,12 @@ The task input contains, under `=== FILE … ===` sections, the current contents
 # "read every touched file / re-run git" gather step is replaced by a verify-and-go-deeper
 # instruction. Used by the Phase-1 `converge` path (handlers.critique_branch).
 CODE_REVIEW_INSTRUCTIONS_PACKET = CODE_REVIEW_INSTRUCTIONS + "\n\n" + _PACKET_PREAMBLE
+# Staged roles replace only the legacy five-section output contract. They retain the
+# established investigation, calibration, proportionality and packet-use profile so
+# changing review lifecycle does not silently narrow what branch reviewers inspect.
+CODE_REVIEW_INVESTIGATION = CODE_REVIEW_INSTRUCTIONS.partition(
+    "\n## Output — EXACTLY"
+)[0] + "\n\n" + _PACKET_PREAMBLE
 
 PLAN_REVIEW_INSTRUCTIONS = f"""You are Paranoia, an adversarial reviewer of plans and design documents. Assume the plan will fail in ways the author has not considered.
 
@@ -295,14 +301,22 @@ required), including plans, contracts, and documentation stored in the repositor
 
 def staged_census_instructions(mode: str, lane: str) -> str:
     policy = PLAN_EVIDENCE_ANCHORS if mode == "plan" else BRANCH_EVIDENCE_ANCHORS
-    return STAGED_CENSUS_INSTRUCTIONS.replace("ANCHOR_POLICY", policy).replace(
+    instructions = STAGED_CENSUS_INSTRUCTIONS.replace("ANCHOR_POLICY", policy).replace(
         "LANE", lane,
+    )
+    return (
+        CODE_REVIEW_INVESTIGATION + "\n\n" + instructions
+        if mode == "branch" else instructions
     )
 
 
 def staged_followup_instructions(mode: str) -> str:
     policy = PLAN_EVIDENCE_ANCHORS if mode == "plan" else BRANCH_EVIDENCE_ANCHORS
-    return STAGED_FOLLOWUP_INSTRUCTIONS.replace("ANCHOR_POLICY", policy)
+    instructions = STAGED_FOLLOWUP_INSTRUCTIONS.replace("ANCHOR_POLICY", policy)
+    return (
+        CODE_REVIEW_INVESTIGATION + "\n\n" + instructions
+        if mode == "branch" else instructions
+    )
 
 
 STAGED_CENSUS_INSTRUCTIONS = """You are one independent lane in a cold structural review census.
@@ -322,13 +336,17 @@ STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do 
 review. Map every source finding and class assessment exactly once. Preserve the highest severity
 of merged findings. Every blocking governing finding and every governing finding referenced by a
 violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
-is tracked but does not block convergence. Return only === REVIEW SETTLEMENT JSON === followed by
+is tracked but does not block convergence. If existing_debt is supplied, update every item exactly
+once; preserve it open with a concrete reason or close it with current evidence. Return only
+=== REVIEW SETTLEMENT JSON === followed by
 one JSON object with: role, source_dispositions, assessment_dispositions, findings, debt,
 debt_updates, and class_records. Class record op is one of
 new, close, reopen, reclassify, replace. Use replace as one atomic predecessor-to-open-successor
-operation. A new/replace record has op, invariant, severity and either pattern+pathspec (branch)
-or procedure (plan), with class_id additionally required for replace. Close/reopen has only op and
-class_id; reclassify additionally has severity. Use these exact row shapes:
+operation. A branch new/replace record has op, invariant, severity and exactly one of
+pattern+pathspec or procedure; a plan record has procedure. A replace additionally has class_id.
+Close/reopen has only op and class_id; reclassify additionally has severity. A closed mechanized
+class that is violated must use replace with a corrected predicate—reopen is only for unmechanized
+classes. Use these exact row shapes:
 source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
@@ -344,7 +362,10 @@ followed by one JSON object with role, source_dispositions, assessment_dispositi
 debt, debt_updates, class_records and, for final, coverage plus class_assessments. Account for every
 supplied open debt exactly once. Final must include all nine checklist IDs and assess every active class
 exactly once; a violated class creates a finding and open debt. Use the same exact row shapes as the
-census settlement; each debt update is {"id":"D1","status":"closed|open","evidence":["path:1"]}.
+census settlement. A closed debt update is
+{"id":"D1","status":"closed","evidence":["path:1"]}; an open debt update is
+{"id":"D1","status":"open","evidence":["path:1"],"reason":"exact remaining defect"}.
+The open reason must state the concrete unresolved condition so the operator can repair it directly.
 Correction returns empty source/assessment dispositions. Final returns empty source dispositions
 and one assessment disposition per class. The task's checklist array is governing. The exact
 final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
@@ -369,10 +390,12 @@ STAGED_SETTLEMENT_RETRY_GUIDANCE = (
     "assessment needs exactly one open debt row, including MINOR and OUT-OF-SCOPE; advisory "
     "debt is tracked but does not block convergence. Finding rows have exactly "
     "id,severity,summary,evidence,remedy (never class_id). Debt rows have exactly "
-    "id,finding_id,status. Debt updates have exactly id,status,evidence. Class records are "
+    "id,finding_id,status. Closed debt updates have exactly id,status,evidence; open updates "
+    "also require reason. Class records are "
     "operations: close/reopen have only op,class_id; reclassify adds severity; new/replace use "
-    "the exact invariant, severity and mode-specific procedure or pattern/pathspec shape from "
-    "the original prompt. They never contain status,finding_ids,debt_ids."
+    "the exact invariant and severity plus procedure or pattern/pathspec as allowed by the mode "
+    "and predecessor mechanism. A violated closed mechanized class uses replace, not reopen. "
+    "They never contain status,finding_ids,debt_ids."
 )
 
 

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -230,18 +230,23 @@ def parse_settlement(
         governing = by_id[item["finding_id"]]
         item.update(
             severity=governing["severity"], summary=governing["summary"],
-            evidence=list(governing["evidence"]),
+            evidence=list(governing["evidence"]), remedy=governing["remedy"],
         )
     updates = _list(obj, "debt_updates")
     seen_updates: set[str] = set()
     for item in updates:
-        _exact(item, {"id", "status", "evidence"}, "debt update")
+        if not isinstance(item, dict) or item.get("status") not in {"open", "closed"}:
+            raise CensusError("invalid debt-update status")
+        required = {"id", "status", "evidence", "reason"} if item["status"] == "open" else {
+            "id", "status", "evidence",
+        }
+        _exact(item, required, "debt update")
         if item["id"] in seen_updates or item["id"] not in set(known_debt):
             raise CensusError("unexpected or duplicate debt update")
         seen_updates.add(item["id"])
-        if item["status"] not in {"open", "closed"}:
-            raise CensusError("invalid debt-update status")
         _anchors(item["evidence"])
+        if item["status"] == "open":
+            _bounded(item["reason"], MAX_SUMMARY_CHARS, "open debt reason")
     if known_debt and seen_updates != set(known_debt):
         raise CensusError("every existing debt item must be updated exactly once")
     _list(obj, "class_records")
@@ -285,8 +290,13 @@ def parse_settlement(
         if class_states and cid in class_states:
             status, mechanized, prior_severity = class_states[cid]
             op = operation_by_class.get(cid)
-            if verdict == "violated" and status == cc.CLOSED and op not in {"reopen", "replace"}:
-                raise CensusError("closed violated class must reopen or replace")
+            if verdict == "violated" and status == cc.CLOSED:
+                allowed = {"replace"} if mechanized else {"reopen", "replace"}
+                if op not in allowed:
+                    raise CensusError(
+                        "closed violated mechanized class must replace" if mechanized
+                        else "closed violated class must reopen or replace"
+                    )
             if verdict == "satisfied" and status in cc.UNPROVEN_STATUSES:
                 if mechanized:
                     raise CensusError("mechanized open class cannot be model-closed")
@@ -304,17 +314,22 @@ def parse_settlement(
     return obj
 
 
-def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool) -> cc.Register:
+def register_from_records(
+    records: Sequence[dict[str, Any]], *, mechanized: bool | None,
+) -> cc.Register:
     new: list[cc.NewClass] = []
     transitions: list[cc.Transition] = []
     for row in records:
         if not isinstance(row, dict):
             raise CensusError("class record must be an object")
         op = row.get("op")
+        row_mechanized = mechanized if mechanized is not None else (
+            "pattern" in row or "pathspec" in row
+        )
         if op == "new":
             allowed = (
                 {"op", "invariant", "severity", "pattern", "pathspec"}
-                if mechanized else {"op", "invariant", "severity", "procedure"}
+                if row_mechanized else {"op", "invariant", "severity", "procedure"}
             )
             _exact(row, allowed, "new class record")
             if row.get("severity") not in cc.SEVERITIES:
@@ -322,9 +337,9 @@ def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool
             new.append(cc.NewClass(
                 invariant=_bounded(row.get("invariant"), 1000, "class invariant"),
                 severity=row.get("severity"),
-                pattern=_bounded(row.get("pattern"), 2000, "pattern") if mechanized else None,
-                pathspec=_bounded(row.get("pathspec"), 1000, "pathspec") if mechanized else None,
-                procedure=None if mechanized else _bounded(row.get("procedure"), 2000, "procedure"),
+                pattern=_bounded(row.get("pattern"), 2000, "pattern") if row_mechanized else None,
+                pathspec=_bounded(row.get("pathspec"), 1000, "pathspec") if row_mechanized else None,
+                procedure=None if row_mechanized else _bounded(row.get("procedure"), 2000, "procedure"),
             ))
         elif op in {"close", "reopen", "reclassify", "replace"}:
             if op in {"close", "reopen"}:
@@ -334,7 +349,7 @@ def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool
             else:
                 allowed = (
                     {"op", "class_id", "invariant", "severity", "pattern", "pathspec"}
-                    if mechanized else {"op", "class_id", "invariant", "severity", "procedure"}
+                    if row_mechanized else {"op", "class_id", "invariant", "severity", "procedure"}
                 )
                 _exact(row, allowed, "class replacement record")
             if op in {"reclassify", "replace"} and row.get("severity") not in cc.SEVERITIES:
@@ -349,15 +364,15 @@ def register_from_records(records: Sequence[dict[str, Any]], *, mechanized: bool
                 ),
                 pattern=(
                     _bounded(row.get("pattern"), 2000, "pattern")
-                    if op == "replace" and mechanized else None
+                    if op == "replace" and row_mechanized else None
                 ),
                 pathspec=(
                     _bounded(row.get("pathspec"), 1000, "pathspec")
-                    if op == "replace" and mechanized else None
+                    if op == "replace" and row_mechanized else None
                 ),
                 procedure=(
                     _bounded(row.get("procedure"), 2000, "procedure")
-                    if op == "replace" and not mechanized else None
+                    if op == "replace" and not row_mechanized else None
                 ),
             ))
         else:
@@ -371,6 +386,10 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     for update in settlement.get("debt_updates", []):
         item = old[update["id"]]
         item.update(status=update["status"], evidence=update["evidence"], last_round=round_no)
+        if update["status"] == "open":
+            item["reason"] = update["reason"]
+        else:
+            item.pop("reason", None)
     for item in settlement.get("debt", []):
         if item["id"] in old:
             raise CensusError(f"new debt reuses durable id {item['id']!r}")
@@ -379,6 +398,11 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
             source["source_id"] for source in settlement.get("source_dispositions", [])
             if source["governing_id"] == item["finding_id"]
         ]
+        row["class_ids"] = [
+            assessment["assessment_id"]
+            for assessment in settlement.get("assessment_dispositions", [])
+            if assessment["governing_id"] == item["finding_id"]
+        ]
         row["first_round"] = round_no; row["last_round"] = round_no
         old[row["id"]] = row
     active = [d for d in old.values() if d.get("status") == "open" and d.get("severity") in BLOCKING]
@@ -386,6 +410,7 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     out = dict(state)
     out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
     out.pop("format_debt", None)
+    out.pop("unbound_classes", None)
     return out
 
 
@@ -406,19 +431,39 @@ def trailer(state: dict[str, Any]) -> str:
     return "\n".join(lines)
 
 
-def render_review(settlement: dict[str, Any]) -> str:
+def render_review(settlement: dict[str, Any], state: dict[str, Any] | None = None) -> str:
     """Restore the stable human response while JSON remains in Review.raw/audit state."""
-    findings = settlement.get("findings", [])
+    findings = list(settlement.get("findings", []))
+    if state is not None:
+        current = {row.get("id"): dict(row) for row in findings}
+        rendered: list[dict[str, Any]] = []
+        consumed: set[str] = set()
+        for debt in state.get("debt", []):
+            if debt.get("status") != "open":
+                continue
+            fid = debt.get("finding_id")
+            row = dict(current.get(fid, {}))
+            row.update(debt)
+            rendered.append(row)
+            consumed.add(fid)
+        rendered.extend(row for fid, row in current.items() if fid not in consumed)
+        findings = rendered
+        findings.extend(state.get("unbound_classes", []))
 
     def rows(items: list[dict[str, Any]]) -> str:
         if not items:
             return "Nothing notable."
         return "\n".join(
-            f"- [{f['severity']}] {f['summary']} ({', '.join(f['evidence'])})"
+            f"- [{f['severity']}] {f['summary']}"
+            + (f" — remains open: {f['reason']}" if f.get("reason") else "")
+            + f" ({', '.join(f['evidence'])})"
             for f in items
         )
 
-    improvements = [f"- [{f['severity']}] {f['remedy']}" for f in findings]
+    improvements = [
+        f"- [{f['severity']}] {f.get('remedy') or f.get('reason') or 'Resolve the cited debt.'}"
+        for f in findings
+    ]
     return "\n\n".join((
         "## What works\n\nNothing notable.",
         "## What doesn't work\n\n" + rows(findings),
@@ -451,6 +496,12 @@ def resolve_anchors(
             relative = Path(path)
             if relative.is_absolute() or ".." in relative.parts:
                 raise CensusError(f"unresolvable repository anchor {anchor!r}")
+            if trusted_roots and "repository" in trusted_roots and (
+                not relative.parts or relative.parts[0] != "repository"
+            ):
+                raise CensusError(
+                    f"repository evidence anchor requires repository/ prefix: {anchor!r}"
+                )
             anchor_base = base
             if trusted_roots and relative.parts and relative.parts[0] in trusted_roots:
                 anchor_base = Path(trusted_roots[relative.parts[0]]).resolve()

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1,4 +1,6 @@
 import json
+import os
+import subprocess
 
 import pytest
 
@@ -140,7 +142,7 @@ def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
     )
     assert parsed["debt"][0] == {
         "id":"D1", "finding_id":"C1", "status":"open", "severity":"MAJOR",
-        "summary":"broken", "evidence":["a.py:1"],
+        "summary":"broken", "evidence":["a.py:1"], "remedy":"fix it",
     }
 
     fatal = payload(settlement())
@@ -158,6 +160,64 @@ def test_correction_cannot_clear_without_updating_every_existing_debt():
     with pytest.raises(rc.CensusError, match="every existing debt"):
         rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
                             known_debt=["D1"], role="correction")
+
+
+def test_open_debt_update_requires_and_renders_an_actionable_reason():
+    value = payload(settlement())
+    value.update(
+        role="correction", source_dispositions=[], assessment_dispositions=[],
+        findings=[], debt=[],
+        debt_updates=[{"id":"D1", "status":"open", "evidence":["a.py:2"]}],
+    )
+    with pytest.raises(rc.CensusError, match="debt update fields"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+            known_debt=["D1"], role="correction",
+        )
+    value["debt_updates"][0]["reason"] = "the stale-head path still bypasses validation"
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+        known_debt=["D1"], role="correction",
+    )
+    state = {
+        "phase":"correction", "debt":[{
+            "id":"D1", "finding_id":"G1", "status":"open", "severity":"MAJOR",
+            "summary":"validate the selected head", "evidence":["a.py:1"],
+            "remedy":"reject a stale head", "source_ids":[],
+        }],
+    }
+    updated = rc.settle_state(
+        state, parsed, phase="correction", snapshot="p", round_no=2,
+    )
+    rendered = rc.render_review(parsed, updated)
+    what_doesnt_work = rendered.split("## What doesn't work\n\n", 1)[1].split("\n\n## Risks", 1)[0]
+    assert what_doesnt_work != "Nothing notable."
+    assert "stale-head path still bypasses validation" in rendered
+    assert "validate the selected head" in rendered
+
+    advisory = finding("A1", "MINOR")
+    advisory["summary"] = "current advisory finding"
+    rendered = rc.render_review(
+        {"findings":[advisory]},
+        {"debt":updated["debt"]},
+    )
+    assert "current advisory finding" in rendered
+    assert "validate the selected head" in rendered
+    rendered = rc.render_review({"findings":[]}, {"debt":[], "unbound_classes":[{
+        "class_id":"abc", "severity":"MAJOR", "summary":"exact live owner",
+        "reason":"OPEN: unmechanized review required", "evidence":[],
+        "remedy":"Re-audit this class in the broad integrity census.",
+    }]})
+    assert "exact live owner" in rendered
+    assert "unmechanized review required" in rendered
+    rendered = rc.render_review({"findings":[]}, {"debt":[
+        {"id":"D1", "finding_id":"F1", "status":"open", "severity":"MAJOR",
+         "summary":"first durable debt", "evidence":[], "remedy":"fix first"},
+        {"id":"D2", "finding_id":"F1", "status":"open", "severity":"MAJOR",
+         "summary":"second durable debt", "evidence":[], "remedy":"fix second"},
+    ]})
+    assert "first durable debt" in rendered
+    assert "second durable debt" in rendered
 
 
 def test_correction_cannot_downgrade_a_class_or_reuse_durable_debt():
@@ -221,6 +281,67 @@ def test_replace_carries_corrected_severity_in_one_transition():
     assert lineage.classes[minted[0]].status == cc.OPEN
 
 
+def test_branch_records_allow_procedure_classes_and_reject_mechanized_reopen():
+    created = rc.register_from_records([{
+        "op":"new", "invariant":"new semantic invariant", "severity":"MAJOR",
+        "procedure":"inspect every generated record",
+    }], mechanized=None)
+    assert created.new_classes[0].procedure == "inspect every generated record"
+    assert created.new_classes[0].pattern is None
+
+    register = rc.register_from_records([{
+        "op":"replace", "class_id":"old", "invariant":"semantic invariant",
+        "severity":"MAJOR", "procedure":"inspect every transition",
+    }], mechanized=None)
+    lineage = cc.Lineage("branch", classes={
+        "old": cc.TrackedClass(
+            "old", "legacy semantic invariant", "MAJOR", 1, cc.CLOSED,
+            procedure="inspect one transition",
+        ),
+    }, next_seq=2, mode=cc.BRANCH_MODE)
+    minted = cc.apply_register(lineage, register, round_no=2)
+    assert lineage.classes[minted[0]].procedure == "inspect every transition"
+
+    to_procedure = rc.register_from_records([{
+        "op":"replace", "class_id":"regex", "invariant":"semantic successor",
+        "severity":"MAJOR", "procedure":"inspect semantics",
+    }], mechanized=None)
+    conversion = cc.Lineage("conversion", classes={
+        "regex":cc.TrackedClass(
+            "regex", "regex predecessor", "MAJOR", 1, cc.CLOSED,
+            pattern="BAD", pathspec="*.py",
+        ),
+    }, next_seq=2, mode=cc.BRANCH_MODE)
+    successor = cc.apply_register(conversion, to_procedure, round_no=2)[0]
+    assert conversion.classes[successor].procedure == "inspect semantics"
+
+    to_pattern = rc.register_from_records([{
+        "op":"replace", "class_id":"semantic", "invariant":"regex successor",
+        "severity":"MAJOR", "pattern":"BAD", "pathspec":"*.py",
+    }], mechanized=None)
+    conversion = cc.Lineage("conversion-2", classes={
+        "semantic":cc.TrackedClass(
+            "semantic", "semantic predecessor", "MAJOR", 1, cc.CLOSED,
+            procedure="inspect semantics",
+        ),
+    }, next_seq=2, mode=cc.BRANCH_MODE)
+    successor = cc.apply_register(conversion, to_pattern, round_no=2)[0]
+    assert conversion.classes[successor].pattern == "BAD"
+
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":"C1"}],
+        class_records=[{"op":"reopen", "class_id":"abc"}],
+    )
+    with pytest.raises(rc.CensusError, match="mechanized class must replace"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"violated"},
+            class_states={"abc": (cc.CLOSED, True, "MAJOR")},
+        )
+
+
 def test_correction_requires_a_final_before_clearance():
     state = rc.normalize_state({}, stakes="s", snapshot="p")
     first = rc.parse_settlement(settlement(), source_ids=["domain-1"], assessment_ids=[])
@@ -254,6 +375,11 @@ def test_evidence_anchors_resolve_against_snapshot(tmp_path):
         {"evidence":["repository/a.py:2"]}, root=tmp_path,
         trusted_roots={"repository":tmp_path},
     )
+    with pytest.raises(rc.CensusError, match="requires repository/ prefix"):
+        rc.resolve_anchors(
+            {"evidence":["a.py:2"]}, root=tmp_path,
+            trusted_roots={"repository":tmp_path},
+        )
     with pytest.raises(rc.CensusError, match="out-of-range"):
         rc.resolve_anchors({"evidence":["a.py:3"]}, root=tmp_path)
     with pytest.raises(rc.CensusError, match="unresolvable plan"):
@@ -861,14 +987,36 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert [row["role"] for row in third_audit["attempt_ledger"]] == ["final"]
 
 
-def test_branch_codex_keeps_the_single_broad_review_path(
+def test_branch_codex_runs_the_staged_census_path(
     repo_with_branch, tmp_path, monkeypatch,
 ):
     calls = []
+    web_flags = []
 
     def run(self, prompt, *args, **kwargs):
         calls.append(prompt)
-        text = "## What works\nNothing notable.\n\n=== CLASS REGISTER ===\nNONE"
+        web_flags.append(args[3])
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            value = payload(lane(lane_name))
+            for row in value["coverage"]:
+                row["evidence"] = ["repository/README.md:1"]
+            text = wire(rc.LANE_MARKER, value)
+        else:
+            debt_updates = []
+            if '"id": "legacy-register"' in prompt:
+                debt_updates = [{
+                    "id":"legacy-register", "status":"closed",
+                    "evidence":["repository/README.md:1"],
+                }]
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"census", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":debt_updates, "class_records":[],
+            })
         return Review(text=text, session_ref="branch-session", raw=text)
 
     monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
@@ -876,13 +1024,167 @@ def test_branch_codex_keeps_the_single_broad_review_path(
         "repo_path": str(repo_with_branch),
         "base_ref": "main",
         "head_ref": "feature",
-        "lineage": "single-broad-branch",
+        "lineage": "staged-branch",
         "round": 1,
         "stakes": "trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B1")
 
-    assert len(calls) == 1
-    assert prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] not in calls[0]
-    assert "CLASS-CLOSURE: 0 open, 0 closed" in result
+    assert len(calls) == 4
+    assert web_flags == [True] * 4
+    assert sum(prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in call for call in calls) == 3
+    assert all("Follow the blast radius" in call for call in calls[:3])
+    assert "STRUCTURAL-PHASE: clear" in result
     audit = json.loads(next((tmp_path / "logs").glob("B1-critique_branch-*.json")).read_text())
-    assert audit["staged_manifests"] is None
+    assert len(audit["staged_manifests"]) == 3
+    lineage = cc.load_lineage(
+        cc.default_state_root(), "staged-branch", stamp="B2", mode=cc.BRANCH_MODE,
+    )
+    assert len(lineage.review_state["snapshot_digest"]) == 64
+    assert lineage.review_state["snapshot_digest"] != audit["head_id"]
+    assert audit["base_id"] not in lineage.review_state["snapshot_digest"]
+
+    lineage.debt = {"round":0, "reason":"legacy register was malformed"}
+    cc.save_lineage(cc.default_state_root(), lineage)
+    calls.clear(); web_flags.clear()
+    result = handlers.critique_branch({
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"staged-branch", "round":2, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B2")
+    assert len(calls) == 4
+    assert "CONVERGENCE: NOT-BLOCKED" in result
+    migrated = cc.load_lineage(
+        cc.default_state_root(), "staged-branch", stamp="B3", mode=cc.BRANCH_MODE,
+    )
+    assert migrated.debt is None
+    assert not [d for d in migrated.review_state["debt"] if d["status"] == "open"]
+
+    subprocess.run(
+        ["git", "checkout", "-q", "-b", "moved-base", "main"],
+        cwd=repo_with_branch, check=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL":"/dev/null", "GIT_CONFIG_SYSTEM":"/dev/null"},
+    )
+    (repo_with_branch / "base-only.txt").write_text("changed base endpoint\n")
+    subprocess.run(["git", "add", "base-only.txt"], cwd=repo_with_branch, check=True)
+    subprocess.run(
+        ["git", "-c", "user.name=test", "-c", "user.email=test@example.com",
+         "-c", "commit.gpgsign=false", "commit", "-qm", "move base"],
+        cwd=repo_with_branch, check=True,
+        env={**os.environ, "GIT_CONFIG_GLOBAL":"/dev/null", "GIT_CONFIG_SYSTEM":"/dev/null"},
+    )
+    calls.clear(); web_flags.clear()
+    result = handlers.critique_branch({
+        "repo_path":str(repo_with_branch), "base_ref":"moved-base", "head_ref":"feature",
+        "lineage":"staged-branch", "round":3, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "B3")
+    assert len(calls) == 4
+    assert "CONVERGENCE: NOT-BLOCKED" in result
+
+
+def test_branch_settlement_persists_a_new_procedure_class(
+    repo_with_branch, tmp_path, monkeypatch,
+):
+    def run(self, prompt, *args, **kwargs):
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            value = payload(lane(lane_name))
+            for row in value["coverage"]:
+                row["evidence"] = ["repository/README.md:1"]
+        else:
+            value = {
+                "role":"census", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[], "class_records":[{
+                    "op":"new", "invariant":"semantic transition ownership",
+                    "severity":"MAJOR", "procedure":"inspect every transition owner",
+                }],
+            }
+        text = wire(
+            rc.LANE_MARKER if "lane" in value else rc.SETTLEMENT_MARKER, value,
+        )
+        return Review(text=text, session_ref="branch-session", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    result = handlers.critique_branch({
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"procedure-branch", "round":1, "stakes":"trusted local tool",
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "P1")
+    assert "CONVERGENCE: BLOCKED" in result
+    lineage = cc.load_lineage(
+        cc.default_state_root(), "procedure-branch", stamp="P2", mode=cc.BRANCH_MODE,
+    )
+    classes = lineage.active()
+    assert len(classes) == 1
+    assert classes[0].procedure == "inspect every transition owner"
+    assert not classes[0].mechanized
+
+
+def test_staged_replace_transfers_debt_to_successor_and_stays_in_correction(tmp_path):
+    (tmp_path / "a.py").write_text("broken\n")
+    state = rc.normalize_state({}, stakes="s", snapshot="p")
+    state["phase"] = "final"
+    lineage = cc.Lineage("replace-binding", classes={
+        "abc":cc.TrackedClass(
+            "abc", "old invariant", "MAJOR", 1, cc.CLOSED,
+            procedure="inspect old behavior",
+        ),
+    }, next_seq=2, mode=cc.BRANCH_MODE, review_state=state)
+
+    class Closure:
+        state_root = tmp_path
+        unavailable = None
+        claims_enabled = False
+        staged_settlement = None
+        register_status = None
+        _settled = False
+
+        def __init__(self):
+            self.lineage = lineage
+
+        def _blocks(self):
+            return []
+
+        def _sweep(self, only=None):
+            return None
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            findings = [finding("G1", "MAJOR")]
+            coverage = payload(lane(findings=findings))["coverage"]
+            findings[0]["evidence"] = ["repository/a.py:1"]
+            for row in coverage:
+                row["evidence"] = ["repository/a.py:1"]
+            value = {
+                "role":"final", "source_dispositions":[],
+                "assessment_dispositions":[{"assessment_id":"abc", "governing_id":"G1"}],
+                "findings":findings,
+                "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
+                "debt_updates":[], "class_records":[{
+                    "op":"replace", "class_id":"abc", "invariant":"new invariant",
+                    "severity":"MAJOR", "procedure":"inspect new behavior",
+                }],
+                "coverage":coverage,
+                "class_assessments":[{
+                    "class_id":"abc", "verdict":"violated",
+                    "evidence":["repository/a.py:1"],
+                    "finding_id":"G1",
+                }],
+            }
+            text = wire(rc.SETTLEMENT_MARKER, value)
+            return Review(text=text, session_ref="s", raw=text)
+
+    closure = Closure()
+    _, trailer, _ = handlers._staged_structural_review(
+        engine=Engine(), cwd=tmp_path, model="m", effort="high", mode=cc.BRANCH_MODE,
+        body="artifact", closure=closure, stakes="s", snapshot="p", round_no=2,
+        on_progress=None,
+    )
+    successor = lineage.classes["abc"].superseded_by
+    assert successor
+    assert lineage.review_state["debt"][0]["class_ids"] == [successor]
+    assert lineage.review_state["phase"] == "correction"
+    assert "STRUCTURAL-PHASE: correction" in trailer


### PR DESCRIPTION
## Outcome
- activate the existing census/correction/cold-final lifecycle for tracked branch reviews
- preserve full code-review investigation and warranted web search while using structured staged settlement
- bind phase identity to full base/head IDs and the complete packet
- preserve legacy register debt, actionable open debt, class mechanism conversions, and replacement debt ownership
- keep all existing staged plan-review behavior and improve its open-debt rendering

## Evidence
- representative branch trials are documented honestly: stronger controlled coverage, not a guaranteed calls/tokens reduction
- full local suite: 733 passed
- real Codex CODE review: 9 rounds, 12 provider attempts, 9,489,439 processed input tokens, 82,961 output tokens
- final: STRUCTURAL-PHASE clear; STRUCTURAL-DEBT 0 blocking open; CONVERGENCE NOT-BLOCKED
- one advisory MINOR remains recorded: a current advisory finding may be omitted if its model-local finding ID collides with historical debt; it does not affect blocking debt or computed convergence

## Frozen stakes
Trusted single operator/OS and local MCP operation; repository/model bytes untrusted data. False clearance, lost durable debt, incorrect phase transitions, and skipped broad census/final coverage are material. Hostile local races, compromised OS/provider, multi-tenancy, security hardening, claim-pipeline redesign, and unrelated refactors are excluded.