### PR TITLE
Allow one census finding to violate multiple classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -39,6 +39,8 @@ prompt mismatch.
 One atomic lane finding may violate several active classes. Preserve that observation and allow
 its source disposition to fan out to one distinct governing finding per affected class; do not
 force the reviewer to split or paraphrase the source finding merely to satisfy settlement shape.
+Every target of a repeated source must be an existing-class finding backed by its own distinct
+violated assessment citing that source; repetition must not manufacture one-off or new-class debt.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -36,6 +36,9 @@ finding and every governing finding referenced by a violated class assessment, i
 `MINOR` and `OUT-OF-SCOPE`. Advisory debt is tracked but excluded from phase gating and the
 computed blocking-debt count; do not weaken the validator or inflate severity to reconcile a
 prompt mismatch.
+One atomic lane finding may violate several active classes. Preserve that observation and allow
+its source disposition to fan out to one distinct governing finding per affected class; do not
+force the reviewer to split or paraphrase the source finding merely to satisfy settlement shape.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,6 @@
   finding as one-off/new/existing, bind every new record, use the canonical class engine, and expose
   `CLASS-REGISTER` and `CLASS-CLOSURE`; structural debt alone is not feature parity.
   Ambiguous persistence uses `CLASS-CLOSURE: STATE-UNAVAILABLE`, not unconfirmed class counts.
+- preserve an atomic lane finding that violates several active classes and let its source
+  disposition fan out to one distinct governing finding per affected class; do not split the
+  observation merely to satisfy the settlement schema.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,4 +44,5 @@
   Ambiguous persistence uses `CLASS-CLOSURE: STATE-UNAVAILABLE`, not unconfirmed class counts.
 - preserve an atomic lane finding that violates several active classes and let its source
   disposition fan out to one distinct governing finding per affected class; do not split the
-  observation merely to satisfy the settlement schema.
+  observation merely to satisfy the settlement schema. Require every repeated-source target to be
+  an existing-class finding backed by its own distinct violated assessment citing that source.

--- a/README.md
+++ b/README.md
@@ -205,7 +205,9 @@ row; a `finding` row names its finding IDs and non-finding rows cannot hide one.
 receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
 If one atomic lane finding violates several active classes, census consolidation may map that source
 finding to one distinct governing finding per class. The source observation is not artificially
-split; duplicate source-to-governing pairs and omitted sources still reject the settlement.
+split: every target of a repeated source must be an existing-class finding backed by its own
+violated assessment citing that source. One-off or new-class targets, duplicate source-to-governing
+pairs, and omitted sources still reject the settlement.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -203,6 +203,9 @@ finding; omission or an unbound record rejects the settlement instead of silentl
 finding as classless. Every lane finding must be named by at least one checklist
 row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
 receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
+If one atomic lane finding violates several active classes, census consolidation may map that source
+finding to one distinct governing finding per class. The source observation is not artificially
+split; duplicate source-to-governing pairs and omitted sources still reject the settlement.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -131,7 +131,9 @@ dispositions, extra existing-class findings, and unbound new records reject the 
 settlement. Every source finding of every severity is mapped at least once and every integrity
 assessment exactly once. A single atomic source finding may fan out to distinct governing findings
 when it is an occurrence of multiple active classes; each source-to-governing pair remains unique,
-and each resulting existing-class governing finding retains its one matching violated assessment.
+and every target of that repeated source is an existing-class governing finding with its own
+matching violated assessment citing the same source. Repetition cannot manufacture one-off or new
+class debt from a single observation.
 The governing severity
 cannot be lower than any merged source; every blocking governing finding and every governing
 finding referenced by a violated class assessment maps to exactly one open concrete-debt record,

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -128,8 +128,11 @@ exactly one new-class disposition; a violated active-class assessment binds its 
 to that same class. Multiple occurrences of one active class consolidate into one governing root
 finding and one violated assessment in census, correction, and final. Missing or duplicate
 dispositions, extra existing-class findings, and unbound new records reject the complete
-settlement. Every source finding
-of every severity and every integrity assessment is mapped exactly once; the governing severity
+settlement. Every source finding of every severity is mapped at least once and every integrity
+assessment exactly once. A single atomic source finding may fan out to distinct governing findings
+when it is an occurrence of multiple active classes; each source-to-governing pair remains unique,
+and each resulting existing-class governing finding retains its one matching violated assessment.
+The governing severity
 cannot be lower than any merged source; every blocking governing finding and every governing
 finding referenced by a violated class assessment maps to exactly one open concrete-debt record,
 including advisory findings whose debt does not gate convergence. The server parses the complete envelope into the existing

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -333,9 +333,9 @@ least one coverage row."""
 
 
 STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do not conduct a new
-review. Map every source finding and class assessment exactly once. Preserve the highest severity
-of merged findings. Every blocking governing finding and every governing finding referenced by a
-violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
+review. Map every source finding at least once and every class assessment exactly once. Preserve
+the highest severity of merged findings. Every blocking governing finding and every governing
+finding referenced by a violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
 is tracked but does not block convergence. If existing_debt is supplied, update every item exactly
 once; preserve it open with a concrete reason or close it with current evidence. Return only
 === REVIEW SETTLEMENT JSON === followed by
@@ -356,7 +356,9 @@ pattern+pathspec or procedure; a plan record has procedure. A replace additional
 Close/reopen has only op and class_id; reclassify additionally has severity. A closed mechanized
 class that is violated must use replace with a corrected predicate—reopen is only for unmechanized
 classes. Use these exact row shapes:
-source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}];
+source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}]; one source_id may appear
+again with a distinct governing_id when one atomic lane finding is an occurrence of multiple active
+classes. Never split the lane finding or duplicate the same source_id/governing_id pair;
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
 debt=[{"id":"D1","finding_id":"G1","status":"open"}];

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -334,8 +334,8 @@ least one coverage row."""
 
 STAGED_CONSOLIDATION_INSTRUCTIONS = """Consolidate validated lane manifests; do not conduct a new
 review. Map every source finding at least once and every class assessment exactly once. Preserve
-the highest severity of merged findings. Every blocking governing finding and every governing
-finding referenced by a violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
+the highest severity of merged findings. Every blocking governing finding and every governing finding referenced by a
+violated class assessment needs exactly one open debt record, regardless of severity. Advisory debt
 is tracked but does not block convergence. If existing_debt is supplied, update every item exactly
 once; preserve it open with a concrete reason or close it with current evidence. Return only
 === REVIEW SETTLEMENT JSON === followed by
@@ -358,7 +358,9 @@ class that is violated must use replace with a corrected predicate—reopen is o
 classes. Use these exact row shapes:
 source_dispositions=[{"source_id":"lane:id","governing_id":"G1"}]; one source_id may appear
 again with a distinct governing_id when one atomic lane finding is an occurrence of multiple active
-classes. Never split the lane finding or duplicate the same source_id/governing_id pair;
+classes. Every target of a repeated source_id must be an existing_class finding backed by a distinct
+violated assessment that cites that source. Never split a finding into one_off or new_class targets,
+or duplicate the same source_id/governing_id pair;
 assessment_dispositions=[{"assessment_id":"class-id","governing_id":null}];
 findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],"remedy":"repair"}];
 debt=[{"id":"D1","finding_id":"G1","status":"open"}];

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -351,6 +351,20 @@ def parse_settlement(
         raise CensusError(
             "every existing-class finding needs one matching violated assessment"
         )
+    for source, targets in governing_by_source.items():
+        if len(targets) == 1:
+            continue
+        for target in targets:
+            cid = finding_class.get(target)
+            if (
+                not isinstance(cid, str)
+                or existing_bindings.get(cid) != target
+                or (assessment_verdicts or {}).get(cid) != "violated"
+                or (assessment_findings or {}).get(cid) != source
+            ):
+                raise CensusError(
+                    "source fan-out requires distinct violated existing-class findings"
+                )
     operation_by_class: dict[str, str] = {}
     for record in obj["class_records"]:
         cid = record.get("class_id") if isinstance(record, dict) else None

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -222,7 +222,9 @@ def parse_settlement(
     debt = _list(obj, "debt")
     debt_ids = _unique_ids(debt, "debt")
     source_rows = _list(obj, "source_dispositions")
-    _exact_dispositions(source_rows, source_ids, finding_ids, "source_id")
+    _exact_dispositions(
+        source_rows, source_ids, finding_ids, "source_id", allow_fanout=True,
+    )
     assessment_rows = _list(obj, "assessment_dispositions")
     _exact_dispositions(assessment_rows, assessment_ids, finding_ids, "assessment_id", allow_null=True)
     for finding in findings:
@@ -330,7 +332,9 @@ def parse_settlement(
     # callers or audit readers mistake derived class IDs for model-supplied fields.
     obj["_finding_class_refs"] = finding_class
     disposition_by_class = {r["assessment_id"]: r["governing_id"] for r in assessment_rows}
-    governing_by_source = {r["source_id"]: r["governing_id"] for r in source_rows}
+    governing_by_source: dict[str, set[str]] = {}
+    for row in source_rows:
+        governing_by_source.setdefault(row["source_id"], set()).add(row["governing_id"])
     existing_rows = [
         item for item in class_dispositions if item.get("kind") == "existing_class"
     ]
@@ -383,9 +387,9 @@ def parse_settlement(
         cited = (assessment_findings or {}).get(cid)
         if verdict == "violated" and assessment_findings is not None:
             expected = governing_by_source.get(
-                cited, cited if role in {"correction", "final"} else None,
+                cited, {cited} if role in {"correction", "final"} else set(),
             )
-            if expected is None or target != expected:
+            if target not in expected:
                 raise CensusError(
                     "violated class disposition must follow its cited finding"
                 )
@@ -739,14 +743,25 @@ def _unique_ids(rows: Sequence[Any], label: str) -> set[str]:
 
 
 def _exact_dispositions(rows: Sequence[Any], expected: Sequence[str], targets: set[str], key: str,
-                        allow_null: bool = False) -> None:
+                        allow_null: bool = False, allow_fanout: bool = False) -> None:
     seen: set[str] = set()
+    seen_pairs: set[tuple[str, str | None]] = set()
+    expected_set = set(expected)
     for row in rows:
         if not isinstance(row, dict) or set(row) != {key, "governing_id"}:
             raise CensusError(f"invalid {key} disposition")
+        source = row[key]
         target = row["governing_id"]
-        if (row[key] in seen or row[key] not in set(expected)
-                or (target not in targets and not (allow_null and target is None))):
+        pair = (source, target)
+        if (
+            source not in expected_set
+            or pair in seen_pairs
+            or (source in seen and not allow_fanout)
+            or (target not in targets and not (allow_null and target is None))
+        ):
             raise CensusError(f"invalid or duplicate {key} disposition")
-        seen.add(row[key])
-    if seen != set(expected): raise CensusError(f"every {key} must be dispositioned exactly once")
+        seen.add(source)
+        seen_pairs.add(pair)
+    if seen != expected_set:
+        suffix = "at least once" if allow_fanout else "exactly once"
+        raise CensusError(f"every {key} must be dispositioned {suffix}")

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -253,7 +253,7 @@ def test_census_rejects_an_extra_existing_class_finding_without_an_assessment():
         )
 
 
-def test_census_source_finding_can_fan_out_to_two_violated_classes():
+def test_census_source_finding_can_fan_out_only_to_violated_classes():
     source = "integrity:F1"
     classes = ["class-a", "class-b"]
     value = payload(settlement())
@@ -298,6 +298,26 @@ def test_census_source_finding_can_fan_out_to_two_violated_classes():
         rc.parse_settlement(
             wire(rc.SETTLEMENT_MARKER, value), source_ids=[source],
             assessment_ids=classes,
+        )
+
+    value["source_dispositions"].pop()
+    value["class_dispositions"][1] = {
+        "finding_id":"G2", "kind":"one_off", "reason":"unique site",
+    }
+    value["assessment_dispositions"][1]["governing_id"] = None
+    verdicts = {classes[0]:"violated", classes[1]:"satisfied"}
+    cited_findings = {classes[0]:source, classes[1]:None}
+    with pytest.raises(
+        rc.CensusError,
+        match="source fan-out requires distinct violated existing-class findings",
+    ):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[source],
+            source_severities={source:"MAJOR"}, assessment_ids=classes,
+            assessment_verdicts=verdicts,
+            assessment_findings=cited_findings,
+            class_states={cid:(cc.OPEN, False, "MAJOR") for cid in classes},
+            class_mechanized=None, role="census",
         )
 
 

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -253,6 +253,54 @@ def test_census_rejects_an_extra_existing_class_finding_without_an_assessment():
         )
 
 
+def test_census_source_finding_can_fan_out_to_two_violated_classes():
+    source = "integrity:F1"
+    classes = ["class-a", "class-b"]
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[
+            {"source_id":source, "governing_id":"G1"},
+            {"source_id":source, "governing_id":"G2"},
+        ],
+        assessment_dispositions=[
+            {"assessment_id":classes[0], "governing_id":"G1"},
+            {"assessment_id":classes[1], "governing_id":"G2"},
+        ],
+        findings=[finding("G1"), finding("G2")],
+        debt=[
+            {"id":"D1", "finding_id":"G1", "status":"open"},
+            {"id":"D2", "finding_id":"G2", "status":"open"},
+        ],
+        class_dispositions=[
+            {"finding_id":"G1", "kind":"existing_class", "class_id":classes[0]},
+            {"finding_id":"G2", "kind":"existing_class", "class_id":classes[1]},
+        ],
+    )
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[source],
+        source_severities={source:"MAJOR"}, assessment_ids=classes,
+        assessment_verdicts={cid:"violated" for cid in classes},
+        assessment_findings={cid:source for cid in classes},
+        class_states={cid:(cc.OPEN, False, "MAJOR") for cid in classes},
+        class_mechanized=None, role="census",
+    )
+    assert parsed["_finding_class_refs"] == {"G1":classes[0], "G2":classes[1]}
+    state = rc.settle_state(
+        rc.normalize_state({}, stakes="s", snapshot="p"), parsed,
+        phase="census", snapshot="p", round_no=1,
+    )
+    assert [row["source_ids"] for row in state["debt"]] == [[source], [source]]
+
+    value["source_dispositions"].append(
+        {"source_id":source, "governing_id":"G2"},
+    )
+    with pytest.raises(rc.CensusError, match="duplicate source_id disposition"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[source],
+            assessment_ids=classes,
+        )
+
+
 def test_settlement_accepts_only_the_observed_decorative_marker_variant():
     short = rc.SETTLEMENT_MARKER.removesuffix(" ===")
     text = settlement().replace(rc.SETTLEMENT_MARKER, short, 1)


### PR DESCRIPTION
## Summary
- allow an atomic lane finding to fan out to distinct governing findings when it violates multiple active classes
- constrain repeated sources to existing-class targets backed by distinct violated assessments citing the same source
- document the contract and add exact positive and negative regressions

## Validation
- `pytest -q` — 741 passed
- paranoia-local Codex CODE convergence — round 1 opened one class; round 2 closed it; `CLASS-CLOSURE: 0 open, 1 closed`; `CONVERGENCE: NOT-BLOCKED`

## Scope
No lane-manifest persistence, claim/arbitration changes, generic hardening, or unrelated refactor.