### PR TITLE
Restore staged class closure semantics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -37,6 +37,14 @@ finding and every governing finding referenced by a violated class assessment, i
 computed blocking-debt count; do not weaken the validator or inflate severity to reconcile a
 prompt mismatch.
 
+Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
+finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing
+active class. Bind each new class record to one finding, apply it through the canonical class engine,
+and render `CLASS-REGISTER` plus `CLASS-CLOSURE` with canonical IDs and blocking detail alongside the
+single staged structural verdict. Concrete structural debt is not a substitute for class closure.
+When lineage state is unavailable or persistence is ambiguous, render both class fields but use
+`CLASS-CLOSURE: STATE-UNAVAILABLE`; never present unconfirmed in-memory counts as durable state.
+
 ## Classes are architectural hypotheses
 
 An open class is not a patch instruction. Triage all open/reopened classes together: concrete

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -38,3 +38,7 @@
   through the shared inert Git launcher so missing promised objects cannot lazy-fetch;
 - require claim closure, class closure, real acceptance, updated docs, and a governing computed
   `CONVERGENCE: NOT-BLOCKED` before delivery.
+- preserve class closure on staged plan and branch reviews: explicitly disposition every governing
+  finding as one-off/new/existing, bind every new record, use the canonical class engine, and expose
+  `CLASS-REGISTER` and `CLASS-CLOSURE`; structural debt alone is not feature parity.
+  Ambiguous persistence uses `CLASS-CLOSURE: STATE-UNAVAILABLE`, not unconfirmed class counts.

--- a/README.md
+++ b/README.md
@@ -195,8 +195,12 @@ the claim and its citation, never the previous reviewer's prose.
 invariant, several sites. Class closure makes the class itself a tracked object
 that survives the round.
 
-Tracked staged plan reviews return strict staged JSON, and the server applies their class records
-atomically with concrete finding debt. Every lane finding must be named by at least one checklist
+Tracked staged plan and branch reviews return strict staged JSON, and the server applies their
+class records through the same durable class engine used by the legacy terminal register. Every
+governing finding must explicitly declare whether it is a genuine one-off, a new reusable class,
+or an occurrence of an active class. Every new class record is bound to exactly one governing
+finding; omission or an unbound record rejects the settlement instead of silently treating its
+finding as classless. Every lane finding must be named by at least one checklist
 row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
 receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
@@ -715,6 +719,9 @@ The footer carries the `session_ref` for [`rebut`](#rebut).
 Appended below a staged tracked plan or branch review:
 
 ```
+CLASS-REGISTER: staged census parsed — NEW 19ef00ab
+CLASS-CLOSURE: 1 open, 0 closed
+  19ef00ab repeated state transitions preserve their owner (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)
 STRUCTURAL-PHASE: correction
 STRUCTURAL-DEBT: 2 blocking open
 CONVERGENCE: BLOCKED — staged structural debt remains open.
@@ -722,6 +729,8 @@ CONVERGENCE: BLOCKED — staged structural debt remains open.
 
 | Line | Meaning |
 |---|---|
+| `CLASS-REGISTER` | The class operations applied by this staged settlement, including canonical IDs minted by the existing class engine |
+| `CLASS-CLOSURE` | Open/closed reusable-class counts plus blocking class detail |
 | `STRUCTURAL-PHASE: census\|correction\|final\|clear` | The next broad/targeted gate; `final` requires one fresh cold regression |
 | `STRUCTURAL-DEBT: N blocking open` | Concrete governing findings still requiring correction |
 | `CONVERGENCE: NOT-BLOCKED` | Structural debt/classes and, for plans, external claims are clear |
@@ -729,9 +738,19 @@ CONVERGENCE: BLOCKED — staged structural debt remains open.
 | `STRUCTURAL-ERROR` / `STRUCTURAL-PENDING` | A bounded format/deadline path did not produce a settled review |
 | `STATE-UNAVAILABLE` | Lineage state is unreadable, unwritable, or a previous write may not have completed. The message names the absolute path; repair or delete it, then re-run |
 
-One-shot and injected-engine trailers retain `CLASS-REGISTER`, `CLASS-CLOSURE`, match, and
-unmechanized-class detail. Staged branch class state is incorporated into `STRUCTURAL-DEBT` and the
-computed convergence line.
+`STRUCTURAL-DEBT` counts concrete governing findings only. An unbound live reusable class remains a
+first-class blocker in `CLASS-CLOSURE`; it is not duplicated into synthetic finding prose or given
+invented evidence anchors. The class trailer lists bounded path/line/text match detail and renders a
+binary recurrence as `path: binary match (line not shown)`. In that case the governing line says
+class closure remains open.
+
+One-shot, injected-engine, and successfully persisted staged tracked trailers all retain
+`CLASS-REGISTER`, `CLASS-CLOSURE`, match, and unmechanized-class detail. If lineage state cannot be
+loaded or a write may not have persisted, the staged trailer instead emits `CLASS-REGISTER` plus
+`CLASS-CLOSURE: STATE-UNAVAILABLE`; reporting in-memory counts as durable in that case would be
+misleading. Staged plan and branch reviews additionally
+bind concrete debt to the corresponding canonical class IDs and use one final structural verdict;
+the class trailer does not emit a competing convergence line.
 
 `NOT-BLOCKED` asserts only that the computed structural-debt, class, and (for verified plans)
 external-claim gates are clear. It is a review result, not a proof that the change is correct.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -121,15 +121,27 @@ assessments, frozen stakes, and current class IDs/invariants. Claim packets and 
 are omitted: their structural conclusions are already present in validated findings. Consolidation
 groups shared root causes without conducting another broad review. Its one staged JSON envelope
 contains every source-finding disposition, integrity-assessment disposition, governing finding,
-concrete-debt record, and class registration/transition in structured form. Every source finding
+concrete-debt record, explicit finding-to-class disposition, and class registration/transition in
+structured form. Every governing finding is classified exactly once as a genuine one-off, a new
+reusable class, or an occurrence of an active class. Every `new` class record is referenced by
+exactly one new-class disposition; a violated active-class assessment binds its governing finding
+to that same class. Multiple occurrences of one active class consolidate into one governing root
+finding and one violated assessment in census, correction, and final. Missing or duplicate
+dispositions, extra existing-class findings, and unbound new records reject the complete
+settlement. Every source finding
 of every severity and every integrity assessment is mapped exactly once; the governing severity
 cannot be lower than any merged source; every blocking governing finding and every governing
 finding referenced by a violated class assessment maps to exactly one open concrete-debt record,
 including advisory findings whose debt does not gate convergence. The server parses the complete envelope into the existing
 `Register`/lineage types, validates all fields, then applies finding and class state atomically. A
 missing source or assessment ID, dangling merge, missing blocking debt, unsupported class
-transition, or prose-only blocker rejects the whole envelope. The legacy terminal text class block
-remains only on unstaged one-shot paths.
+transition, or prose-only blocker rejects the whole envelope. The staged JSON is an adapter into
+the existing class engine rather than a second closure implementation. The legacy terminal text
+class block remains only on unstaged one-shot paths, but staged output still renders the canonical
+`CLASS-REGISTER` and `CLASS-CLOSURE` trailer (including minted IDs and blocking class detail) beside
+the single governing structural convergence verdict.
+If lineage loading or persistence is ambiguous, both fields remain present but class closure is
+`STATE-UNAVAILABLE`; in-memory counts are not represented as confirmed durable state.
 
 A valid census costs four model calls over two serial wall-clock phases. The bounded worst case is
 eight calls when all four replies need their one format correction. All limits use Python Unicode
@@ -166,8 +178,17 @@ not ask for unrelated novelty in unchanged material.
 Its terminal staged JSON envelope accounts for every open concrete finding as `closed|open`, with
 resolved evidence for closure, may add a correction-introduced finding, and carries structured new
 class records/transitions. The server converts those class records to the existing reusable
-invariant model only after the whole envelope validates. Missing debt or an unregistered prose
-blocker rejects the reply and gets one bounded same-session format correction.
+invariant model only after the whole envelope validates. Every newly introduced governing finding
+uses the same mandatory finding-to-class disposition contract as census. Missing debt, a missing
+class disposition, an unbound new class, or an unregistered prose
+blocker rejects the reply and gets one bounded same-session format correction. Correction does not
+reassess every active class. Consolidation merges multiple occurrences of one reusable class into
+at most one `existing_class` governing root finding per active class per settlement. Correction
+returns exactly one partial `violated` assessment for each active class with such a finding, using
+the same consolidated finding binding; it returns no assessment for other classes. Duplicate
+governing rows for one class are rejected rather than adding a second class identity. An
+already-open class needs no transition; binding new debt to a closed unmechanised class additionally
+requires `REOPEN`, and a closed mechanised class requires `REPLACE`.
 
 When correction closes all blocking finding, class, and claim debt, computed output remains blocked
 with `FINAL-REGRESSION: required`. The same round cannot declare final convergence.
@@ -201,6 +222,10 @@ Extend the existing atomically replaced lineage JSON; do not add a state store. 
 Concrete debt carries exact census findings until correction. The existing class register continues
 to carry reusable invariants; claim state continues to carry external evidence. Clearance requires
 no blocking debt in any of the three.
+An unbound live class remains first-class class debt and is rendered by `CLASS-CLOSURE`; it is not
+converted into a synthetic concrete finding. `STRUCTURAL-DEBT` therefore continues to count only
+real governing findings, while the class trailer preserves bounded path-level recurrence evidence
+using the canonical binary-safe display and the single verdict explicitly names open class closure.
 
 Transitions settle with class results in one atomic lineage write: census with blockers →
 correction; census clear → clear; correction with blockers → correction; correction clear → final;

--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -939,7 +939,8 @@ def render_exempt(lineage: Lineage) -> str | None:
 
 
 def render_trailer(lineage: Lineage, *, register_status: str,
-                   minted: Sequence[str] = (), reopened: Sequence[str] = ()) -> str:
+                   minted: Sequence[str] = (), reopened: Sequence[str] = (),
+                   include_verdict: bool = True) -> str:
     """The computed verdict. It only ever asserts the NEGATIVE: `NOT-BLOCKED` says no
     blocking class is unclosed, never that the change is correct and never the word
     `converged` — a mechanical check laundered into an approval is the failure mode
@@ -974,7 +975,16 @@ def render_trailer(lineage: Lineage, *, register_status: str,
                 for c in born_closed
             )
         )
-    if lineage.debt:
+    if not include_verdict:
+        if blocking:
+            for c in sorted(blocking, key=lambda c: (c.first_round, c.class_id)):
+                how = (f"mechanized: {len(c.matches)} match(es)" if c.mechanized
+                       else "unmechanized: awaiting reviewer CLOSED or RECLASSIFY")
+                if c.status in (MALFORMED, OVER_BROAD, UNCHECKED):
+                    how = f"{c.status}: {display(c.detail or 'closure not proven')}"
+                lines.append(f"  {c.class_id} {display(c.invariant)} ({how})")
+                _append_match_detail(lines, c)
+    elif lineage.debt:
         lines.append(
             f"CONVERGENCE: BLOCKED — register debt from round {lineage.debt.get('round')}: "
             f"{lineage.debt.get('reason')}"
@@ -987,6 +997,7 @@ def render_trailer(lineage: Lineage, *, register_status: str,
             if c.status in (MALFORMED, OVER_BROAD, UNCHECKED):
                 how = f"{c.status}: {display(c.detail or 'closure not proven')}"
             lines.append(f"  {c.class_id} {display(c.invariant)} ({how})")
+            _append_match_detail(lines, c)
         lines.append(
             "  Any `CONVERGED` in the review text above is VOID: it is the reviewer's "
             "judgement about new findings, not a statement about these classes."
@@ -995,3 +1006,16 @@ def render_trailer(lineage: Lineage, *, register_status: str,
         lines.append("CONVERGENCE: NOT-BLOCKED — no blocking class is unclosed; advisory "
                      "classes may remain open. Reviewer findings still govern.")
     return "\n".join(lines)
+
+
+def _append_match_detail(lines: list[str], tracked: TrackedClass) -> None:
+    """Use the same bounded, binary-safe recurrence display as reviewer context."""
+    for match in tracked.matches[:MAX_MATCHES]:
+        if match.get("binary"):
+            lines.append(f"    {display(match['path'])}: binary match (line not shown)")
+        else:
+            lines.append(
+                f"    {display(match['path'])}:{match['line']}: {display(match['text'])}"
+            )
+    if len(tracked.matches) > MAX_MATCHES:
+        lines.append(f"    … {len(tracked.matches) - MAX_MATCHES} further match(es) not shown")

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -135,6 +135,18 @@ def _staged_call(
         return retry, parsed, attempts
 
 
+def _staged_class_trailer(closure: "_ClosureRound", status: str) -> str:
+    """Render the canonical class surface on every staged result path."""
+    if closure.lineage is None:
+        return (
+            f"CLASS-REGISTER: {status}\n"
+            "CLASS-CLOSURE: STATE-UNAVAILABLE — lineage could not be loaded."
+        )
+    return cc.render_trailer(
+        closure.lineage, register_status=status, include_verdict=False,
+    )
+
+
 def _settle_staged_failure(
     closure: "_ClosureRound", *, stakes: str, snapshot: str, error: rc.CensusError,
     mode: str,
@@ -153,6 +165,7 @@ def _settle_staged_failure(
             session_ref=None, raw=message, returncode=2, error=True,
         )
         trailer = (
+            "CLASS-REGISTER: staged rejected; failure state persistence unavailable\n"
             f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
             "CONVERGENCE: BLOCKED — staged failure state may not have persisted."
         )
@@ -169,10 +182,11 @@ def _settle_staged_failure(
         ),
         session_ref=None, raw=str(error), returncode=2, error=True,
     )
-    trailer = (
+    trailer = "\n".join((
+        _staged_class_trailer(closure, closure.register_status),
         f"STRUCTURAL-PHASE: {state['phase']}\nSTRUCTURAL-ERROR: {error}\n"
-        "CONVERGENCE: BLOCKED — staged review did not settle."
-    )
+        "CONVERGENCE: BLOCKED — staged review did not settle.",
+    ))
     if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
         trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
     return review, trailer, attempts
@@ -190,6 +204,7 @@ def _state_unavailable_review(
         session_ref=None, raw=reason, returncode=2, error=True,
     )
     trailer = (
+        "CLASS-REGISTER: staged state unavailable\n"
         f"CLASS-CLOSURE: STATE-UNAVAILABLE — {reason}\n"
         "CONVERGENCE: BLOCKED — lineage state could not be used this round."
     )
@@ -214,10 +229,11 @@ def _structural_pending_review(
         session_ref=None, raw=reason,
         returncode=124, error=True,
     )
-    trailer = (
+    trailer = "\n".join((
+        _staged_class_trailer(closure, closure.register_status),
         f"STRUCTURAL-PHASE: {phase}\nSTRUCTURAL-PENDING: {reason}\n"
-        "CONVERGENCE: BLOCKED — structural review has not run."
-    )
+        "CONVERGENCE: BLOCKED — structural review has not run.",
+    ))
     if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
         trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
     return review, trailer, []
@@ -276,7 +292,9 @@ def _staged_structural_review(
         d.get("status") == "open" and d.get("severity") in rc.BLOCKING
         for d in state.get("debt", [])
     )
-    if phase == "census" and state.get("unbound_classes") and has_blocking_debt:
+    if phase == "census" and (
+        state.get("unbound_class_ids") or state.get("unbound_classes")
+    ) and has_blocking_debt:
         # State written by the earlier over-broad gate already has actionable debt;
         # resume targeted correction rather than paying for a redundant census.
         state["phase"] = phase = "correction"
@@ -475,6 +493,7 @@ def _staged_structural_review(
         settlement["class_records"], mechanized=None if mode == cc.BRANCH_MODE else False,
     )
     minted = cc.apply_register(draft, register, round_no=round_no)
+    minted_by_record = rc.minted_record_ids(settlement["class_records"], minted)
     lineage.classes, lineage.next_seq, lineage.exemptions = (
         draft.classes, draft.next_seq, draft.exemptions
     )
@@ -486,7 +505,14 @@ def _staged_structural_review(
         if cls.status == cc.SUPERSEDED and cls.superseded_by
     }
     for debt in state.get("debt", []):
-        debt["class_ids"] = [replacements.get(cid, cid) for cid in debt.get("class_ids", [])]
+        debt.setdefault("class_ids", []).extend(
+            minted_by_record[index] for index in debt.pop("class_record_indexes", [])
+        )
+        if debt.get("status") == "open":
+            debt["class_ids"] = [
+                replacements.get(cid, cid) for cid in debt.get("class_ids", [])
+            ]
+        debt["class_ids"] = list(dict.fromkeys(debt["class_ids"]))
     claim_blocked = (
         mode == cc.PLAN_MODE and closure.claims_enabled
         and pc.is_blocked(lineage.claim_state)
@@ -502,22 +528,16 @@ def _staged_structural_review(
     )
     if unbound:
         state["phase"] = "correction" if has_blocking_debt else "census"
-        state["unbound_classes"] = [{
-            "class_id":c.class_id, "severity":c.severity, "summary":c.invariant,
-            "reason":(
-                f"{c.status}: {len(c.matches)} surviving match(es)"
-                if c.mechanized else f"{c.status}: unmechanized review required"
-            ),
-            "evidence":[
-                f"repository/{m.path}:{m.line}" for m in c.matches
-            ],
-            "remedy":"Re-audit this class in the broad integrity census.",
-        } for c in unbound]
+        state["unbound_class_ids"] = [c.class_id for c in unbound]
+        state.pop("unbound_classes", None)
     elif lineage.blocking() or claim_blocked:
         state["phase"] = "correction"
     lineage.review_state = state
     lineage.debt = None
     lineage.rounds += 1
+    register_status = rc.register_status(
+        settlement["class_records"], minted_by_record, phase=phase,
+    )
     try:
         cc.save_lineage(closure.state_root, lineage)
     except cc.StateUnavailable as exc:
@@ -529,6 +549,7 @@ def _staged_structural_review(
             session_ref=review.session_ref, raw=message, returncode=2, error=True,
         )
         trailer = (
+            f"CLASS-REGISTER: {register_status}; persistence unavailable\n"
             f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
             "CONVERGENCE: BLOCKED — this staged settlement may not have persisted."
         )
@@ -536,10 +557,16 @@ def _staged_structural_review(
             trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
         return failed, trailer, [a.json() for a in attempts]
     closure._settled = True
-    closure.register_status = f"staged {phase} parsed"
+    closure.register_status = register_status
     closure.staged_settlement = settlement
     review = replace(review, text=rc.render_review(settlement, state))
-    trailer = rc.trailer(state)
+    trailer = "\n".join((
+        cc.render_trailer(
+            lineage, register_status=closure.register_status, minted=minted,
+            include_verdict=False,
+        ),
+        rc.trailer(state),
+    ))
     if mode == cc.PLAN_MODE and closure.claims_enabled:
         trailer = f"{pc.render_trailer(lineage.claim_state)}\n{trailer}"
     attempts.sort(key=lambda item: item.sequence or 0)

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -340,7 +340,16 @@ is tracked but does not block convergence. If existing_debt is supplied, update 
 once; preserve it open with a concrete reason or close it with current evidence. Return only
 === REVIEW SETTLEMENT JSON === followed by
 one JSON object with: role, source_dispositions, assessment_dispositions, findings, debt,
-debt_updates, and class_records. Class record op is one of
+debt_updates, class_dispositions, and class_records. A finding is a reusable class when the
+reasoning that condemns this site or passage would condemn another occurrence; a genuinely unique
+wrong value or site is one-off. Classify every governing finding exactly once as
+{"finding_id":"G1","kind":"one_off","reason":"why it cannot recur"},
+{"finding_id":"G1","kind":"new_class","record_index":0}, or
+{"finding_id":"G1","kind":"existing_class","class_id":"active-id"}. Every new class record
+must be referenced by exactly one new_class disposition. A violated existing-class assessment must
+disposition its governing finding to that same existing class. Consolidate same-class occurrences into one governing
+finding in census as well as correction; every existing_class finding has exactly one matching
+violated assessment and assessment disposition. Class record op is one of
 new, close, reopen, reclassify, replace. Use replace as one atomic predecessor-to-open-successor
 operation. A branch new/replace record has op, invariant, severity and exactly one of
 pattern+pathspec or procedure; a plan record has procedure. A replace additionally has class_id.
@@ -351,7 +360,8 @@ source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
 debt=[{"id":"D1","finding_id":"G1","status":"open"}];
-debt_updates=[]; class_records=[]. A violated assessment must map to the same governing finding as
+debt_updates=[]; class_dispositions=[{"finding_id":"G1","kind":"one_off","reason":"unique site"}];
+class_records=[]. A violated assessment must map to the same governing finding as
 its cited lane finding; a satisfied assessment maps to null. Do not emit prose."""
 
 
@@ -359,15 +369,24 @@ STAGED_FOLLOWUP_INSTRUCTIONS = """Perform the staged structural role named in th
 is targeted to every open debt item and effects of its repair. Final is a fresh cold whole-artifact
 review using the complete checklist and every active class. Return only === REVIEW SETTLEMENT JSON
 followed by one JSON object with role, source_dispositions, assessment_dispositions, findings,
-debt, debt_updates, class_records and, for final, coverage plus class_assessments. Account for every
-supplied open debt exactly once. Final must include all nine checklist IDs and assess every active class
+debt, debt_updates, class_dispositions, class_records and class_assessments; final also has coverage.
+Account for every
+governing finding through class_dispositions using the same one_off, new_class, or existing_class
+shapes as census; omission is invalid. Account for every supplied open debt exactly once. Final
+must include all nine checklist IDs and assess every active class
 exactly once; a violated class creates a finding and open debt. Use the same exact row shapes as the
 census settlement. A closed debt update is
 {"id":"D1","status":"closed","evidence":["path:1"]}; an open debt update is
 {"id":"D1","status":"open","evidence":["path:1"],"reason":"exact remaining defect"}.
 The open reason must state the concrete unresolved condition so the operator can repair it directly.
-Correction returns empty source/assessment dispositions. Final returns empty source dispositions
-and one assessment disposition per class. The task's checklist array is governing. The exact
+Correction returns empty source dispositions. Consolidate all occurrences of the same reusable
+class into at most one existing_class governing finding per active class per settlement. For each
+active class with that one governing finding, class_assessments and assessment_dispositions contain
+exactly one violated row; they contain no other classes. The assessment finding_id and disposition
+governing_id both name the consolidated finding.
+Final returns empty source dispositions and one assessment disposition per active class. A closed
+unmechanized class also requires reopen and a closed mechanized class requires replace. The task's
+checklist array is governing. The exact
 final-only fields are "coverage":[{"id":"artifact-complete","status":"covered|finding|not_applicable",
 "summary":"why","evidence":["path:line"],"finding_ids":[]}],"class_assessments":[{
 "class_id":"id","verdict":"satisfied|violated","evidence":["path:line"],"finding_id":null}].
@@ -391,7 +410,11 @@ STAGED_SETTLEMENT_RETRY_GUIDANCE = (
     "debt is tracked but does not block convergence. Finding rows have exactly "
     "id,severity,summary,evidence,remedy (never class_id). Debt rows have exactly "
     "id,finding_id,status. Closed debt updates have exactly id,status,evidence; open updates "
-    "also require reason. Class records are "
+    "also require reason. Every governing finding has exactly one class_dispositions row: "
+    "one_off adds reason, new_class adds record_index, existing_class adds class_id. Every new "
+    "class record is referenced once. Correction consolidates same-class occurrences into one "
+    "governing finding; each existing_class finding also needs one matching violated "
+    "class_assessments row and assessment_dispositions row. Class records are "
     "operations: close/reopen have only op,class_id; reclassify adds severity; new/replace use "
     "the exact invariant and severity plus procedure or pattern/pathspec as allowed by the mode "
     "and predecessor mechanism. A violated closed mechanized class uses replace, not reopen. "

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -196,6 +196,27 @@ def parse_settlement(
         assessment_findings = {
             a["class_id"]: a["finding_id"] for a in parsed_final["class_assessments"]
         }
+    elif role == "correction":
+        # Correction remains targeted: it assesses only active classes claimed by a
+        # newly introduced existing_class finding, not every active class as final does.
+        correction_assessments = _list(obj, "class_assessments")
+        seen_correction_classes: set[str] = set()
+        for row in correction_assessments:
+            _exact(row, {"class_id", "verdict", "evidence", "finding_id"}, "class assessment")
+            cid = row.get("class_id")
+            if (
+                not isinstance(cid, str) or cid in seen_correction_classes
+                or class_states is None or cid not in class_states
+            ):
+                raise CensusError(f"unexpected or duplicate correction class assessment {cid!r}")
+            seen_correction_classes.add(cid)
+            if row.get("verdict") != "violated":
+                raise CensusError("correction class assessment must be violated")
+            _anchors(row.get("evidence"))
+            _bounded(row.get("finding_id"), 120, "class assessment finding_id")
+        assessment_ids = [row["class_id"] for row in correction_assessments]
+        assessment_verdicts = {row["class_id"]: row["verdict"] for row in correction_assessments}
+        assessment_findings = {row["class_id"]: row["finding_id"] for row in correction_assessments}
     findings = _list(obj, "findings")
     finding_ids = _unique_ids(findings, "governing finding")
     debt = _list(obj, "debt")
@@ -249,9 +270,83 @@ def parse_settlement(
             _bounded(item["reason"], MAX_SUMMARY_CHARS, "open debt reason")
     if known_debt and seen_updates != set(known_debt):
         raise CensusError("every existing debt item must be updated exactly once")
-    _list(obj, "class_records")
+    class_records = _list(obj, "class_records")
+    class_dispositions = _list(obj, "class_dispositions")
+    disposition_findings: set[str] = set()
+    referenced_new_records: set[int] = set()
+    finding_class: dict[str, str | None] = {}
+    for item in class_dispositions:
+        if not isinstance(item, dict):
+            raise CensusError("class disposition must be an object")
+        kind = item.get("kind")
+        required = {
+            "one_off":{"finding_id", "kind", "reason"},
+            "new_class":{"finding_id", "kind", "record_index"},
+            "existing_class":{"finding_id", "kind", "class_id"},
+        }.get(kind)
+        if required is None:
+            raise CensusError("invalid class disposition kind")
+        _exact(item, required, "class disposition")
+        fid = item.get("finding_id")
+        if fid not in finding_ids or fid in disposition_findings:
+            raise CensusError("unexpected or duplicate class disposition finding_id")
+        disposition_findings.add(fid)
+        if kind == "one_off":
+            _bounded(item.get("reason"), MAX_SUMMARY_CHARS, "one-off reason")
+            finding_class[fid] = None
+        elif kind == "new_class":
+            index = item.get("record_index")
+            if not isinstance(index, int) or isinstance(index, bool) or not 0 <= index < len(class_records):
+                raise CensusError("new-class disposition has invalid record_index")
+            referenced_record = class_records[index]
+            if (
+                not isinstance(referenced_record, dict)
+                or referenced_record.get("op") != "new"
+                or index in referenced_new_records
+            ):
+                raise CensusError("new-class disposition must uniquely reference a new class record")
+            referenced_new_records.add(index)
+            finding_class[fid] = f"record:{index}"
+        else:
+            cid = item.get("class_id")
+            if class_states is not None and cid not in class_states:
+                raise CensusError(f"class disposition names unknown active class {cid!r}")
+            _bounded(cid, 120, "class disposition class_id")
+            if (assessment_verdicts or {}).get(cid) == "satisfied":
+                raise CensusError(
+                    "satisfied class assessment cannot also receive an existing-class finding"
+                )
+            finding_class[fid] = cid
+    if disposition_findings != set(finding_ids):
+        raise CensusError("every governing finding needs exactly one class disposition")
+    new_record_indexes = {
+        index for index, record in enumerate(class_records)
+        if isinstance(record, dict) and record.get("op") == "new"
+    }
+    if referenced_new_records != new_record_indexes:
+        raise CensusError("every new class record must be bound to one governing finding")
+    # Keep the model-facing debt rows in their documented exact shape.  This private
+    # settlement map carries the validated binding into durable state without making
+    # callers or audit readers mistake derived class IDs for model-supplied fields.
+    obj["_finding_class_refs"] = finding_class
     disposition_by_class = {r["assessment_id"]: r["governing_id"] for r in assessment_rows}
     governing_by_source = {r["source_id"]: r["governing_id"] for r in source_rows}
+    existing_rows = [
+        item for item in class_dispositions if item.get("kind") == "existing_class"
+    ]
+    existing_bindings = {item["class_id"]: item["finding_id"] for item in existing_rows}
+    if len(existing_bindings) != len(existing_rows):
+        raise CensusError(
+            "settlement must consolidate same-class occurrences into one governing finding"
+        )
+    violated_bindings = {
+        cid: disposition_by_class.get(cid)
+        for cid, verdict in (assessment_verdicts or {}).items() if verdict == "violated"
+    }
+    if existing_bindings != violated_bindings:
+        raise CensusError(
+            "every existing-class finding needs one matching violated assessment"
+        )
     operation_by_class: dict[str, str] = {}
     for record in obj["class_records"]:
         cid = record.get("class_id") if isinstance(record, dict) else None
@@ -268,6 +363,17 @@ def parse_settlement(
                     raise CensusError("invalid class severity")
                 if prior_severity and rank[replacement_severity] < rank[prior_severity]:
                     raise CensusError("staged settlement cannot downgrade an active class")
+    for item in class_dispositions:
+        if item.get("kind") != "existing_class" or class_states is None:
+            continue
+        cid = item["class_id"]
+        status, mechanized, _ = class_states[cid]
+        if status == cc.CLOSED and (assessment_verdicts or {}).get(cid) != "violated":
+            allowed = {"replace"} if mechanized else {"reopen", "replace"}
+            if operation_by_class.get(cid) not in allowed:
+                raise CensusError(
+                    "finding bound to a closed class must reopen or replace that class"
+                )
     for cid, verdict in (assessment_verdicts or {}).items():
         target = disposition_by_class.get(cid)
         if verdict == "violated" and target is None:
@@ -276,7 +382,9 @@ def parse_settlement(
             raise CensusError("satisfied class assessment cannot map to a finding")
         cited = (assessment_findings or {}).get(cid)
         if verdict == "violated" and assessment_findings is not None:
-            expected = governing_by_source.get(cited, cited if role == "final" else None)
+            expected = governing_by_source.get(
+                cited, cited if role in {"correction", "final"} else None,
+            )
             if expected is None or target != expected:
                 raise CensusError(
                     "violated class disposition must follow its cited finding"
@@ -287,6 +395,8 @@ def parse_settlement(
             ]
             if len(matches) != 1:
                 raise CensusError("every violated class needs exactly one open debt record")
+            if finding_class.get(target) != cid:
+                raise CensusError("violated class finding must disposition to that existing class")
         if class_states and cid in class_states:
             status, mechanized, prior_severity = class_states[cid]
             op = operation_by_class.get(cid)
@@ -312,6 +422,35 @@ def parse_settlement(
     if class_mechanized is not None:
         register_from_records(obj["class_records"], mechanized=class_mechanized)
     return obj
+
+
+def minted_record_ids(
+    records: Sequence[dict[str, Any]], minted: Sequence[str],
+) -> dict[int, str]:
+    """Map staged record positions to IDs minted by the canonical class engine."""
+    indexes = [i for i, row in enumerate(records) if row.get("op") == "replace"]
+    indexes.extend(i for i, row in enumerate(records) if row.get("op") == "new")
+    if len(indexes) != len(minted):
+        raise CensusError("minted class count does not match class records")
+    return dict(zip(indexes, minted, strict=True))
+
+
+def register_status(
+    records: Sequence[dict[str, Any]], minted_by_record: dict[int, str], *, phase: str,
+) -> str:
+    operations: list[str] = []
+    for index, record in enumerate(records):
+        op = record.get("op")
+        if op == "new":
+            operations.append(f"NEW {minted_by_record[index]}")
+        elif op == "replace":
+            operations.append(
+                f"REPLACE {record.get('class_id')} -> {minted_by_record[index]}"
+            )
+        elif op in {"close", "reopen", "reclassify"}:
+            operations.append(f"{op.upper()} {record.get('class_id')}")
+    detail = ", ".join(operations) if operations else "NONE"
+    return f"staged {phase} parsed — {detail}"
 
 
 def register_from_records(
@@ -403,6 +542,14 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
             for assessment in settlement.get("assessment_dispositions", [])
             if assessment["governing_id"] == item["finding_id"]
         ]
+        class_ref = settlement.get("_finding_class_refs", {}).get(item["finding_id"])
+        if class_ref and not class_ref.startswith("record:"):
+            row["class_ids"].append(class_ref)
+        row["class_ids"] = list(dict.fromkeys(row["class_ids"]))
+        row["class_record_indexes"] = (
+            [int(class_ref.split(":", 1)[1])]
+            if class_ref and class_ref.startswith("record:") else []
+        )
         row["first_round"] = round_no; row["last_round"] = round_no
         old[row["id"]] = row
     active = [d for d in old.values() if d.get("status") == "open" and d.get("severity") in BLOCKING]
@@ -411,6 +558,7 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
     out.pop("format_debt", None)
     out.pop("unbound_classes", None)
+    out.pop("unbound_class_ids", None)
     return out
 
 
@@ -421,6 +569,8 @@ def trailer(state: dict[str, Any]) -> str:
     if state.get("format_debt"):
         lines.append(f"STRUCTURAL-ERROR: {state['format_debt']}")
         lines.append("CONVERGENCE: BLOCKED — staged format debt remains open.")
+    elif state.get("unbound_class_ids"):
+        lines.append("CONVERGENCE: BLOCKED — class closure remains open.")
     elif phase == "final":
         lines.append("FINAL-REGRESSION: required")
         lines.append("CONVERGENCE: BLOCKED — cold final regression is required.")
@@ -448,7 +598,6 @@ def render_review(settlement: dict[str, Any], state: dict[str, Any] | None = Non
             consumed.add(fid)
         rendered.extend(row for fid, row in current.items() if fid not in consumed)
         findings = rendered
-        findings.extend(state.get("unbound_classes", []))
 
     def rows(items: list[dict[str, Any]]) -> str:
         if not items:
@@ -456,6 +605,7 @@ def render_review(settlement: dict[str, Any], state: dict[str, Any] | None = Non
         return "\n".join(
             f"- [{f['severity']}] {f['summary']}"
             + (f" — remains open: {f['reason']}" if f.get("reason") else "")
+            + (f" [classes: {', '.join(f['class_ids'])}]" if f.get("class_ids") else "")
             + f" ({', '.join(f['evidence'])})"
             for f in items
         )

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1501,7 +1501,7 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
             text = handlers.rc.SETTLEMENT_MARKER + "\n" + json.dumps({
                 "role": "census", "source_dispositions": [],
                 "assessment_dispositions": [], "findings": [], "debt": [],
-                "debt_updates": [], "class_records": [],
+                "debt_updates": [], "class_dispositions": [], "class_records": [],
             })
         return Review(text=text, session_ref="structural", raw=text)
 

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -48,7 +48,11 @@ def settlement(**overrides):
         "assessment_dispositions": [],
         "findings": [finding("C1")],
         "debt": [{"id": "D1", "finding_id": "C1", "status": "open"}],
-        "debt_updates": [], "class_records": [],
+        "debt_updates": [],
+        "class_dispositions": [{
+            "finding_id":"C1", "kind":"one_off", "reason":"unique fixture site",
+        }],
+        "class_records": [],
     }
     value.update(overrides)
     return rc.SETTLEMENT_MARKER + "\n" + json.dumps(value)
@@ -110,6 +114,145 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
         rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
 
 
+def test_settlement_requires_an_explicit_class_disposition_for_every_finding():
+    with pytest.raises(rc.CensusError, match="every governing finding needs exactly one"):
+        rc.parse_settlement(
+            settlement(class_dispositions=[]), source_ids=["domain-1"], assessment_ids=[],
+        )
+
+    value = payload(settlement())
+    value.update(
+        class_dispositions=[{"finding_id":"C1", "kind":"new_class", "record_index":0}],
+        class_records=[{
+            "op":"new", "invariant":"all repeated sites obey the same rule",
+            "severity":"MAJOR", "procedure":"inspect every repeated site",
+        }],
+    )
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"], assessment_ids=[],
+        class_mechanized=False,
+    )
+    assert parsed["_finding_class_refs"] == {"C1":"record:0"}
+
+    value["class_dispositions"] = [{
+        "finding_id":"C1", "kind":"one_off", "reason":"incorrectly declared unique",
+    }]
+    with pytest.raises(rc.CensusError, match="every new class record must be bound"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=["domain-1"], assessment_ids=[],
+        )
+
+
+def test_existing_class_disposition_cannot_contradict_satisfied_or_closed_state():
+    assert "at most one existing_class governing finding per active class" in (
+        prompts.STAGED_FOLLOWUP_INSTRUCTIONS
+    )
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":None}],
+        class_dispositions=[{
+            "finding_id":"C1", "kind":"existing_class", "class_id":"abc",
+        }],
+    )
+    with pytest.raises(rc.CensusError, match="satisfied class assessment"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"satisfied"},
+            class_states={"abc":(cc.CLOSED, False, "MAJOR")},
+        )
+
+def test_correction_existing_class_binding_requires_a_matching_violated_assessment():
+    value = payload(settlement())
+    value.update(
+        role="correction", source_dispositions=[],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":"C1"}],
+        class_dispositions=[{
+            "finding_id":"C1", "kind":"existing_class", "class_id":"abc",
+        }],
+        class_assessments=[{
+            "class_id":"abc", "verdict":"violated", "evidence":["a.py:1"],
+            "finding_id":"C1",
+        }],
+    )
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+        class_states={"abc":(cc.OPEN, False, "MAJOR")}, role="correction",
+    )
+    assert parsed["_finding_class_refs"] == {"C1":"abc"}
+    with pytest.raises(rc.CensusError, match="closed violated class must reopen or replace"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+            class_states={"abc":(cc.CLOSED, False, "MAJOR")}, role="correction",
+        )
+    value["class_records"] = [{"op":"reopen", "class_id":"abc"}]
+    assert rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+        class_states={"abc":(cc.CLOSED, False, "MAJOR")}, role="correction",
+    )["_finding_class_refs"] == {"C1":"abc"}
+    value["class_records"] = []
+
+    value["class_assessments"] = []
+    value["assessment_dispositions"] = []
+    with pytest.raises(rc.CensusError, match="matching violated assessment"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+            class_states={"abc":(cc.OPEN, False, "MAJOR")}, role="correction",
+        )
+
+    value = payload(settlement())
+    value.update(
+        role="correction", source_dispositions=[],
+        findings=[finding("C1"), finding("C2")],
+        debt=[
+            {"id":"D1", "finding_id":"C1", "status":"open"},
+            {"id":"D2", "finding_id":"C2", "status":"open"},
+        ],
+        class_dispositions=[
+            {"finding_id":"C1", "kind":"existing_class", "class_id":"abc"},
+            {"finding_id":"C2", "kind":"existing_class", "class_id":"abc"},
+        ],
+        class_assessments=[{
+            "class_id":"abc", "verdict":"violated", "evidence":["a.py:1"],
+            "finding_id":"C1",
+        }],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":"C1"}],
+    )
+    with pytest.raises(rc.CensusError, match="consolidate same-class occurrences"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
+            class_states={"abc":(cc.OPEN, False, "MAJOR")}, role="correction",
+        )
+
+
+def test_census_rejects_an_extra_existing_class_finding_without_an_assessment():
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[
+            {"source_id":"integrity:F1", "governing_id":"C1"},
+            {"source_id":"domain:F2", "governing_id":"C2"},
+        ],
+        findings=[finding("C1"), finding("C2")],
+        debt=[
+            {"id":"D1", "finding_id":"C1", "status":"open"},
+            {"id":"D2", "finding_id":"C2", "status":"open"},
+        ],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":"C1"}],
+        class_dispositions=[
+            {"finding_id":"C1", "kind":"existing_class", "class_id":"abc"},
+            {"finding_id":"C2", "kind":"existing_class", "class_id":"abc"},
+        ],
+    )
+    with pytest.raises(rc.CensusError, match="consolidate same-class occurrences"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value),
+            source_ids=["integrity:F1", "domain:F2"], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"violated"},
+            assessment_findings={"abc":"integrity:F1"},
+            class_states={"abc":(cc.OPEN, False, "MAJOR")}, role="census",
+        )
+
+
 def test_settlement_accepts_only_the_observed_decorative_marker_variant():
     short = rc.SETTLEMENT_MARKER.removesuffix(" ===")
     text = settlement().replace(rc.SETTLEMENT_MARKER, short, 1)
@@ -157,6 +300,7 @@ def test_settlement_cannot_downgrade_source_and_derives_debt_fields():
 def test_correction_cannot_clear_without_updating_every_existing_debt():
     value = payload(settlement())
     value.update(role="correction", source_dispositions=[], findings=[], debt=[], debt_updates=[])
+    value.update(class_dispositions=[], class_assessments=[])
     with pytest.raises(rc.CensusError, match="every existing debt"):
         rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=[],
                             known_debt=["D1"], role="correction")
@@ -168,6 +312,7 @@ def test_open_debt_update_requires_and_renders_an_actionable_reason():
         role="correction", source_dispositions=[], assessment_dispositions=[],
         findings=[], debt=[],
         debt_updates=[{"id":"D1", "status":"open", "evidence":["a.py:2"]}],
+        class_dispositions=[], class_assessments=[],
     )
     with pytest.raises(rc.CensusError, match="debt update fields"):
         rc.parse_settlement(
@@ -203,13 +348,6 @@ def test_open_debt_update_requires_and_renders_an_actionable_reason():
     )
     assert "current advisory finding" in rendered
     assert "validate the selected head" in rendered
-    rendered = rc.render_review({"findings":[]}, {"debt":[], "unbound_classes":[{
-        "class_id":"abc", "severity":"MAJOR", "summary":"exact live owner",
-        "reason":"OPEN: unmechanized review required", "evidence":[],
-        "remedy":"Re-audit this class in the broad integrity census.",
-    }]})
-    assert "exact live owner" in rendered
-    assert "unmechanized review required" in rendered
     rendered = rc.render_review({"findings":[]}, {"debt":[
         {"id":"D1", "finding_id":"F1", "status":"open", "severity":"MAJOR",
          "summary":"first durable debt", "evidence":[], "remedy":"fix first"},
@@ -226,6 +364,7 @@ def test_correction_cannot_downgrade_a_class_or_reuse_durable_debt():
         role="correction", source_dispositions=[], assessment_dispositions=[],
         findings=[], debt=[],
         debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}],
+        class_dispositions=[], class_assessments=[],
         class_records=[{"op":"reclassify","class_id":"abc","severity":"MINOR"}],
     )
     with pytest.raises(rc.CensusError, match="cannot downgrade"):
@@ -255,6 +394,7 @@ def test_every_staged_role_rejects_a_satisfied_class_downgrade():
     value.update(
         source_dispositions=[], findings=[], debt=[],
         assessment_dispositions=[{"assessment_id":"abc", "governing_id":None}],
+        class_dispositions=[],
         class_records=[{"op":"reclassify", "class_id":"abc", "severity":"MINOR"}],
     )
     with pytest.raises(rc.CensusError, match="cannot downgrade"):
@@ -332,6 +472,7 @@ def test_branch_records_allow_procedure_classes_and_reject_mechanized_reopen():
     value.update(
         source_dispositions=[],
         assessment_dispositions=[{"assessment_id":"abc", "governing_id":"C1"}],
+        class_dispositions=[{"finding_id":"C1", "kind":"existing_class", "class_id":"abc"}],
         class_records=[{"op":"reopen", "class_id":"abc"}],
     )
     with pytest.raises(rc.CensusError, match="mechanized class must replace"):
@@ -349,7 +490,8 @@ def test_correction_requires_a_final_before_clearance():
     assert state["phase"] == "correction"
     close = payload(settlement())
     close.update(role="correction", source_dispositions=[], findings=[], debt=[],
-                 debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}])
+                 debt_updates=[{"id":"D1","status":"closed","evidence":["a.py:2"]}],
+                 class_dispositions=[], class_assessments=[])
     state = rc.settle_state(
         state, rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, close), source_ids=[], assessment_ids=[],
                                    known_debt=["D1"], role="correction"),
@@ -363,6 +505,7 @@ def test_final_requires_complete_checklist_and_class_verdict():
     value = payload(settlement())
     value.update(role="final", source_dispositions=[], findings=[], debt=[], debt_updates=[],
                  assessment_dispositions=[{"assessment_id":"abc","governing_id":None}],
+                 class_dispositions=[],
                  class_assessments=[], coverage=[])
     with pytest.raises(rc.CensusError, match="every checklist"):
         rc.parse_settlement(wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"], role="final")
@@ -462,12 +605,43 @@ def test_staged_retry_repeats_exact_shapes_after_multirow_schema_drift(tmp_path)
     assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
 
 
+def test_malformed_referenced_new_class_row_stays_in_bounded_format_retry(tmp_path):
+    invalid = payload(settlement())
+    invalid.update(
+        class_dispositions=[{"finding_id":"C1", "kind":"new_class", "record_index":0}],
+        class_records=["not an object"],
+    )
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, invalid)
+            return Review(text=text, session_ref="s", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert "new-class disposition must uniquely reference" in prompt
+            return Review(text=settlement(), session_ref=session_ref, raw=settlement())
+
+    _, parsed, attempts = handlers._staged_call(
+        role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+        model="m", effort="high", timeout=10, on_progress=None,
+        retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+        parser=lambda text: rc.parse_settlement(
+            text, source_ids=["domain-1"], assessment_ids=[],
+        ),
+    )
+    assert parsed["class_dispositions"][0]["kind"] == "one_off"
+    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+
+
 def test_staged_retry_names_advisory_class_debt_invariant(tmp_path):
     invalid = payload(settlement())
     invalid.update(
         source_dispositions=[{"source_id":"integrity:F1","governing_id":"G1"}],
         findings=[finding("G1", "OUT-OF-SCOPE")], debt=[],
         assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
+        class_dispositions=[{"finding_id":"G1", "kind":"existing_class", "class_id":"abc"}],
     )
     repaired = dict(invalid)
     repaired["debt"] = [{"id":"D1","finding_id":"G1","status":"open"}]
@@ -504,6 +678,7 @@ def test_violated_class_cannot_be_replaced_at_lower_severity():
     value.update(
         source_dispositions=[], findings=[], debt=[],
         assessment_dispositions=[{"assessment_id":"abc","governing_id":"C1"}],
+        class_dispositions=[{"finding_id":"C1", "kind":"existing_class", "class_id":"abc"}],
         class_records=[{
             "op":"replace", "class_id":"abc", "invariant":"narrower invariant",
             "severity":"MINOR", "procedure":"inspect it",
@@ -526,6 +701,7 @@ def test_violated_class_mapping_follows_cited_finding_and_reopens_atomically():
         assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
         findings=[finding("G1", "BLOCKER")],
         debt=[{"id":"D1", "finding_id":"G1", "status":"open"}],
+        class_dispositions=[{"finding_id":"G1", "kind":"existing_class", "class_id":"abc"}],
         debt_updates=[], class_records=[{"op":"reopen", "class_id":"abc"}],
         coverage=payload(lane(findings=[finding("G1", "BLOCKER")]))["coverage"],
         class_assessments=[{
@@ -540,9 +716,12 @@ def test_violated_class_mapping_follows_cited_finding_and_reopens_atomically():
     assert parsed["class_records"] == [{"op":"reopen", "class_id":"abc"}]
     value["assessment_dispositions"][0]["governing_id"] = "G2"
     value["findings"].append(finding("G2", "BLOCKER"))
+    value["class_dispositions"].append({
+        "finding_id":"G2", "kind":"one_off", "reason":"unique second fixture",
+    })
     value["debt"].append({"id":"D2", "finding_id":"G2", "status":"open"})
     value["coverage"][0]["finding_ids"].append("G2")
-    with pytest.raises(rc.CensusError, match="follow its cited finding"):
+    with pytest.raises(rc.CensusError, match="matching violated assessment"):
         rc.parse_settlement(
             wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
             class_states={"abc": (cc.CLOSED, False, "BLOCKER")}, role="final",
@@ -558,6 +737,7 @@ def test_violated_advisory_class_still_requires_concrete_debt():
         source_dispositions=[{"source_id":"integrity:F1","governing_id":"G1"}],
         findings=[finding("G1", "MINOR")], debt=[],
         assessment_dispositions=[{"assessment_id":"abc","governing_id":"G1"}],
+        class_dispositions=[{"finding_id":"G1", "kind":"existing_class", "class_id":"abc"}],
         class_records=[{"op":"reopen", "class_id":"abc"}],
     )
     with pytest.raises(rc.CensusError, match="violated class needs exactly one open debt"):
@@ -653,6 +833,8 @@ def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_pa
     closure.release()
     assert review.error and attempts == []
     assert_five_headings(review.text)
+    assert "CLASS-REGISTER: structural pending" in trailer
+    assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
     assert "STRUCTURAL-PENDING" in trailer and "CONVERGENCE: BLOCKED" in trailer
     assert not (cc.lineage_dir(tmp_path) / "pending-plan.pending").exists()
 
@@ -666,7 +848,24 @@ def test_state_unavailable_result_has_five_headings(tmp_path):
         closure, mode=cc.PLAN_MODE, claim_state=pc.empty_state(),
     )
     assert review.error and attempts == [] and "STATE-UNAVAILABLE" in trailer
+    assert "CLASS-REGISTER: staged state unavailable" in trailer
     assert_five_headings(review.text)
+
+
+def test_staged_format_failure_retains_canonical_class_trailer(tmp_path):
+    closure = handlers._PlanClassClosure(
+        "format-failure", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    review, trailer, attempts = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=rc.CensusError("bad settlement"),
+        mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert review.error and attempts == []
+    assert "CLASS-REGISTER: staged rejected: bad settlement" in trailer
+    assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
+    assert "STRUCTURAL-ERROR: bad settlement" in trailer
 
 
 def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
@@ -694,7 +893,8 @@ def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
             text = wire(rc.SETTLEMENT_MARKER, {
                 "role":"correction", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                    "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                    "class_dispositions":[], "class_assessments":[],
                 "class_records":[],
             })
             return Review(text=text, session_ref="s", raw=text)
@@ -711,6 +911,7 @@ def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
     closure.release()
     assert review.error and [row["role"] for row in attempts] == ["correction"]
     assert_five_headings(review.text)
+    assert "CLASS-REGISTER:" in trailer
     assert "STATE-UNAVAILABLE" in trailer
     assert (cc.lineage_dir(tmp_path) / "save-fail.pending").exists()
     cc.clear_latch(tmp_path, "save-fail")
@@ -733,6 +934,7 @@ def test_staged_format_debt_save_failure_also_retains_latch(tmp_path, monkeypatc
     closure.release()
     assert review.error and attempts == []
     assert_five_headings(review.text)
+    assert "CLASS-REGISTER: staged rejected; failure state persistence unavailable" in trailer
     assert "STATE-UNAVAILABLE" in trailer
     assert (cc.lineage_dir(tmp_path) / "format-save-fail.pending").exists()
     cc.clear_latch(tmp_path, "format-save-fail")
@@ -753,7 +955,7 @@ def test_structural_only_tracked_plan_still_uses_staged_census(repo, tmp_path, m
             text = rc.SETTLEMENT_MARKER + "\n" + json.dumps({
                 "role":"census", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[], "class_records":[],
+                "debt_updates":[], "class_dispositions":[], "class_records":[],
             })
         return Review(text=text, session_ref="s", raw=text)
 
@@ -806,7 +1008,7 @@ def test_disabled_claims_do_not_gate_or_render_stale_claim_debt(tmp_path):
                 text = wire(rc.SETTLEMENT_MARKER, {
                     "role":"census", "source_dispositions":[],
                     "assessment_dispositions":[], "findings":[], "debt":[],
-                    "debt_updates":[], "class_records":[],
+                    "debt_updates":[], "class_dispositions":[], "class_records":[],
                 })
             return Review(text=text, session_ref="s", raw=text)
 
@@ -917,13 +1119,18 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
                     "evidence":["plan:1"], "remedy":"edit the plan",
                 }],
                 "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
-                "debt_updates":[], "class_records":[],
+                "debt_updates":[],
+                "class_dispositions":[{
+                    "finding_id":"G1", "kind":"one_off", "reason":"unique plan edit",
+                }],
+                "class_records":[],
             })
         elif '"role": "correction"' in prompt:
             text = wire(rc.SETTLEMENT_MARKER, {
                 "role":"correction", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                    "debt_updates":[{"id":"D1","status":"closed","evidence":["plan:1"]}],
+                    "class_dispositions":[], "class_assessments":[],
                 "class_records":[],
             })
         else:
@@ -931,7 +1138,7 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
             text = wire(rc.SETTLEMENT_MARKER, {
                 "role":"final", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[], "class_records":[],
+                "debt_updates":[], "class_dispositions":[], "class_records":[],
                 "coverage": payload(lane())["coverage"], "class_assessments":[],
             })
         return Review(text=text, session_ref=f"s{len(calls)}", raw=text)
@@ -956,6 +1163,8 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     )
 
     assert "STRUCTURAL-PHASE: correction" in first
+    assert "CLASS-REGISTER: staged census parsed" in first
+    assert "CLASS-CLOSURE: 0 open, 0 closed" in first
     assert "STRUCTURAL-PHASE: final" in second
     assert "STRUCTURAL-PHASE: clear" in third
     assert "CONVERGENCE: NOT-BLOCKED" in third
@@ -1015,7 +1224,7 @@ def test_branch_codex_runs_the_staged_census_path(
             text = wire(rc.SETTLEMENT_MARKER, {
                 "role":"census", "source_dispositions":[],
                 "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":debt_updates, "class_records":[],
+                "debt_updates":debt_updates, "class_dispositions":[], "class_records":[],
             })
         return Review(text=text, session_ref="branch-session", raw=text)
 
@@ -1095,8 +1304,19 @@ def test_branch_settlement_persists_a_new_procedure_class(
         else:
             value = {
                 "role":"census", "source_dispositions":[],
-                "assessment_dispositions":[], "findings":[], "debt":[],
-                "debt_updates":[], "class_records":[{
+                "assessment_dispositions":[],
+                "findings":[{
+                    "id":"G1", "severity":"MAJOR",
+                    "summary":"transition ownership is inconsistent",
+                    "evidence":["repository/README.md:1"],
+                    "remedy":"make transition ownership consistent",
+                }],
+                "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
+                "debt_updates":[],
+                "class_dispositions":[{
+                    "finding_id":"G1", "kind":"new_class", "record_index":0,
+                }],
+                "class_records":[{
                     "op":"new", "invariant":"semantic transition ownership",
                     "severity":"MAJOR", "procedure":"inspect every transition owner",
                 }],
@@ -1112,6 +1332,8 @@ def test_branch_settlement_persists_a_new_procedure_class(
         "lineage":"procedure-branch", "round":1, "stakes":"trusted local tool",
     }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda: "P1")
     assert "CONVERGENCE: BLOCKED" in result
+    assert "CLASS-REGISTER: staged census parsed" in result
+    assert "CLASS-CLOSURE: 1 open, 0 closed" in result
     lineage = cc.load_lineage(
         cc.default_state_root(), "procedure-branch", stamp="P2", mode=cc.BRANCH_MODE,
     )
@@ -1119,12 +1341,19 @@ def test_branch_settlement_persists_a_new_procedure_class(
     assert len(classes) == 1
     assert classes[0].procedure == "inspect every transition owner"
     assert not classes[0].mechanized
+    assert lineage.review_state["debt"][0]["class_ids"] == [classes[0].class_id]
 
 
 def test_staged_replace_transfers_debt_to_successor_and_stays_in_correction(tmp_path):
     (tmp_path / "a.py").write_text("broken\n")
     state = rc.normalize_state({}, stakes="s", snapshot="p")
     state["phase"] = "final"
+    state["debt"] = [{
+        "id":"historic", "finding_id":"historic", "status":"closed",
+        "severity":"MAJOR", "summary":"past occurrence", "evidence":["repository/a.py:1"],
+        "remedy":"already fixed", "source_ids":[], "class_ids":["abc"],
+        "first_round":1, "last_round":1,
+    }]
     lineage = cc.Lineage("replace-binding", classes={
         "abc":cc.TrackedClass(
             "abc", "old invariant", "MAJOR", 1, cc.CLOSED,
@@ -1163,7 +1392,11 @@ def test_staged_replace_transfers_debt_to_successor_and_stays_in_correction(tmp_
                 "assessment_dispositions":[{"assessment_id":"abc", "governing_id":"G1"}],
                 "findings":findings,
                 "debt":[{"id":"D1", "finding_id":"G1", "status":"open"}],
-                "debt_updates":[], "class_records":[{
+                "debt_updates":[],
+                "class_dispositions":[{
+                    "finding_id":"G1", "kind":"existing_class", "class_id":"abc",
+                }],
+                "class_records":[{
                     "op":"replace", "class_id":"abc", "invariant":"new invariant",
                     "severity":"MAJOR", "procedure":"inspect new behavior",
                 }],
@@ -1185,6 +1418,82 @@ def test_staged_replace_transfers_debt_to_successor_and_stays_in_correction(tmp_
     )
     successor = lineage.classes["abc"].superseded_by
     assert successor
-    assert lineage.review_state["debt"][0]["class_ids"] == [successor]
+    current = next(d for d in lineage.review_state["debt"] if d["id"] == "D1")
+    assert current["class_ids"] == [successor]
+    historic = next(d for d in lineage.review_state["debt"] if d["id"] == "historic")
+    assert historic["class_ids"] == ["abc"]
     assert lineage.review_state["phase"] == "correction"
     assert "STRUCTURAL-PHASE: correction" in trailer
+
+
+def test_unbound_mechanized_class_uses_match_dict_evidence_without_crashing(tmp_path):
+    (tmp_path / "a.py").write_text("BAD\n")
+    state = rc.normalize_state({}, stakes="s", snapshot="p")
+    state["phase"] = "correction"
+    state["debt"] = [{
+        "id":"D0", "finding_id":"G0", "status":"open", "severity":"MAJOR",
+        "summary":"repair another defect", "evidence":["repository/a.py:1"],
+        "remedy":"repair it", "source_ids":[], "class_ids":[],
+        "first_round":1, "last_round":1,
+    }]
+    tracked = cc.TrackedClass(
+        "abc", "no BAD tokens", "MAJOR", 1, cc.OPEN,
+        pattern="BAD", pathspec="*.py",
+        matches=(
+            {"path":"a.py", "line":1, "text":"BAD"},
+            {"path":"blob.bin", "line":0, "text":"", "binary":True},
+        ),
+    )
+    lineage = cc.Lineage(
+        "unbound-match", classes={"abc":tracked}, next_seq=2,
+        mode=cc.BRANCH_MODE, review_state=state,
+    )
+
+    class Closure:
+        state_root = tmp_path
+        unavailable = None
+        claims_enabled = False
+        staged_settlement = None
+        register_status = None
+        _settled = False
+
+        def __init__(self):
+            self.lineage = lineage
+
+        def _blocks(self):
+            return []
+
+        def _sweep(self, only=None):
+            return None
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, {
+                "role":"correction", "source_dispositions":[],
+                "assessment_dispositions":[], "findings":[], "debt":[],
+                "debt_updates":[{
+                    "id":"D0", "status":"closed", "evidence":["repository/a.py:1"],
+                }],
+                "class_dispositions":[], "class_records":[],
+                "class_assessments":[],
+            })
+            return Review(text=text, session_ref="s", raw=text)
+
+    closure = Closure()
+    review, trailer, _ = handlers._staged_structural_review(
+        engine=Engine(), cwd=tmp_path, model="m", effort="high", mode=cc.BRANCH_MODE,
+        body="artifact", closure=closure, stakes="s", snapshot="p", round_no=2,
+        on_progress=None,
+    )
+    assert not review.error
+    assert lineage.review_state["unbound_class_ids"] == ["abc"]
+    assert "abc no BAD tokens" in trailer
+    assert "2 match(es)" in trailer
+    assert "a.py:1: BAD" in trailer
+    assert "blob.bin: binary match (line not shown)" in trailer
+    assert "blob.bin:0" not in trailer
+    assert "STRUCTURAL-DEBT: 0 blocking open" in trailer
+    assert "class closure remains open" in trailer
+    assert "CONVERGENCE: BLOCKED" in trailer


### PR DESCRIPTION
## Summary
- require every staged governing finding to be dispositioned as one-off, new class, or existing class
- bind staged class records and concrete debt through the canonical class engine for both plan and branch reviews
- restore CLASS-REGISTER and CLASS-CLOSURE trailers, including failure-state and binary-safe match detail
- enforce one governing root and violated-assessment bijection consistently across census, correction, and final
- update public/operator documentation and regression coverage

## Verification
- 740 tests pass
- real Codex staged plan acceptance minted and exposed canonical class IDs
- real Codex CODE review converged under frozen proportionate stakes at cold final round 14
- final: CLASS-CLOSURE: 0 open; STRUCTURAL-DEBT: 0; CONVERGENCE: NOT-BLOCKED