### PR TITLE
Reuse validated staged census after settlement rejection

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,10 @@ violated assessment citing that source; repetition must not manufacture one-off 
 Derive the deterministic close transition when an open, unmechanized class is assessed satisfied;
 do not discard a healthy census because the model omitted that redundant lifecycle record.
 After consolidation-only failure, reuse a complete validated lane census only under exact bindings
-to mode, structural snapshot, full review input, stakes, active-class state, and cache schema.
-Incomplete or mismatched cached lanes must never suppress a fresh census.
+to mode, structural snapshot, full review body/open debt, stakes, active-class state,
+engine/model/effort/web settings, plan context, and cache schema. Persist it only after terminal
+validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
+failed retry must never suppress a fresh census.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,7 @@ to mode, structural snapshot, full review body/open debt, stakes, active-class s
 engine/model/effort/web settings, plan context, and cache schema. Persist it only after terminal
 validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
 failed retry must delete any older cache and never suppress a fresh census. Persist those
-non-validation exits as generic staged failure, not validation debt.
+non-consolidation-validation exits as generic staged failure, not validation debt.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -46,11 +46,13 @@ do not discard a healthy census because the model omitted that redundant lifecyc
 After consolidation-only failure, reuse a complete validated lane census only under exact bindings
 to mode, structural snapshot, full review body/open debt, stakes, active-class state,
 engine/model/effort/web settings, plan context, and cache schema. Persist it only after terminal
-validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
+validation rejection, and bind the exact composed lane prompt bytes so instruction changes
+invalidate reuse. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
 failed retry must delete any older cache and never suppress a fresh census. Persist those
 non-terminal-consolidation-validation exits as structured staged failure with exact role, kind,
 and message, not validation debt. Preserve timeout, unavailable executable, provider error, and
 other execution outcomes distinctly, including the validation-retry role.
+Attempt telemetry must use that same `*-validation-retry` role.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -49,7 +49,8 @@ engine/model/effort/web settings, plan context, and cache schema. Persist it onl
 validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
 failed retry must delete any older cache and never suppress a fresh census. Persist those
 non-terminal-consolidation-validation exits as structured staged failure with exact role, kind,
-and message, not validation debt.
+and message, not validation debt. Preserve timeout, unavailable executable, provider error, and
+other execution outcomes distinctly, including the validation-retry role.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -47,7 +47,8 @@ After consolidation-only failure, reuse a complete validated lane census only un
 to mode, structural snapshot, full review body/open debt, stakes, active-class state,
 engine/model/effort/web settings, plan context, and cache schema. Persist it only after terminal
 validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
-failed retry must never suppress a fresh census.
+failed retry must delete any older cache and never suppress a fresh census. Persist those
+non-validation exits as generic staged failure, not validation debt.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -53,6 +53,7 @@ non-terminal-consolidation-validation exits as structured staged failure with ex
 and message, not validation debt. Preserve timeout, unavailable executable, provider error, and
 other execution outcomes distinctly, including the validation-retry role.
 Attempt telemetry must use that same `*-validation-retry` role.
+Terminal validation debt must persist and render the identical structured role, kind, and message.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,11 @@ its source disposition to fan out to one distinct governing finding per affected
 force the reviewer to split or paraphrase the source finding merely to satisfy settlement shape.
 Every target of a repeated source must be an existing-class finding backed by its own distinct
 violated assessment citing that source; repetition must not manufacture one-off or new-class debt.
+Derive the deterministic close transition when an open, unmechanized class is assessed satisfied;
+do not discard a healthy census because the model omitted that redundant lifecycle record.
+After consolidation-only failure, reuse a complete validated lane census only under exact bindings
+to mode, structural snapshot, full review input, stakes, active-class state, and cache schema.
+Incomplete or mismatched cached lanes must never suppress a fresh census.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,8 @@ to mode, structural snapshot, full review body/open debt, stakes, active-class s
 engine/model/effort/web settings, plan context, and cache schema. Persist it only after terminal
 validation rejection. Incomplete or mismatched lanes, execution failure, timeout, cancellation, or
 failed retry must delete any older cache and never suppress a fresh census. Persist those
-non-consolidation-validation exits as generic staged failure, not validation debt.
+non-terminal-consolidation-validation exits as structured staged failure with exact role, kind,
+and message, not validation debt.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,3 +48,6 @@
   disposition fan out to one distinct governing finding per affected class; do not split the
   observation merely to satisfy the settlement schema. Require every repeated-source target to be
   an existing-class finding backed by its own distinct violated assessment citing that source.
+- derive the deterministic close for a satisfied open unmechanized class, and reuse a complete
+  post-consolidation-failure census only when its snapshot, full input, stakes, mode, active-class
+  state, and cache schema all match exactly.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,4 +53,5 @@
   active-class state, engine settings, plan context, and cache schema all match exactly; execution
   failure, timeout, cancellation, and failed retry delete older cache, persist as generic staged
   failure, and are never reusable. Only terminal consolidation validation uses validation debt;
-  lane and follow-up validation are generic staged failures.
+  lane, follow-up, and consolidation-preflight validation are structured staged failures carrying
+  exact role, kind, and message.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,4 +51,5 @@
 - derive the deterministic close for a satisfied open unmechanized class, and reuse a complete
   post-validation-rejection census only when its snapshot, full body/debt input, stakes, mode,
   active-class state, engine settings, plan context, and cache schema all match exactly; execution
-  failure, timeout, cancellation, and failed retry are never reusable.
+  failure, timeout, cancellation, and failed retry delete older cache, persist as generic staged
+  failure, and are never reusable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -49,5 +49,6 @@
   observation merely to satisfy the settlement schema. Require every repeated-source target to be
   an existing-class finding backed by its own distinct violated assessment citing that source.
 - derive the deterministic close for a satisfied open unmechanized class, and reuse a complete
-  post-consolidation-failure census only when its snapshot, full input, stakes, mode, active-class
-  state, and cache schema all match exactly.
+  post-validation-rejection census only when its snapshot, full body/debt input, stakes, mode,
+  active-class state, engine settings, plan context, and cache schema all match exactly; execution
+  failure, timeout, cancellation, and failed retry are never reusable.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -52,4 +52,5 @@
   post-validation-rejection census only when its snapshot, full body/debt input, stakes, mode,
   active-class state, engine settings, plan context, and cache schema all match exactly; execution
   failure, timeout, cancellation, and failed retry delete older cache, persist as generic staged
-  failure, and are never reusable.
+  failure, and are never reusable. Only terminal consolidation validation uses validation debt;
+  lane and follow-up validation are generic staged failures.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,4 +54,5 @@
   failure, timeout, cancellation, and failed retry delete older cache, persist as generic staged
   failure, and are never reusable. Only terminal consolidation validation uses validation debt;
   lane, follow-up, and consolidation-preflight validation are structured staged failures carrying
-  exact role, kind, and message.
+  exact role, kind, and message; preserve timeout, unavailable, provider, execution, and retry roles
+  rather than flattening them.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,8 @@
   an existing-class finding backed by its own distinct violated assessment citing that source.
 - derive the deterministic close for a satisfied open unmechanized class, and reuse a complete
   post-validation-rejection census only when its snapshot, full body/debt input, stakes, mode,
-  active-class state, engine settings, plan context, and cache schema all match exactly; execution
+  active-class state, engine settings, plan context, exact composed lane prompts, and cache schema
+  all match exactly; execution
   failure, timeout, cancellation, and failed retry delete older cache, persist as generic staged
   failure, and are never reusable. Only terminal consolidation validation uses validation debt;
   lane, follow-up, and consolidation-preflight validation are structured staged failures carrying

--- a/README.md
+++ b/README.md
@@ -221,7 +221,9 @@ their separate mechanical closure rule. Rejections after parsing are recorded as
 Only terminal consolidation validation populates `validation_debt`; lane/follow-up validation and
 execution, retry, timeout, cancellation, deadline, and consolidation-preflight failures persist as
 structured `staged_failure` records with their exact role, kind, and message. They invalidate any
-older census cache and cannot authorize reuse.
+older census cache and cannot authorize reuse. Engine outcomes retain `timeout`, `unavailable`,
+`provider`, or `execution` rather than being flattened into an exit-code label; a failed validation
+retry has its own retry role.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -219,8 +219,9 @@ emit the explicit close record, and the server derives it when omitted; mechaniz
 their separate mechanical closure rule. Rejections after parsing are recorded as
 `validation-invalid`, which covers both envelope/schema and semantic lifecycle failures.
 Only terminal consolidation validation populates `validation_debt`; lane/follow-up validation and
-execution, retry, timeout, cancellation, and deadline failures persist as `staged_failure`,
-invalidate any older census cache, and cannot authorize reuse.
+execution, retry, timeout, cancellation, deadline, and consolidation-preflight failures persist as
+structured `staged_failure` records with their exact role, kind, and message. They invalidate any
+older census cache and cannot authorize reuse.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -147,7 +147,8 @@ If all three census lanes validate but consolidation is rejected, their manifest
 with the lineage and the next invocation reruns consolidation only. Reuse requires an exact match
 on mode, structural snapshot, complete review body and open debt, frozen stakes, active-class state,
 engine/model/effort/web capability settings, plan line context, and cache schema. It is recorded only
-after terminal validation rejection; execution failure, timeout, cancellation, or failed retry is
+after terminal validation rejection; the binding also digests the exact composed lane prompt bytes,
+including current instructions. Execution failure, timeout, cancellation, or failed retry is
 not reusable. Any binding change or incomplete lane set forces a fresh census.
 
 Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
@@ -223,7 +224,7 @@ execution, retry, timeout, cancellation, deadline, and consolidation-preflight f
 structured `staged_failure` records with their exact role, kind, and message. They invalidate any
 older census cache and cannot authorize reuse. Engine outcomes retain `timeout`, `unavailable`,
 `provider`, or `execution` rather than being flattened into an exit-code label; a failed validation
-retry has its own retry role.
+retry and its attempt-ledger event use the same `*-validation-retry` role.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -225,6 +225,8 @@ structured `staged_failure` records with their exact role, kind, and message. Th
 older census cache and cannot authorize reuse. Engine outcomes retain `timeout`, `unavailable`,
 `provider`, or `execution` rather than being flattened into an exit-code label; a failed validation
 retry and its attempt-ledger event use the same `*-validation-retry` role.
+Terminal validation debt retains that same structured role, kind, and message in lineage state and
+the convergence trailer.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state
@@ -901,7 +903,8 @@ cannot silently reset a tracked lineage. Set `PARANOIA_STATE_ROOT` to relocate i
 
 Reviews draw on your subscription's agentic-usage pool. A tracked plan cold census is three concurrent
 reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
-same-session format correction per call. Use `query` for quick checks.
+same-session validation correction per call. It covers schema and semantic settlement rejection and
+is recorded as `*-validation-retry`. Use `query` for quick checks.
 
 Audit `attempt_ledger` rows enumerate every provider run/resume exactly once. A synchronized
 sequence is assigned immediately before each concurrent census run/resume boundary, and the stage

--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ An open, unmechanized active class assessed `satisfied` closes deterministically
 emit the explicit close record, and the server derives it when omitted; mechanized classes retain
 their separate mechanical closure rule. Rejections after parsing are recorded as
 `validation-invalid`, which covers both envelope/schema and semantic lifecycle failures.
+Execution, retry, timeout, cancellation, and deadline failures instead persist as
+`staged_failure`, invalidate any older census cache, and cannot authorize reuse.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -145,8 +145,10 @@ code-review investigation, packet-use, proportionality, and warranted-web-search
 structured output contract changes. One-shot reviews retain the single broad review.
 If all three census lanes validate but consolidation is rejected, their manifests are persisted
 with the lineage and the next invocation reruns consolidation only. Reuse requires an exact match
-on mode, structural snapshot, complete review input, frozen stakes, active-class state, and cache
-schema; any change or incomplete lane set forces a fresh census.
+on mode, structural snapshot, complete review body and open debt, frozen stakes, active-class state,
+engine/model/effort/web capability settings, plan line context, and cache schema. It is recorded only
+after terminal validation rejection; execution failure, timeout, cancellation, or failed retry is
+not reusable. Any binding change or incomplete lane set forces a fresh census.
 
 Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
 claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and

--- a/README.md
+++ b/README.md
@@ -143,6 +143,10 @@ three-lane census, targeted correction rounds over durable debt and changed code
 broad, cold final regression before clearance. Every staged branch role retains the established
 code-review investigation, packet-use, proportionality, and warranted-web-search profile; only its
 structured output contract changes. One-shot reviews retain the single broad review.
+If all three census lanes validate but consolidation is rejected, their manifests are persisted
+with the lineage and the next invocation reruns consolidation only. Reuse requires an exact match
+on mode, structural snapshot, complete review input, frozen stakes, active-class state, and cache
+schema; any change or incomplete lane set forces a fresh census.
 
 Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
 claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and
@@ -208,6 +212,10 @@ finding to one distinct governing finding per class. The source observation is n
 split: every target of a repeated source must be an existing-class finding backed by its own
 violated assessment citing that source. One-off or new-class targets, duplicate source-to-governing
 pairs, and omitted sources still reject the settlement.
+An open, unmechanized active class assessed `satisfied` closes deterministically. Consolidation may
+emit the explicit close record, and the server derives it when omitted; mechanized classes retain
+their separate mechanical closure rule. Rejections after parsing are recorded as
+`validation-invalid`, which covers both envelope/schema and semantic lifecycle failures.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/README.md
+++ b/README.md
@@ -218,8 +218,9 @@ An open, unmechanized active class assessed `satisfied` closes deterministically
 emit the explicit close record, and the server derives it when omitted; mechanized classes retain
 their separate mechanical closure rule. Rejections after parsing are recorded as
 `validation-invalid`, which covers both envelope/schema and semantic lifecycle failures.
-Execution, retry, timeout, cancellation, and deadline failures instead persist as
-`staged_failure`, invalidate any older census cache, and cannot authorize reuse.
+Only terminal consolidation validation populates `validation_debt`; lane/follow-up validation and
+execution, retry, timeout, cancellation, and deadline failures persist as `staged_failure`,
+invalidate any older census cache, and cannot authorize reuse.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -303,6 +303,7 @@ first delete any older cache and persist as structured `staged_failure` with exa
 message; consolidation preflight validation does the same. Engine outcomes preserve timeout,
 unavailable executable, in-band provider error, and other execution failure distinctly, including
 the same `*-validation-retry` role in failure state and attempt telemetry. They cannot authorize reuse.
+Terminal validation debt also persists and renders that structured role, kind, and message.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -293,7 +293,8 @@ resumable structural-pending output. The autonomous caller repeats the same roun
 makes it cheaper. When all three lanes validated and only consolidation failed, the lineage retains
 those manifests and a retry runs consolidation only if mode, structural snapshot, full review body,
 open debt, stakes, active-class state, engine/model/effort/web settings, plan line context, and cache
-schema all match exactly. Persistence requires terminal validation rejection; incomplete lanes,
+schema all match exactly. The digest includes the exact composed prompt bytes for every lane, so an
+instruction-contract change invalidates reuse. Persistence requires terminal validation rejection; incomplete lanes,
 failed validation retry, execution failure, timeout, cancellation, or any binding change force a
 fresh immutable census. Parser and semantic settlement failures are logged as
 `validation-invalid`, not misclassified as format-only failures. Only terminal consolidation
@@ -301,7 +302,7 @@ validation populates `validation_debt`. Lane/follow-up validation and every exec
 first delete any older cache and persist as structured `staged_failure` with exact role, kind, and
 message; consolidation preflight validation does the same. Engine outcomes preserve timeout,
 unavailable executable, in-band provider error, and other execution failure distinctly, including
-the validation-retry role. They cannot authorize reuse.
+the same `*-validation-retry` role in failure state and attempt telemetry. They cannot authorize reuse.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -292,9 +292,10 @@ persist valid claim progress, leave phase and structural round unchanged, and re
 resumable structural-pending output. The autonomous caller repeats the same round; retained evidence
 makes it cheaper. When all three lanes validated and only consolidation failed, the lineage retains
 those manifests and a retry runs consolidation only if mode, structural snapshot, full review body,
-stakes, active-class state, and cache schema all match exactly. Incomplete lanes or any binding
-change force a fresh immutable census. Cancellation, provider execution failure, and deadline are
-terminal for that attempt. Parser and semantic settlement failures are logged as
+open debt, stakes, active-class state, engine/model/effort/web settings, plan line context, and cache
+schema all match exactly. Persistence requires terminal validation rejection; incomplete lanes,
+failed validation retry, execution failure, timeout, cancellation, or any binding change force a
+fresh immutable census. Parser and semantic settlement failures are logged as
 `validation-invalid`, not misclassified as format-only failures.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -147,13 +147,16 @@ class block remains only on unstaged one-shot paths, but staged output still ren
 the single governing structural convergence verdict.
 If lineage loading or persistence is ambiguous, both fields remain present but class closure is
 `STATE-UNAVAILABLE`; in-memory counts are not represented as confirmed durable state.
+For a satisfied open, unmechanized class, the server derives the deterministic `close` transition
+when consolidation omits it; the prompt still asks for the explicit record. The model supplies the
+assessment judgement, while the server owns its fixed lifecycle consequence.
 
 A valid census costs four model calls over two serial wall-clock phases. The bounded worst case is
 eight calls when all four replies need their one format correction. All limits use Python Unicode
 characters. The existing `MAX_PACKET_CHARS = 400_000` branch evidence-packet contract remains
 unchanged. Plan review passes the complete active claim register and current retirements; it does
 not truncate evidence that may change authority or entailment. Each exact staged lane prompt has a
-5,000,000-character ceiling, and an oversized prompt persists visible format debt rather than
+5,000,000-character ceiling, and an oversized prompt persists visible validation debt rather than
 running partially or clearing. Each lane envelope is
 capped at 48,000 characters, with 2,000-character summaries/remedies and 512-character anchors.
 New class invariant/procedure fields are capped at 1,000/2,000 characters and total rendered active
@@ -287,9 +290,12 @@ most 600 seconds. The three census lanes run concurrently.
 Plan evidence gathering can consume most of a request. If the full census reserve no longer fits,
 persist valid claim progress, leave phase and structural round unchanged, and return explicit
 resumable structural-pending output. The autonomous caller repeats the same round; retained evidence
-makes it cheaper. Completed sibling lane replies remain in failure audit diagnostics, but a retry
-starts one fresh immutable census attempt. Cancellation, provider execution failure and deadline are
-terminal for that attempt, not format errors.
+makes it cheaper. When all three lanes validated and only consolidation failed, the lineage retains
+those manifests and a retry runs consolidation only if mode, structural snapshot, full review body,
+stakes, active-class state, and cache schema all match exactly. Incomplete lanes or any binding
+change force a fresh immutable census. Cancellation, provider execution failure, and deadline are
+terminal for that attempt. Parser and semantic settlement failures are logged as
+`validation-invalid`, not misclassified as format-only failures.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -299,7 +299,9 @@ fresh immutable census. Parser and semantic settlement failures are logged as
 `validation-invalid`, not misclassified as format-only failures. Only terminal consolidation
 validation populates `validation_debt`. Lane/follow-up validation and every execution-class failure
 first delete any older cache and persist as structured `staged_failure` with exact role, kind, and
-message; consolidation preflight validation does the same. They cannot authorize reuse.
+message; consolidation preflight validation does the same. Engine outcomes preserve timeout,
+unavailable executable, in-band provider error, and other execution failure distinctly, including
+the validation-retry role. They cannot authorize reuse.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -296,7 +296,9 @@ open debt, stakes, active-class state, engine/model/effort/web settings, plan li
 schema all match exactly. Persistence requires terminal validation rejection; incomplete lanes,
 failed validation retry, execution failure, timeout, cancellation, or any binding change force a
 fresh immutable census. Parser and semantic settlement failures are logged as
-`validation-invalid`, not misclassified as format-only failures.
+`validation-invalid`, not misclassified as format-only failures. Every other staged failure first
+deletes any older cache and persists as generic `staged_failure`; it is never represented as
+validation debt and cannot authorize reuse.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -160,8 +160,10 @@ not truncate evidence that may change authority or entailment. Each exact staged
 running partially or clearing. Each lane envelope is
 capped at 48,000 characters, with 2,000-character summaries/remedies and 512-character anchors.
 New class invariant/procedure fields are capped at 1,000/2,000 characters and total rendered active
-class context at 64,000 characters. Before a lane call, render its exact prompt and reject over
-5,000,000 characters; do not truncate a valid evidence packet. Consolidation has no
+class context at 64,000 characters. Active-class or lane-prompt overflow is a non-cacheable
+structured staged failure of kind `validation`; only terminal consolidation rejection populates
+`validation_debt`. Before a lane call, render its exact prompt and reject over 5,000,000
+characters; do not truncate a valid evidence packet. Consolidation has no
 artifact packet and retains a 400,000-character exact-prompt ceiling; three maximum lane envelopes
 leave more than 250,000 characters for its instructions, stakes, and class context. The plan
 prototype's complete raw four-call JSON record was 46,708 bytes.

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -156,8 +156,8 @@ eight calls when all four replies need their one format correction. All limits u
 characters. The existing `MAX_PACKET_CHARS = 400_000` branch evidence-packet contract remains
 unchanged. Plan review passes the complete active claim register and current retirements; it does
 not truncate evidence that may change authority or entailment. Each exact staged lane prompt has a
-5,000,000-character ceiling, and an oversized prompt persists visible validation debt rather than
-running partially or clearing. Each lane envelope is
+5,000,000-character ceiling, and an oversized prompt persists a visible non-cacheable structured
+failure rather than running partially or clearing. Each lane envelope is
 capped at 48,000 characters, with 2,000-character summaries/remedies and 512-character anchors.
 New class invariant/procedure fields are capped at 1,000/2,000 characters and total rendered active
 class context at 64,000 characters. Active-class or lane-prompt overflow is a non-cacheable

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -298,7 +298,8 @@ failed validation retry, execution failure, timeout, cancellation, or any bindin
 fresh immutable census. Parser and semantic settlement failures are logged as
 `validation-invalid`, not misclassified as format-only failures. Only terminal consolidation
 validation populates `validation_debt`. Lane/follow-up validation and every execution-class failure
-first delete any older cache and persist as generic `staged_failure`; they cannot authorize reuse.
+first delete any older cache and persist as structured `staged_failure` with exact role, kind, and
+message; consolidation preflight validation does the same. They cannot authorize reuse.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -296,9 +296,9 @@ open debt, stakes, active-class state, engine/model/effort/web settings, plan li
 schema all match exactly. Persistence requires terminal validation rejection; incomplete lanes,
 failed validation retry, execution failure, timeout, cancellation, or any binding change force a
 fresh immutable census. Parser and semantic settlement failures are logged as
-`validation-invalid`, not misclassified as format-only failures. Every other staged failure first
-deletes any older cache and persists as generic `staged_failure`; it is never represented as
-validation debt and cannot authorize reuse.
+`validation-invalid`, not misclassified as format-only failures. Only terminal consolidation
+validation populates `validation_debt`. Lane/follow-up validation and every execution-class failure
+first delete any older cache and persist as generic `staged_failure`; they cannot authorize reuse.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -57,6 +57,7 @@ class Review:
     error: bool = False
     usage: dict | None = None
     duration_ms: int | None = None
+    failure_detail: str | None = None
 
 
 class Engine(ABC):
@@ -162,18 +163,27 @@ class Engine(ABC):
         # non-empty stdout, which the old "rc != 0 AND empty stdout" gate silently
         # swallowed, defeating any downstream fallback.
         failed = result.returncode != 0 or review.error
+        failure_detail = (
+            result.stderr if result.returncode != 0 and result.stderr
+            else review.failure_detail
+        )
         if failed and not (review.text or "").strip():
+            detail = failure_detail or review.raw or "engine failure"
             return Review(
                 text=(
                     f"[paranoia-local error] {self.name} exited {result.returncode}: "
-                    f"{result.stderr.strip()[:2000]}"
+                    f"{detail.strip()[:2000]}"
                 ),
                 session_ref=review.session_ref,
                 raw=result.stderr or result.stdout,
                 returncode=result.returncode,
                 error=True,
+                failure_detail=detail,
             )
-        return replace(review, returncode=result.returncode, error=failed)
+        return replace(
+            review, returncode=result.returncode, error=failed,
+            failure_detail=failure_detail,
+        )
 
 
 class CodexEngine(Engine):
@@ -288,6 +298,7 @@ class CodexEngine(Engine):
         last_message: str | None = None
         usage: dict | None = None
         error = False
+        failure_detail: str | None = None
         for line in stdout.splitlines():
             line = line.strip()
             if not line:
@@ -303,6 +314,13 @@ class CodexEngine(Engine):
                 thread_id = event.get("thread_id") or thread_id
             if etype in {"error", "turn.failed"}:
                 error = True
+                detail = event.get("error")
+                if isinstance(detail, dict):
+                    detail = detail.get("message")
+                if not isinstance(detail, str):
+                    detail = event.get("message")
+                if isinstance(detail, str):
+                    failure_detail = detail
             if etype == "turn.completed":
                 u = event.get("usage")
                 if isinstance(u, dict):
@@ -312,6 +330,7 @@ class CodexEngine(Engine):
                 # terminal event, not an earlier recovered event, governs the
                 # process result.
                 error = False
+                failure_detail = None
             item = event.get("item")
             if isinstance(item, dict):
                 if item.get("type") == "agent_message":
@@ -320,8 +339,12 @@ class CodexEngine(Engine):
                         last_message = text
                 elif item.get("type") == "error":
                     error = True
+                    detail = item.get("message") or item.get("text")
+                    if isinstance(detail, str):
+                        failure_detail = detail
         return Review(
-            text=last_message or "", session_ref=thread_id, raw=stdout, error=error, usage=usage
+            text=last_message or "", session_ref=thread_id, raw=stdout, error=error,
+            usage=usage, failure_detail=failure_detail,
         )
 
 
@@ -417,13 +440,16 @@ class ClaudeEngine(Engine):
         tokens, cost = data.get("usage"), data.get("total_cost_usd")
         if tokens is not None or cost is not None:
             usage = {"tokens": tokens, "cost_usd": cost}
+        text = str(data.get("result", ""))
+        is_error = bool(data.get("is_error", False))
         return Review(
-            text=str(data.get("result", "")),
+            text=text,
             session_ref=data.get("session_id"),
             raw=stdout,
-            error=bool(data.get("is_error", False)),
+            error=is_error,
             usage=usage,
             duration_ms=data.get("duration_ms"),
+            failure_detail=text if is_error else None,
         )
 
 

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -164,7 +164,10 @@ class Engine(ABC):
         # swallowed, defeating any downstream fallback.
         failed = result.returncode != 0 or review.error
         failure_detail = (
-            result.stderr if result.returncode != 0 and result.stderr
+            (
+                result.stderr or review.failure_detail
+                or f"{self.name} exited with return code {result.returncode}"
+            ) if result.returncode != 0
             else review.failure_detail
         )
         if failed and not (review.text or "").strip():

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -165,7 +165,7 @@ class Engine(ABC):
         failed = result.returncode != 0 or review.error
         failure_detail = (
             (
-                result.stderr or review.failure_detail
+                (result.stderr if result.stderr.strip() else None) or review.failure_detail
                 or f"{self.name} exited with return code {result.returncode}"
             ) if result.returncode != 0
             else review.failure_detail

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -99,7 +99,7 @@ def _engine_failure_error(review: Review, *, role: str) -> rc.CensusError:
         else "provider" if review.returncode == 0
         else "execution"
     )
-    detail = review.text or review.raw or "engine failure"
+    detail = review.failure_detail or review.text or review.raw or "engine failure"
     error = rc.CensusError(detail)
     error.stage_role = role  # type: ignore[attr-defined]
     error.failure_kind = kind  # type: ignore[attr-defined]
@@ -182,6 +182,15 @@ def _staged_error(message: str, *, role: str, kind: str) -> rc.CensusError:
     error.stage_role = role  # type: ignore[attr-defined]
     error.failure_kind = kind  # type: ignore[attr-defined]
     return error
+
+
+def _staged_class_context(blocks: list[str]) -> str:
+    try:
+        return rc.class_context(blocks)
+    except rc.CensusError as exc:
+        raise _staged_error(
+            str(exc), role="active-class-preflight", kind="validation",
+        ) from exc
 
 
 def _staged_lane_prompt(
@@ -382,7 +391,7 @@ def _staged_structural_review(
     """Run census/correction/final and atomically settle it into the open lineage."""
     assert closure.lineage is not None
     lineage = closure.lineage
-    rc.class_context(closure._blocks())
+    _staged_class_context(closure._blocks())
     state = rc.normalize_state(lineage.review_state, stakes=stakes, snapshot=snapshot)
     if lineage.debt:
         # A pre-staging malformed-register round is not silently normalized into an

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -116,6 +116,7 @@ def _staged_call(
             error = rc.CensusError(
                 f"{role} validation invalid and has no resumable session: {first}"
             )
+            error.failure_kind = "validation"  # type: ignore[attr-defined]
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
         retry_sequence = next_sequence() if next_sequence else None
@@ -139,6 +140,7 @@ def _staged_call(
             parsed = parser(retry.text)
         except rc.CensusError as second:
             attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
+            second.failure_kind = "validation"  # type: ignore[attr-defined]
             second.attempts = attempts  # type: ignore[attr-defined]
             raise
         return retry, parsed, attempts
@@ -228,11 +230,12 @@ def _settle_staged_failure(
     state.pop("staged_failure", None)
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
-    if isinstance(cache, dict):
+    if getattr(error, "failure_kind", None) == "validation":
         state["validation_debt"] = str(error)
-        state["census_cache"] = deepcopy(cache)
     else:
         state["staged_failure"] = str(error)
+    if isinstance(cache, dict):
+        state["census_cache"] = deepcopy(cache)
     closure.lineage.review_state = state
     try:
         cc.save_lineage(closure.state_root, closure.lineage)
@@ -263,8 +266,7 @@ def _settle_staged_failure(
     )
     trailer = "\n".join((
         _staged_class_trailer(closure, closure.register_status),
-        f"STRUCTURAL-PHASE: {state['phase']}\nSTRUCTURAL-ERROR: {error}\n"
-        "CONVERGENCE: BLOCKED — staged review did not settle.",
+        rc.trailer(state),
     ))
     if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
         trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -247,13 +247,14 @@ def _settle_staged_failure(
     state.pop("staged_failure", None)
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
-    if (
-        getattr(error, "stage_role", None) == "consolidation"
-        and getattr(error, "failure_kind", None) == "validation"
-    ):
+    if isinstance(cache, dict):
         state["validation_debt"] = str(error)
     else:
-        state["staged_failure"] = str(error)
+        state["staged_failure"] = {
+            "role":getattr(error, "stage_role", "unknown"),
+            "kind":getattr(error, "failure_kind", "unknown"),
+            "message":str(error),
+        }
     if isinstance(cache, dict):
         state["census_cache"] = deepcopy(cache)
     closure.lineage.review_state = state

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -106,6 +106,8 @@ def _staged_call(
     attempts = [_attempt(role, engine, review, sequence=sequence)]
     if review.error:
         error = rc.CensusError(f"{role} failed (exit {review.returncode})")
+        error.stage_role = role  # type: ignore[attr-defined]
+        error.failure_kind = "execution"  # type: ignore[attr-defined]
         error.attempts = attempts  # type: ignore[attr-defined]
         raise error
     try:
@@ -116,6 +118,7 @@ def _staged_call(
             error = rc.CensusError(
                 f"{role} validation invalid and has no resumable session: {first}"
             )
+            error.stage_role = role  # type: ignore[attr-defined]
             error.failure_kind = "validation"  # type: ignore[attr-defined]
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
@@ -134,12 +137,15 @@ def _staged_call(
         ))
         if retry.error:
             error = rc.CensusError(f"{role} validation retry failed (exit {retry.returncode})")
+            error.stage_role = role  # type: ignore[attr-defined]
+            error.failure_kind = "execution"  # type: ignore[attr-defined]
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
         try:
             parsed = parser(retry.text)
         except rc.CensusError as second:
             attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
+            second.stage_role = role  # type: ignore[attr-defined]
             second.failure_kind = "validation"  # type: ignore[attr-defined]
             second.attempts = attempts  # type: ignore[attr-defined]
             raise
@@ -156,6 +162,13 @@ def _staged_class_trailer(closure: "_ClosureRound", status: str) -> str:
     return cc.render_trailer(
         closure.lineage, register_status=status, include_verdict=False,
     )
+
+
+def _staged_error(message: str, *, role: str, kind: str) -> rc.CensusError:
+    error = rc.CensusError(message)
+    error.stage_role = role  # type: ignore[attr-defined]
+    error.failure_kind = kind  # type: ignore[attr-defined]
+    return error
 
 
 def _census_cache_binding(
@@ -214,8 +227,12 @@ def _cached_census_manifests(
 
 def _cacheable_consolidation_error(error: rc.CensusError) -> bool:
     attempts = getattr(error, "attempts", [])
-    return bool(attempts) and all(
-        attempt.outcome == "validation-invalid" for attempt in attempts
+    return (
+        getattr(error, "stage_role", None) == "consolidation"
+        and getattr(error, "failure_kind", None) == "validation"
+        and bool(attempts) and all(
+            attempt.outcome == "validation-invalid" for attempt in attempts
+        )
     )
 
 
@@ -230,7 +247,10 @@ def _settle_staged_failure(
     state.pop("staged_failure", None)
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
-    if getattr(error, "failure_kind", None) == "validation":
+    if (
+        getattr(error, "stage_role", None) == "consolidation"
+        and getattr(error, "failure_kind", None) == "validation"
+    ):
         state["validation_debt"] = str(error)
     else:
         state["staged_failure"] = str(error)
@@ -466,7 +486,10 @@ def _staged_structural_review(
             )
             prompt = prompts.compose(instructions, lane_body)
             if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
-                raise rc.CensusError(f"staged lane prompt is {len(prompt)} characters")
+                raise _staged_error(
+                    f"staged lane prompt is {len(prompt)} characters",
+                    role=f"census-{lane}", kind="validation",
+                )
             result, parsed, lane_attempts = _staged_call(
                 role=f"census-{lane}", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=STAGED_CENSUS_LANE_TIMEOUT_SEC,
@@ -534,7 +557,10 @@ def _staged_structural_review(
         try:
             prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
             if len(prompt) > rc.MAX_CONSOLIDATION_PROMPT_CHARS:
-                raise rc.CensusError(f"consolidation prompt is {len(prompt)} characters")
+                raise _staged_error(
+                    f"consolidation prompt is {len(prompt)} characters",
+                    role="consolidation", kind="validation",
+                )
             review, settlement, call_attempts = _staged_call(
                 role="consolidation", engine=engine, prompt=prompt, cwd=cwd,
                 model=model, effort=effort, timeout=STAGED_CONSOLIDATION_TIMEOUT_SEC,
@@ -577,7 +603,10 @@ def _staged_structural_review(
         }, ensure_ascii=False)
         prompt = prompts.compose(prompts.staged_followup_instructions(mode), stage_body)
         if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
-            raise rc.CensusError(f"{role} prompt is {len(prompt)} characters")
+            raise _staged_error(
+                f"{role} prompt is {len(prompt)} characters",
+                role=role, kind="validation",
+            )
         review, settlement, call_attempts = _staged_call(
             role=role, engine=engine, prompt=prompt, cwd=cwd, model=model, effort=effort,
             timeout=STAGED_FOLLOWUP_TIMEOUT_SEC, on_progress=on_progress,

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -91,6 +91,20 @@ def _attempt(
                       response[:4000] if response else None, sequence)
 
 
+def _engine_failure_error(review: Review, *, role: str) -> rc.CensusError:
+    kind = (
+        "timeout" if review.returncode == 124
+        else "unavailable" if review.returncode == 127
+        else "provider" if review.returncode == 0
+        else "execution"
+    )
+    detail = " ".join((review.text or review.raw or "engine failure").split())[:2000]
+    error = rc.CensusError(f"{role} {kind}: {detail}")
+    error.stage_role = role  # type: ignore[attr-defined]
+    error.failure_kind = kind  # type: ignore[attr-defined]
+    return error
+
+
 def _staged_call(
     *, role: str, engine: Engine, prompt: str, cwd: Path, model: str, effort: str,
     timeout: int, parser: Callable[[str], dict[str, Any]],
@@ -105,9 +119,7 @@ def _staged_call(
                         **_progress_kwargs(on_progress))
     attempts = [_attempt(role, engine, review, sequence=sequence)]
     if review.error:
-        error = rc.CensusError(f"{role} failed (exit {review.returncode})")
-        error.stage_role = role  # type: ignore[attr-defined]
-        error.failure_kind = "execution"  # type: ignore[attr-defined]
+        error = _engine_failure_error(review, role=role)
         error.attempts = attempts  # type: ignore[attr-defined]
         raise error
     try:
@@ -136,9 +148,9 @@ def _staged_call(
             f"{role}-format-retry", engine, retry, sequence=retry_sequence,
         ))
         if retry.error:
-            error = rc.CensusError(f"{role} validation retry failed (exit {retry.returncode})")
-            error.stage_role = role  # type: ignore[attr-defined]
-            error.failure_kind = "execution"  # type: ignore[attr-defined]
+            error = _engine_failure_error(
+                retry, role=f"{role}-validation-retry",
+            )
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
         try:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -111,7 +111,7 @@ def _staged_call(
     try:
         return review, parser(review.text), attempts
     except rc.CensusError as first:
-        attempts[-1] = replace(attempts[-1], outcome="format-invalid")
+        attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
         if not review.session_ref:
             error = rc.CensusError(f"{role} format invalid and has no resumable session: {first}")
             error.attempts = attempts  # type: ignore[attr-defined]
@@ -136,7 +136,7 @@ def _staged_call(
         try:
             parsed = parser(retry.text)
         except rc.CensusError as second:
-            attempts[-1] = replace(attempts[-1], outcome="format-invalid")
+            attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
             second.attempts = attempts  # type: ignore[attr-defined]
             raise
         return retry, parsed, attempts
@@ -154,13 +154,63 @@ def _staged_class_trailer(closure: "_ClosureRound", status: str) -> str:
     )
 
 
+def _census_cache_binding(
+    *, mode: str, snapshot: str, stakes: str, body: str,
+    active_classes: list[dict[str, Any]],
+) -> dict[str, Any]:
+    canonical_classes = json.dumps(
+        sorted(active_classes, key=lambda row: row["class_id"]),
+        ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    )
+    return {
+        "version":rc.CENSUS_CACHE_VERSION,
+        "mode":mode,
+        "snapshot_digest":snapshot,
+        "stakes_digest":rc.digest(stakes),
+        "input_digest":rc.digest(body),
+        "active_classes_digest":rc.digest(canonical_classes),
+    }
+
+
+def _cached_census_manifests(
+    state: dict[str, Any], *, binding: dict[str, Any], lanes: tuple[str, ...],
+    validate: Callable[[str, str], dict[str, Any]],
+) -> list[dict[str, Any]] | None:
+    cache = state.get("census_cache")
+    if not isinstance(cache, dict) or any(cache.get(key) != value for key, value in binding.items()):
+        return None
+    raw = cache.get("manifests")
+    if not isinstance(raw, list) or len(raw) != len(lanes):
+        return None
+    by_lane = {
+        item.get("lane"): item for item in raw
+        if isinstance(item, dict) and isinstance(item.get("lane"), str)
+    }
+    if set(by_lane) != set(lanes):
+        return None
+    validated: list[dict[str, Any]] = []
+    try:
+        for lane in lanes:
+            validated.append(validate(
+                rc.LANE_MARKER + "\n" + json.dumps(by_lane[lane], ensure_ascii=False),
+                lane,
+            ))
+    except rc.CensusError:
+        return None
+    return validated
+
+
 def _settle_staged_failure(
     closure: "_ClosureRound", *, stakes: str, snapshot: str, error: rc.CensusError,
     mode: str,
 ) -> tuple[Review, str, list[dict[str, Any]]]:
     assert closure.lineage is not None
     state = rc.normalize_state(closure.lineage.review_state, stakes=stakes, snapshot=snapshot)
-    state["format_debt"] = str(error)
+    state["validation_debt"] = str(error)
+    state.pop("format_debt", None)
+    cache = getattr(error, "census_cache", None)
+    if isinstance(cache, dict):
+        state["census_cache"] = deepcopy(cache)
     closure.lineage.review_state = state
     try:
         cc.save_lineage(closure.state_root, closure.lineage)
@@ -373,6 +423,10 @@ def _staged_structural_review(
 
     if phase == "census":
         lanes = rc.LANES[mode]
+        cache_binding = _census_cache_binding(
+            mode=mode, snapshot=snapshot, stakes=stakes, body=body,
+            active_classes=active_classes,
+        )
 
         def run_lane(lane: str) -> tuple[str, Review, dict[str, Any], list[rc.Attempt]]:
             instructions = prompts.staged_census_instructions(mode, lane)
@@ -402,29 +456,37 @@ def _staged_structural_review(
                     assessment["finding_id"] = renamed[assessment["finding_id"]]
             return lane, result, parsed, lane_attempts
 
-        lane_rows = []
-        lane_errors: list[rc.CensusError] = []
-        with ThreadPoolExecutor(max_workers=3) as pool:
-            pending = {pool.submit(run_lane, lane): lane for lane in lanes}
-            for future in as_completed(pending):
-                try:
-                    lane_rows.append(future.result())
-                except rc.CensusError as error:
-                    lane_errors.append(error)
-        lane_rows.sort(key=lambda row: lanes.index(row[0]))
-        if lane_errors:
-            all_attempts = [a for row in lane_rows for a in row[3]]
-            all_attempts.extend(
-                a for error in lane_errors for a in getattr(error, "attempts", [])
-            )
-            all_attempts.sort(key=lambda item: item.sequence or 0)
-            first_error = lane_errors[0]
-            first_error.attempts = all_attempts  # type: ignore[attr-defined]
-            first_error.manifests = [row[2] for row in lane_rows]  # type: ignore[attr-defined]
-            raise first_error
-        for _, _, _, lane_attempts in lane_rows:
-            attempts.extend(lane_attempts)
-        manifests = [row[2] for row in lane_rows]
+        manifests = _cached_census_manifests(
+            state, binding=cache_binding, lanes=lanes, validate=validate_lane,
+        )
+        if manifests is None:
+            lane_rows = []
+            lane_errors: list[rc.CensusError] = []
+            with ThreadPoolExecutor(max_workers=3) as pool:
+                pending = {pool.submit(run_lane, lane): lane for lane in lanes}
+                for future in as_completed(pending):
+                    try:
+                        lane_rows.append(future.result())
+                    except rc.CensusError as error:
+                        lane_errors.append(error)
+            lane_rows.sort(key=lambda row: lanes.index(row[0]))
+            if lane_errors:
+                all_attempts = [a for row in lane_rows for a in row[3]]
+                all_attempts.extend(
+                    a for error in lane_errors for a in getattr(error, "attempts", [])
+                )
+                all_attempts.sort(key=lambda item: item.sequence or 0)
+                first_error = lane_errors[0]
+                first_error.attempts = all_attempts  # type: ignore[attr-defined]
+                first_error.manifests = [  # type: ignore[attr-defined]
+                    row[2] for row in lane_rows
+                ]
+                raise first_error
+            for _, _, _, lane_attempts in lane_rows:
+                attempts.extend(lane_attempts)
+            manifests = [row[2] for row in lane_rows]
+        elif on_progress is not None:
+            on_progress("reusing validated census lanes after settlement rejection")
         closure.staged_manifests = manifests
         source_ids = [f["id"] for m in manifests for f in m["findings"]]
         source_severities = {f["id"]: f["severity"] for m in manifests for f in m["findings"]}
@@ -469,6 +531,9 @@ def _staged_structural_review(
                 *attempts, *getattr(error, "attempts", []),
             ]
             error.manifests = manifests  # type: ignore[attr-defined]
+            error.census_cache = {  # type: ignore[attr-defined]
+                **cache_binding, "manifests":deepcopy(manifests),
+            }
             raise
         attempts.extend(call_attempts)
     else:
@@ -898,19 +963,20 @@ def _converge_branch_review(
                     closure, mode=cc.BRANCH_MODE,
                 )
             elif closure and type(engine) in (eng.CodexEngine, eng.ClaudeEngine):
+                structural_snapshot = rc.digest(f"{base_id}\0{head_id}\0{packet}")
                 try:
                     review, trailer, attempt_ledger = _staged_structural_review(
                         engine=engine, cwd=wt, model=model,
                         effort=effort, mode=cc.BRANCH_MODE,
                         body=f"=== REVIEW STAKES ===\n{stakes}\n\n{packet}",
                         closure=closure, stakes=stakes,
-                        snapshot=rc.digest(f"{base_id}\0{head_id}\0{packet}"),
+                        snapshot=structural_snapshot,
                         round_no=review_round or 1, on_progress=on_progress,
                         web_search=web_search,
                     )
                 except rc.CensusError as error:
                     review, trailer, attempt_ledger = _settle_staged_failure(
-                        closure, stakes=stakes, snapshot=head_id, error=error,
+                        closure, stakes=stakes, snapshot=structural_snapshot, error=error,
                         mode=cc.BRANCH_MODE,
                     )
             else:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -95,11 +95,12 @@ def _engine_failure_error(review: Review, *, role: str) -> rc.CensusError:
     kind = (
         "timeout" if review.returncode == 124
         else "unavailable" if review.returncode == 127
+        else "cancellation" if review.returncode in {-15, -2, 130, 143}
         else "provider" if review.returncode == 0
         else "execution"
     )
-    detail = " ".join((review.text or review.raw or "engine failure").split())[:2000]
-    error = rc.CensusError(f"{role} {kind}: {detail}")
+    detail = review.text or review.raw or "engine failure"
+    error = rc.CensusError(detail)
     error.stage_role = role  # type: ignore[attr-defined]
     error.failure_kind = kind  # type: ignore[attr-defined]
     return error

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -157,7 +157,7 @@ def _staged_call(
             parsed = parser(retry.text)
         except rc.CensusError as second:
             attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
-            second.stage_role = role  # type: ignore[attr-defined]
+            second.stage_role = f"{role}-validation-retry"  # type: ignore[attr-defined]
             second.failure_kind = "validation"  # type: ignore[attr-defined]
             second.attempts = attempts  # type: ignore[attr-defined]
             raise
@@ -253,7 +253,9 @@ def _cached_census_manifests(
 def _cacheable_consolidation_error(error: rc.CensusError) -> bool:
     attempts = getattr(error, "attempts", [])
     return (
-        getattr(error, "stage_role", None) == "consolidation"
+        getattr(error, "stage_role", None) in {
+            "consolidation", "consolidation-validation-retry",
+        }
         and getattr(error, "failure_kind", None) == "validation"
         and bool(attempts) and all(
             attempt.outcome == "validation-invalid" for attempt in attempts
@@ -273,7 +275,11 @@ def _settle_staged_failure(
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
     if isinstance(cache, dict):
-        state["validation_debt"] = str(error)
+        state["validation_debt"] = {
+            "role":getattr(error, "stage_role", "consolidation-validation-retry"),
+            "kind":"validation",
+            "message":str(error),
+        }
     else:
         state["staged_failure"] = {
             "role":getattr(error, "stage_role", "unknown"),

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -113,7 +113,9 @@ def _staged_call(
     except rc.CensusError as first:
         attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
         if not review.session_ref:
-            error = rc.CensusError(f"{role} format invalid and has no resumable session: {first}")
+            error = rc.CensusError(
+                f"{role} validation invalid and has no resumable session: {first}"
+            )
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
         retry_sequence = next_sequence() if next_sequence else None
@@ -130,7 +132,7 @@ def _staged_call(
             f"{role}-format-retry", engine, retry, sequence=retry_sequence,
         ))
         if retry.error:
-            error = rc.CensusError(f"{role} format retry failed (exit {retry.returncode})")
+            error = rc.CensusError(f"{role} validation retry failed (exit {retry.returncode})")
             error.attempts = attempts  # type: ignore[attr-defined]
             raise error from first
         try:
@@ -156,18 +158,26 @@ def _staged_class_trailer(closure: "_ClosureRound", status: str) -> str:
 
 def _census_cache_binding(
     *, mode: str, snapshot: str, stakes: str, body: str,
-    active_classes: list[dict[str, Any]],
+    active_classes: list[dict[str, Any]], existing_debt: list[dict[str, Any]],
+    engine_name: str, model: str, effort: str, web_search: bool,
+    plan_lines: int | None,
 ) -> dict[str, Any]:
     canonical_classes = json.dumps(
         sorted(active_classes, key=lambda row: row["class_id"]),
         ensure_ascii=False, sort_keys=True, separators=(",", ":"),
     )
+    complete_input = json.dumps({
+        "mode":mode, "snapshot_digest":snapshot, "stakes":stakes, "body":body,
+        "active_classes":active_classes, "existing_debt":existing_debt,
+        "engine":engine_name, "model":model, "effort":effort,
+        "web_search":web_search, "plan_lines":plan_lines,
+    }, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return {
         "version":rc.CENSUS_CACHE_VERSION,
         "mode":mode,
         "snapshot_digest":snapshot,
         "stakes_digest":rc.digest(stakes),
-        "input_digest":rc.digest(body),
+        "input_digest":rc.digest(complete_input),
         "active_classes_digest":rc.digest(canonical_classes),
     }
 
@@ -198,6 +208,13 @@ def _cached_census_manifests(
     except rc.CensusError:
         return None
     return validated
+
+
+def _cacheable_consolidation_error(error: rc.CensusError) -> bool:
+    attempts = getattr(error, "attempts", [])
+    return bool(attempts) and all(
+        attempt.outcome == "validation-invalid" for attempt in attempts
+    )
 
 
 def _settle_staged_failure(
@@ -423,9 +440,14 @@ def _staged_structural_review(
 
     if phase == "census":
         lanes = rc.LANES[mode]
+        existing_debt = [
+            d for d in state.get("debt", []) if d.get("status") == "open"
+        ]
         cache_binding = _census_cache_binding(
             mode=mode, snapshot=snapshot, stakes=stakes, body=body,
-            active_classes=active_classes,
+            active_classes=active_classes, existing_debt=existing_debt,
+            engine_name=engine.name, model=model, effort=effort,
+            web_search=web_search, plan_lines=plan_lines,
         )
 
         def run_lane(lane: str) -> tuple[str, Review, dict[str, Any], list[rc.Attempt]]:
@@ -500,9 +522,7 @@ def _staged_structural_review(
         consolidation_body = json.dumps({
             "role": "census", "stakes": stakes, "manifests": manifests,
             "active_classes": active_classes,
-            "existing_debt": [
-                d for d in state.get("debt", []) if d.get("status") == "open"
-            ],
+            "existing_debt": existing_debt,
         }, ensure_ascii=False)
         try:
             prompt = prompts.compose(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS, consolidation_body)
@@ -527,13 +547,15 @@ def _staged_structural_review(
                 ),
             )
         except rc.CensusError as error:
+            cacheable = _cacheable_consolidation_error(error)
             error.attempts = [  # type: ignore[attr-defined]
                 *attempts, *getattr(error, "attempts", []),
             ]
             error.manifests = manifests  # type: ignore[attr-defined]
-            error.census_cache = {  # type: ignore[attr-defined]
-                **cache_binding, "manifests":deepcopy(manifests),
-            }
+            if cacheable:
+                error.census_cache = {  # type: ignore[attr-defined]
+                    **cache_binding, "manifests":deepcopy(manifests),
+                }
             raise
         attempts.extend(call_attempts)
     else:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -223,11 +223,16 @@ def _settle_staged_failure(
 ) -> tuple[Review, str, list[dict[str, Any]]]:
     assert closure.lineage is not None
     state = rc.normalize_state(closure.lineage.review_state, stakes=stakes, snapshot=snapshot)
-    state["validation_debt"] = str(error)
+    state.pop("census_cache", None)
+    state.pop("validation_debt", None)
+    state.pop("staged_failure", None)
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
     if isinstance(cache, dict):
+        state["validation_debt"] = str(error)
         state["census_cache"] = deepcopy(cache)
+    else:
+        state["staged_failure"] = str(error)
     closure.lineage.review_state = state
     try:
         cc.save_lineage(closure.state_root, closure.lineage)

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -360,26 +360,15 @@ def _state_unavailable_review(
 
 
 def _structural_pending_review(
-    closure: "_ClosureRound", *, mode: str, claim_state: dict[str, Any], reason: str,
+    closure: "_ClosureRound", *, mode: str, stakes: str, snapshot: str, reason: str,
 ) -> tuple[Review, str, list[dict[str, Any]]]:
     """Settle a zero-attempt plan round whose structural reserve no longer fits."""
-    assert closure.lineage is not None
-    phase = closure.lineage.review_state.get("phase", "census")
-    closure._settled = True
-    closure.register_status = "structural pending"
-    review = Review(
-        text=rc.render_error_review(f"[paranoia-local error] {reason}"),
-        session_ref=None, raw=reason,
-        returncode=124, error=True,
+    error = _staged_error(
+        reason, role="structural-reserve-preflight", kind="deadline",
     )
-    trailer = "\n".join((
-        _staged_class_trailer(closure, closure.register_status),
-        f"STRUCTURAL-PHASE: {phase}\nSTRUCTURAL-PENDING: {reason}\n"
-        "CONVERGENCE: BLOCKED — structural review has not run.",
-    ))
-    if mode == cc.PLAN_MODE and getattr(closure, "claims_enabled", False):
-        trailer = f"{pc.render_trailer(claim_state)}\n{trailer}"
-    return review, trailer, []
+    return _settle_staged_failure(
+        closure, stakes=stakes, snapshot=snapshot, error=error, mode=mode,
+    )
 
 
 def _staged_structural_review(
@@ -1387,8 +1376,8 @@ def critique_plan(
                     )
                     if closure:
                         review, trailer, structural_attempts = _structural_pending_review(
-                            closure, mode=cc.PLAN_MODE, claim_state=claim_state,
-                            reason=pending_reason,
+                            closure, mode=cc.PLAN_MODE, stakes=stakes or "",
+                            snapshot=structural_snapshot, reason=pending_reason,
                         )
                         attempt_ledger.extend(structural_attempts)
                     else:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -145,7 +145,7 @@ def _staged_call(
             **_progress_kwargs(on_progress),
         )
         attempts.append(_attempt(
-            f"{role}-format-retry", engine, retry, sequence=retry_sequence,
+            f"{role}-validation-retry", engine, retry, sequence=retry_sequence,
         ))
         if retry.error:
             error = _engine_failure_error(
@@ -183,11 +183,23 @@ def _staged_error(message: str, *, role: str, kind: str) -> rc.CensusError:
     return error
 
 
+def _staged_lane_prompt(
+    *, mode: str, lane: str, active_classes: list[dict[str, Any]], body: str,
+) -> str:
+    instructions = prompts.staged_census_instructions(mode, lane)
+    lane_body = (
+        f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
+        "ACTIVE CLASSES: "
+        f"{json.dumps(active_classes if lane == 'integrity' else [])}\n\n{body}"
+    )
+    return prompts.compose(instructions, lane_body)
+
+
 def _census_cache_binding(
     *, mode: str, snapshot: str, stakes: str, body: str,
     active_classes: list[dict[str, Any]], existing_debt: list[dict[str, Any]],
     engine_name: str, model: str, effort: str, web_search: bool,
-    plan_lines: int | None,
+    plan_lines: int | None, lane_prompts: dict[str, str],
 ) -> dict[str, Any]:
     canonical_classes = json.dumps(
         sorted(active_classes, key=lambda row: row["class_id"]),
@@ -198,6 +210,7 @@ def _census_cache_binding(
         "active_classes":active_classes, "existing_debt":existing_debt,
         "engine":engine_name, "model":model, "effort":effort,
         "web_search":web_search, "plan_lines":plan_lines,
+        "lane_prompts":lane_prompts,
     }, ensure_ascii=False, sort_keys=True, separators=(",", ":"))
     return {
         "version":rc.CENSUS_CACHE_VERSION,
@@ -480,6 +493,12 @@ def _staged_structural_review(
 
     if phase == "census":
         lanes = rc.LANES[mode]
+        lane_prompts = {
+            lane:_staged_lane_prompt(
+                mode=mode, lane=lane, active_classes=active_classes, body=body,
+            )
+            for lane in lanes
+        }
         existing_debt = [
             d for d in state.get("debt", []) if d.get("status") == "open"
         ]
@@ -488,16 +507,11 @@ def _staged_structural_review(
             active_classes=active_classes, existing_debt=existing_debt,
             engine_name=engine.name, model=model, effort=effort,
             web_search=web_search, plan_lines=plan_lines,
+            lane_prompts=lane_prompts,
         )
 
         def run_lane(lane: str) -> tuple[str, Review, dict[str, Any], list[rc.Attempt]]:
-            instructions = prompts.staged_census_instructions(mode, lane)
-            lane_body = (
-                f"ROLE: census lane {lane}\nCHECKLIST: {json.dumps(rc.CHECKLIST)}\n"
-                "ACTIVE CLASSES: "
-                f"{json.dumps(active_classes if lane == 'integrity' else [])}\n\n{body}"
-            )
-            prompt = prompts.compose(instructions, lane_body)
+            prompt = lane_prompts[lane]
             if len(prompt) > rc.MAX_STAGED_PROMPT_CHARS:
                 raise _staged_error(
                     f"staged lane prompt is {len(prompt)} characters",

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -366,7 +366,10 @@ findings=[{"id":"G1","severity":"MAJOR","summary":"issue","evidence":["path:1"],
 debt=[{"id":"D1","finding_id":"G1","status":"open"}];
 debt_updates=[]; class_dispositions=[{"finding_id":"G1","kind":"one_off","reason":"unique site"}];
 class_records=[]. A violated assessment must map to the same governing finding as
-its cited lane finding; a satisfied assessment maps to null. Do not emit prose."""
+its cited lane finding; a satisfied assessment maps to null. A satisfied active class that is
+currently open and unmechanized must also have {"op":"close","class_id":"that-id"} in
+class_records; an already-closed satisfied class needs no record. The server derives that close if
+it is omitted, but emitting it makes the settlement's lifecycle explicit. Do not emit prose."""
 
 
 STAGED_FOLLOWUP_INSTRUCTIONS = """Perform the staged structural role named in the task. Correction

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -591,6 +591,7 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
     out.pop("format_debt", None)
     out.pop("validation_debt", None)
+    out.pop("staged_failure", None)
     out.pop("census_cache", None)
     out.pop("unbound_classes", None)
     out.pop("unbound_class_ids", None)
@@ -602,7 +603,10 @@ def trailer(state: dict[str, Any]) -> str:
     phase = state.get("phase", "census")
     lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
     validation_debt = state.get("validation_debt") or state.get("format_debt")
-    if validation_debt:
+    if state.get("staged_failure"):
+        lines.append(f"STRUCTURAL-ERROR: {state['staged_failure']}")
+        lines.append("CONVERGENCE: BLOCKED — staged execution did not settle.")
+    elif validation_debt:
         lines.append(f"STRUCTURAL-ERROR: {validation_debt}")
         lines.append("CONVERGENCE: BLOCKED — staged validation debt remains open.")
     elif state.get("unbound_class_ids"):

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -604,8 +604,18 @@ def trailer(state: dict[str, Any]) -> str:
     lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
     validation_debt = state.get("validation_debt") or state.get("format_debt")
     if state.get("staged_failure"):
-        lines.append(f"STRUCTURAL-ERROR: {state['staged_failure']}")
-        lines.append("CONVERGENCE: BLOCKED — staged execution did not settle.")
+        failure = state["staged_failure"]
+        if isinstance(failure, dict):
+            role = failure.get("role", "unknown")
+            kind = failure.get("kind", "unknown")
+            message = failure.get("message", "staged review failed")
+            lines.append(f"STRUCTURAL-ERROR: {message}")
+            lines.append(f"STRUCTURAL-FAILURE: role={role} kind={kind}")
+            lines.append(f"CONVERGENCE: BLOCKED — staged {kind} failure did not settle.")
+        else:
+            # Version-1 state written before structured failure metadata.
+            lines.append(f"STRUCTURAL-ERROR: {failure}")
+            lines.append("CONVERGENCE: BLOCKED — staged failure did not settle.")
     elif validation_debt:
         lines.append(f"STRUCTURAL-ERROR: {validation_debt}")
         lines.append("CONVERGENCE: BLOCKED — staged validation debt remains open.")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -617,7 +617,14 @@ def trailer(state: dict[str, Any]) -> str:
             lines.append(f"STRUCTURAL-ERROR: {failure}")
             lines.append("CONVERGENCE: BLOCKED — staged failure did not settle.")
     elif validation_debt:
-        lines.append(f"STRUCTURAL-ERROR: {validation_debt}")
+        if isinstance(validation_debt, dict):
+            role = validation_debt.get("role", "consolidation-validation-retry")
+            kind = validation_debt.get("kind", "validation")
+            message = validation_debt.get("message", "settlement validation rejected")
+            lines.append(f"STRUCTURAL-ERROR: {message}")
+            lines.append(f"STRUCTURAL-FAILURE: role={role} kind={kind}")
+        else:
+            lines.append(f"STRUCTURAL-ERROR: {validation_debt}")
         lines.append("CONVERGENCE: BLOCKED — staged validation debt remains open.")
     elif state.get("unbound_class_ids"):
         lines.append("CONVERGENCE: BLOCKED — class closure remains open.")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -32,6 +32,7 @@ MAX_CLASS_CONTEXT_CHARS = 64_000
 MAX_STAGED_PROMPT_CHARS = 5_000_000
 MAX_CONSOLIDATION_PROMPT_CHARS = 400_000
 PHASES = frozenset({"census", "correction", "final", "clear"})
+CENSUS_CACHE_VERSION = 1
 
 
 class CensusError(ValueError):
@@ -365,6 +366,20 @@ def parse_settlement(
                 raise CensusError(
                     "source fan-out requires distinct violated existing-class findings"
                 )
+    declared_class_ops = {
+        record.get("class_id") for record in obj["class_records"]
+        if isinstance(record, dict) and isinstance(record.get("class_id"), str)
+    }
+    for cid, verdict in (assessment_verdicts or {}).items():
+        if verdict != "satisfied" or class_states is None or cid not in class_states:
+            continue
+        status, mechanized, _ = class_states[cid]
+        if status in cc.UNPROVEN_STATUSES and not mechanized and cid not in declared_class_ops:
+            # The assessment is the model judgement. Closing the corresponding open,
+            # unmechanized class is its deterministic lifecycle consequence; requiring
+            # the model to restate that consequence made healthy censuses fail wholesale.
+            obj["class_records"].append({"op":"close", "class_id":cid})
+            declared_class_ops.add(cid)
     operation_by_class: dict[str, str] = {}
     for record in obj["class_records"]:
         cid = record.get("class_id") if isinstance(record, dict) else None
@@ -575,6 +590,8 @@ def settle_state(state: dict[str, Any], settlement: dict[str, Any], *, phase: st
     out = dict(state)
     out.update(phase=next_phase, snapshot_digest=snapshot, debt=list(old.values()), last_round=round_no)
     out.pop("format_debt", None)
+    out.pop("validation_debt", None)
+    out.pop("census_cache", None)
     out.pop("unbound_classes", None)
     out.pop("unbound_class_ids", None)
     return out
@@ -584,9 +601,10 @@ def trailer(state: dict[str, Any]) -> str:
     debt = [d for d in state.get("debt", []) if d.get("status") == "open" and d.get("severity") in BLOCKING]
     phase = state.get("phase", "census")
     lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
-    if state.get("format_debt"):
-        lines.append(f"STRUCTURAL-ERROR: {state['format_debt']}")
-        lines.append("CONVERGENCE: BLOCKED — staged format debt remains open.")
+    validation_debt = state.get("validation_debt") or state.get("format_debt")
+    if validation_debt:
+        lines.append(f"STRUCTURAL-ERROR: {validation_debt}")
+        lines.append("CONVERGENCE: BLOCKED — staged validation debt remains open.")
     elif state.get("unbound_class_ids"):
         lines.append("CONVERGENCE: BLOCKED — class closure remains open.")
     elif phase == "final":

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -48,6 +48,7 @@ def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:
 
     assert review.error is False
     assert review.text == "settled"
+    assert review.failure_detail is None
 
 
 def test_codex_terminal_error_remains_a_failure() -> None:
@@ -59,6 +60,8 @@ def test_codex_terminal_error_remains_a_failure() -> None:
     )
 
     assert review.error is True
+    assert review.text == "partial"
+    assert review.failure_detail == "terminal"
 
 class TestCodexArgv:
     def test_build_argv_read_only_and_model_and_effort(self) -> None:
@@ -229,6 +232,28 @@ class TestRunWithInjectedRunner:
         )
         assert "error" in review.text.lower()
         assert "auth failed" in review.text
+        assert review.failure_detail == "auth failed: not logged in"
+
+    def test_process_failure_detail_is_not_masked_by_partial_output(self) -> None:
+        e = engines.get_engine("codex")
+        partial = (
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"partial reviewer output"}}\n'
+        )
+
+        def fake_runner(argv, stdin_text, cwd, timeout):
+            return RunResult(
+                returncode=9, stdout=partial,
+                stderr="terminal process diagnostic\n",
+            )
+
+        review = e.run(
+            prompt="x", cwd=Path("/repo"), model="m", effort="high",
+            web_search=False, runner=fake_runner,
+        )
+        assert review.error is True
+        assert review.text == "partial reviewer output"
+        assert review.failure_detail == "terminal process diagnostic\n"
 
     def test_resume_uses_resume_argv(self) -> None:
         e = engines.get_engine("claude")

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -775,10 +775,47 @@ def test_staged_timeout_preserves_kind_message_state_and_trailer(tmp_path):
     closure.release()
     assert closure.lineage.review_state["staged_failure"] == {
         "role":"consolidation", "kind":"timeout",
-        "message":"consolidation timeout: [paranoia-local error] timed out after 1800s",
+        "message":"[paranoia-local error] timed out after 1800s",
     }
     assert "STRUCTURAL-FAILURE: role=consolidation kind=timeout" in trailer
     assert "CONVERGENCE: BLOCKED — staged timeout failure did not settle." in trailer
+
+
+@pytest.mark.parametrize("returncode", [-15, -2, 130, 143])
+def test_staged_cancellation_preserves_exact_kind_and_message(tmp_path, returncode):
+    message = "cancelled by operator\nwithout rewriting"
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            return Review(
+                text=message, session_ref=None, raw=message,
+                returncode=returncode, error=True,
+            )
+
+    with pytest.raises(rc.CensusError) as caught:
+        handlers._staged_call(
+            role="coverage", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=1800, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: {},
+        )
+    assert str(caught.value) == message
+    assert caught.value.failure_kind == "cancellation"
+    closure = handlers._PlanClassClosure(
+        f"cancel-{returncode}", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"coverage", "kind":"cancellation", "message":message,
+    }
+    assert f"STRUCTURAL-ERROR: {message}" in trailer
+    assert "CONVERGENCE: BLOCKED — staged cancellation failure did not settle." in trailer
 
 
 def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
@@ -795,7 +832,7 @@ def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
                 returncode=124, error=True,
             )
 
-    with pytest.raises(rc.CensusError, match="validation-retry timeout") as caught:
+    with pytest.raises(rc.CensusError, match="reviewer timed out") as caught:
         handlers._staged_call(
             role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
             model="m", effort="high", timeout=1800, on_progress=None,
@@ -807,6 +844,17 @@ def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
     assert caught.value.stage_role == "consolidation-validation-retry"
     assert caught.value.failure_kind == "timeout"
     assert not handlers._cacheable_consolidation_error(caught.value)
+
+
+def test_staged_execution_failure_preserves_exact_message():
+    message = "engine failed\nwith useful detail"
+    error = handlers._engine_failure_error(
+        Review(text=message, session_ref=None, raw=message, returncode=9, error=True),
+        role="consolidation",
+    )
+    assert error.stage_role == "consolidation"
+    assert error.failure_kind == "execution"
+    assert str(error) == message
 
 
 def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1033,11 +1033,13 @@ def test_state_unavailable_result_has_five_headings(tmp_path):
     assert_five_headings(review.text)
 
 
-def test_staged_format_failure_retains_canonical_class_trailer(tmp_path):
+def test_staged_generic_failure_clears_old_cache_and_uses_matching_debt(tmp_path):
     closure = handlers._PlanClassClosure(
         "format-failure", round_no=1, state_root=tmp_path, stamp="T",
     )
     closure.prepare()
+    closure.lineage.review_state = rc.normalize_state({}, stakes="s", snapshot="p")
+    closure.lineage.review_state["census_cache"] = {"stale":True}
     review, trailer, attempts = handlers._settle_staged_failure(
         closure, stakes="s", snapshot="p", error=rc.CensusError("bad settlement"),
         mode=cc.PLAN_MODE,
@@ -1047,6 +1049,9 @@ def test_staged_format_failure_retains_canonical_class_trailer(tmp_path):
     assert "CLASS-REGISTER: staged rejected: bad settlement" in trailer
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
     assert "STRUCTURAL-ERROR: bad settlement" in trailer
+    assert "census_cache" not in closure.lineage.review_state
+    assert closure.lineage.review_state["staged_failure"] == "bad settlement"
+    assert "validation_debt" not in closure.lineage.review_state
 
 
 def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
@@ -1431,6 +1436,8 @@ def test_branch_reuses_complete_census_after_settlement_rejection(
         mode=cc.BRANCH_MODE,
     )
     assert len(lineage.review_state["census_cache"]["manifests"]) == 3
+    assert "validation_debt" in lineage.review_state
+    assert "staged_failure" not in lineage.review_state
     assert calls.count("consolidation") == 1
     assert sum(call.startswith("lane:") for call in calls) == 3
 

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1047,22 +1047,28 @@ def test_staged_generic_failure_clears_old_cache_and_uses_matching_debt(tmp_path
     closure.prepare()
     closure.lineage.review_state = rc.normalize_state({}, stakes="s", snapshot="p")
     closure.lineage.review_state["census_cache"] = {"stale":True}
+    error = handlers._staged_error(
+        "provider exited", role="correction", kind="execution",
+    )
     review, trailer, attempts = handlers._settle_staged_failure(
-        closure, stakes="s", snapshot="p", error=rc.CensusError("bad settlement"),
+        closure, stakes="s", snapshot="p", error=error,
         mode=cc.PLAN_MODE,
     )
     closure.release()
     assert review.error and attempts == []
-    assert "CLASS-REGISTER: staged rejected: bad settlement" in trailer
+    assert "CLASS-REGISTER: staged rejected: provider exited" in trailer
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
-    assert "STRUCTURAL-ERROR: bad settlement" in trailer
-    assert "CONVERGENCE: BLOCKED — staged execution did not settle." in trailer
+    assert "STRUCTURAL-ERROR: provider exited" in trailer
+    assert "STRUCTURAL-FAILURE: role=correction kind=execution" in trailer
+    assert "CONVERGENCE: BLOCKED — staged execution failure did not settle." in trailer
     assert "census_cache" not in closure.lineage.review_state
-    assert closure.lineage.review_state["staged_failure"] == "bad settlement"
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"correction", "kind":"execution", "message":"provider exited",
+    }
     assert "validation_debt" not in closure.lineage.review_state
 
 
-def test_staged_validation_failure_without_cache_renders_validation_debt(tmp_path):
+def test_consolidation_preflight_validation_without_cache_is_structured_failure(tmp_path):
     closure = handlers._PlanClassClosure(
         "validation-failure", round_no=1, state_root=tmp_path, stamp="T",
     )
@@ -1075,9 +1081,12 @@ def test_staged_validation_failure_without_cache_renders_validation_debt(tmp_pat
     )
     closure.release()
     assert review.error and attempts == []
-    assert closure.lineage.review_state["validation_debt"] == "lane schema rejected"
-    assert "staged_failure" not in closure.lineage.review_state
-    assert "CONVERGENCE: BLOCKED — staged validation debt remains open." in trailer
+    assert "validation_debt" not in closure.lineage.review_state
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"consolidation", "kind":"validation", "message":"lane schema rejected",
+    }
+    assert "STRUCTURAL-FAILURE: role=consolidation kind=validation" in trailer
+    assert "CONVERGENCE: BLOCKED — staged validation failure did not settle." in trailer
 
 
 def test_lane_validation_failure_remains_generic_staged_failure(tmp_path):
@@ -1092,9 +1101,51 @@ def test_lane_validation_failure_remains_generic_staged_failure(tmp_path):
         closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
     )
     closure.release()
-    assert closure.lineage.review_state["staged_failure"] == "lane prompt exceeds ceiling"
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"census-domain", "kind":"validation",
+        "message":"lane prompt exceeds ceiling",
+    }
     assert "validation_debt" not in closure.lineage.review_state
-    assert "CONVERGENCE: BLOCKED — staged execution did not settle." in trailer
+    assert "STRUCTURAL-FAILURE: role=census-domain kind=validation" in trailer
+    assert "CONVERGENCE: BLOCKED — staged validation failure did not settle." in trailer
+
+
+def test_consolidation_prompt_ceiling_is_noncacheable_structured_validation(
+    tmp_path, monkeypatch,
+):
+    closure = handlers._PlanClassClosure(
+        "consolidation-preflight", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+
+    class Engine:
+        name = "fake"
+
+        def run(self, prompt, *args, **kwargs):
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            text = lane(lane_name)
+            return Review(text=text, session_ref="s", raw=text)
+
+    monkeypatch.setattr(rc, "MAX_CONSOLIDATION_PROMPT_CHARS", 1)
+    with pytest.raises(rc.CensusError, match="consolidation prompt") as caught:
+        handlers._staged_structural_review(
+            engine=Engine(), cwd=tmp_path, model="m", effort="high",
+            mode=cc.PLAN_MODE, body="artifact", closure=closure, stakes="s",
+            snapshot="p", round_no=1, on_progress=None, plan_lines=1,
+        )
+    assert caught.value.stage_role == "consolidation"
+    assert caught.value.failure_kind == "validation"
+    assert not handlers._cacheable_consolidation_error(caught.value)
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert "STRUCTURAL-FAILURE: role=consolidation kind=validation" in trailer
+    assert "validation_debt" not in closure.lineage.review_state
+    assert "census_cache" not in closure.lineage.review_state
 
 
 def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1162,15 +1162,21 @@ def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_pa
     )
     closure.prepare()
     review, trailer, attempts = handlers._structural_pending_review(
-        closure, mode=cc.PLAN_MODE, claim_state=pc.empty_state(),
+        closure, mode=cc.PLAN_MODE, stakes="s", snapshot="p",
         reason="not enough bounded time",
     )
     closure.release()
     assert review.error and attempts == []
     assert_five_headings(review.text)
-    assert "CLASS-REGISTER: structural pending" in trailer
+    assert "CLASS-REGISTER: staged rejected: not enough bounded time" in trailer
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
-    assert "STRUCTURAL-PENDING" in trailer and "CONVERGENCE: BLOCKED" in trailer
+    assert "STRUCTURAL-ERROR: not enough bounded time" in trailer
+    assert "STRUCTURAL-FAILURE: role=structural-reserve-preflight kind=deadline" in trailer
+    assert "CONVERGENCE: BLOCKED — staged deadline failure did not settle." in trailer
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"structural-reserve-preflight", "kind":"deadline",
+        "message":"not enough bounded time",
+    }
     assert not (cc.lineage_dir(tmp_path) / "pending-plan.pending").exists()
 
 

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -722,6 +722,7 @@ def test_no_session_validation_failure_is_not_mislabeled_as_format(tmp_path):
             ),
         )
     assert "format invalid" not in str(caught.value)
+    assert caught.value.failure_kind == "validation"
     assert [row.outcome for row in caught.value.attempts] == ["validation-invalid"]
 
 
@@ -1049,9 +1050,27 @@ def test_staged_generic_failure_clears_old_cache_and_uses_matching_debt(tmp_path
     assert "CLASS-REGISTER: staged rejected: bad settlement" in trailer
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
     assert "STRUCTURAL-ERROR: bad settlement" in trailer
+    assert "CONVERGENCE: BLOCKED — staged execution did not settle." in trailer
     assert "census_cache" not in closure.lineage.review_state
     assert closure.lineage.review_state["staged_failure"] == "bad settlement"
     assert "validation_debt" not in closure.lineage.review_state
+
+
+def test_staged_validation_failure_without_cache_renders_validation_debt(tmp_path):
+    closure = handlers._PlanClassClosure(
+        "validation-failure", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    error = rc.CensusError("lane schema rejected")
+    error.failure_kind = "validation"  # type: ignore[attr-defined]
+    review, trailer, attempts = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert review.error and attempts == []
+    assert closure.lineage.review_state["validation_debt"] == "lane schema rejected"
+    assert "staged_failure" not in closure.lineage.review_state
+    assert "CONVERGENCE: BLOCKED — staged validation debt remains open." in trailer
 
 
 def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(
@@ -1431,6 +1450,7 @@ def test_branch_reuses_complete_census_after_settlement_rejection(
         log_dir=tmp_path / "logs", now=lambda: "C1",
     )
     assert "STRUCTURAL-ERROR" in first
+    assert "CONVERGENCE: BLOCKED — staged validation debt remains open." in first
     lineage = cc.load_lineage(
         cc.default_state_root(), "cached-census-branch", stamp="C2",
         mode=cc.BRANCH_MODE,

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -36,7 +36,8 @@ def test_census_cache_requires_every_exact_binding():
     manifests = [payload(lane(name)) for name in lanes]
     binding = handlers._census_cache_binding(
         mode=cc.PLAN_MODE, snapshot="snapshot", stakes="stakes", body="body",
-        active_classes=[],
+        active_classes=[], existing_debt=[], engine_name="codex", model="model",
+        effort="high", web_search=False, plan_lines=3,
     )
     state = {"census_cache":{**binding, "manifests":manifests}}
 
@@ -56,6 +57,26 @@ def test_census_cache_requires_every_exact_binding():
     assert handlers._cached_census_manifests(
         incomplete, binding=binding, lanes=lanes, validate=validate,
     ) is None
+
+
+def test_only_terminal_validation_rejection_can_cache_completed_lanes():
+    def error(*outcomes):
+        value = rc.CensusError("rejected")
+        value.attempts = [  # type: ignore[attr-defined]
+            rc.Attempt("consolidation", "codex", "s", outcome, None, None)
+            for outcome in outcomes
+        ]
+        return value
+
+    assert handlers._cacheable_consolidation_error(error("validation-invalid"))
+    assert handlers._cacheable_consolidation_error(error(
+        "validation-invalid", "validation-invalid",
+    ))
+    assert not handlers._cacheable_consolidation_error(error("failed"))
+    assert not handlers._cacheable_consolidation_error(error(
+        "validation-invalid", "failed",
+    ))
+    assert not handlers._cacheable_consolidation_error(rc.CensusError("oversized"))
 
 
 def assert_five_headings(text):
@@ -681,6 +702,27 @@ def test_evidence_anchors_resolve_against_snapshot(tmp_path):
         {"evidence":["repository/README.md:1"]}, root=tmp_path,
         trusted_roots={"repository":materialized},
     )
+
+
+def test_no_session_validation_failure_is_not_mislabeled_as_format(tmp_path):
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, {"role":"census"})
+            return Review(text=text, session_ref=None, raw=text)
+
+    with pytest.raises(rc.CensusError, match="validation invalid") as caught:
+        handlers._staged_call(
+            role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=10, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=[], assessment_ids=[],
+            ),
+        )
+    assert "format invalid" not in str(caught.value)
+    assert [row.outcome for row in caught.value.attempts] == ["validation-invalid"]
 
 
 def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -62,6 +62,8 @@ def test_census_cache_requires_every_exact_binding():
 def test_only_terminal_validation_rejection_can_cache_completed_lanes():
     def error(*outcomes):
         value = rc.CensusError("rejected")
+        value.stage_role = "consolidation"  # type: ignore[attr-defined]
+        value.failure_kind = "validation"  # type: ignore[attr-defined]
         value.attempts = [  # type: ignore[attr-defined]
             rc.Attempt("consolidation", "codex", "s", outcome, None, None)
             for outcome in outcomes
@@ -76,6 +78,9 @@ def test_only_terminal_validation_rejection_can_cache_completed_lanes():
     assert not handlers._cacheable_consolidation_error(error(
         "validation-invalid", "failed",
     ))
+    lane_error = error("validation-invalid")
+    lane_error.stage_role = "census-domain"  # type: ignore[attr-defined]
+    assert not handlers._cacheable_consolidation_error(lane_error)
     assert not handlers._cacheable_consolidation_error(rc.CensusError("oversized"))
 
 
@@ -722,6 +727,7 @@ def test_no_session_validation_failure_is_not_mislabeled_as_format(tmp_path):
             ),
         )
     assert "format invalid" not in str(caught.value)
+    assert caught.value.stage_role == "consolidation"
     assert caught.value.failure_kind == "validation"
     assert [row.outcome for row in caught.value.attempts] == ["validation-invalid"]
 
@@ -1062,6 +1068,7 @@ def test_staged_validation_failure_without_cache_renders_validation_debt(tmp_pat
     )
     closure.prepare()
     error = rc.CensusError("lane schema rejected")
+    error.stage_role = "consolidation"  # type: ignore[attr-defined]
     error.failure_kind = "validation"  # type: ignore[attr-defined]
     review, trailer, attempts = handlers._settle_staged_failure(
         closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
@@ -1071,6 +1078,23 @@ def test_staged_validation_failure_without_cache_renders_validation_debt(tmp_pat
     assert closure.lineage.review_state["validation_debt"] == "lane schema rejected"
     assert "staged_failure" not in closure.lineage.review_state
     assert "CONVERGENCE: BLOCKED — staged validation debt remains open." in trailer
+
+
+def test_lane_validation_failure_remains_generic_staged_failure(tmp_path):
+    closure = handlers._PlanClassClosure(
+        "lane-validation-failure", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    error = handlers._staged_error(
+        "lane prompt exceeds ceiling", role="census-domain", kind="validation",
+    )
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert closure.lineage.review_state["staged_failure"] == "lane prompt exceeds ceiling"
+    assert "validation_debt" not in closure.lineage.review_state
+    assert "CONVERGENCE: BLOCKED — staged execution did not settle." in trailer
 
 
 def test_staged_settlement_save_failure_retains_latch_and_five_heading_result(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -860,33 +860,48 @@ def test_staged_execution_failure_preserves_exact_message():
 
 
 @pytest.mark.parametrize(
-    ("engine_name", "stdout"),
+    ("engine_name", "stdout", "stderr", "expected_text", "expected_detail"),
     [
         (
             "codex",
             '{"type":"item.completed","item":{"type":"agent_message",'
             '"text":"partial"}}\n',
+            "", "partial", "codex exited with return code 9",
         ),
         (
             "claude",
             '{"is_error":false,"result":"partial","session_id":"s"}',
+            "", "partial", "claude exited with return code 9",
+        ),
+        (
+            "codex",
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"partial"}}\n'
+            '{"type":"turn.failed","error":{"message":'
+            '"terminal provider diagnostic"}}\n',
+            " \n\t", "partial", "terminal provider diagnostic",
+        ),
+        (
+            "claude",
+            '{"is_error":true,"result":"terminal provider diagnostic",'
+            '"session_id":"s"}',
+            " \n\t", "terminal provider diagnostic", "terminal provider diagnostic",
         ),
     ],
 )
-def test_empty_stderr_process_exit_reaches_staged_trailer(
-    tmp_path, engine_name, stdout,
+def test_empty_or_whitespace_stderr_process_exit_reaches_staged_trailer(
+    tmp_path, engine_name, stdout, stderr, expected_text, expected_detail,
 ):
     engine = engines.get_engine(engine_name)
 
     def runner(argv, stdin_text, cwd, timeout):
-        return RunResult(returncode=9, stdout=stdout, stderr="")
+        return RunResult(returncode=9, stdout=stdout, stderr=stderr)
 
     review = engine.run(
         "p", tmp_path, engine.default_model, "high", False, runner=runner,
     )
-    expected = f"{engine_name} exited with return code 9"
-    assert review.text == "partial"
-    assert review.failure_detail == expected
+    assert review.text == expected_text
+    assert review.failure_detail == expected_detail
     error = handlers._engine_failure_error(review, role="consolidation")
     closure = handlers._PlanClassClosure(
         f"empty-stderr-{engine_name}", round_no=1, state_root=tmp_path, stamp="T",
@@ -897,9 +912,9 @@ def test_empty_stderr_process_exit_reaches_staged_trailer(
     )
     closure.release()
     assert closure.lineage.review_state["staged_failure"] == {
-        "role":"consolidation", "kind":"execution", "message":expected,
+        "role":"consolidation", "kind":"execution", "message":expected_detail,
     }
-    assert f"STRUCTURAL-ERROR: {expected}" in trailer
+    assert f"STRUCTURAL-ERROR: {expected_detail}" in trailer
 
 
 def test_oversized_class_preflight_persists_exact_validation_identity(tmp_path):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -85,6 +85,9 @@ def test_only_terminal_validation_rejection_can_cache_completed_lanes():
     assert handlers._cacheable_consolidation_error(error(
         "validation-invalid", "validation-invalid",
     ))
+    retry_error = error("validation-invalid", "validation-invalid")
+    retry_error.stage_role = "consolidation-validation-retry"  # type: ignore[attr-defined]
+    assert handlers._cacheable_consolidation_error(retry_error)
     assert not handlers._cacheable_consolidation_error(error("failed"))
     assert not handlers._cacheable_consolidation_error(error(
         "validation-invalid", "failed",
@@ -1599,13 +1602,17 @@ def test_branch_reuses_complete_census_after_settlement_rejection(
         log_dir=tmp_path / "logs", now=lambda: "C1",
     )
     assert "STRUCTURAL-ERROR" in first
+    assert "STRUCTURAL-FAILURE: role=consolidation-validation-retry kind=validation" in first
     assert "CONVERGENCE: BLOCKED — staged validation debt remains open." in first
     lineage = cc.load_lineage(
         cc.default_state_root(), "cached-census-branch", stamp="C2",
         mode=cc.BRANCH_MODE,
     )
     assert len(lineage.review_state["census_cache"]["manifests"]) == 3
-    assert "validation_debt" in lineage.review_state
+    assert lineage.review_state["validation_debt"]["role"] == (
+        "consolidation-validation-retry"
+    )
+    assert lineage.review_state["validation_debt"]["kind"] == "validation"
     assert "staged_failure" not in lineage.review_state
     assert calls.count("consolidation") == 1
     assert sum(call.startswith("lane:") for call in calls) == 3

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -31,6 +31,33 @@ def test_staged_timeouts_are_generous_and_reserves_cover_full_retry_paths():
     )
 
 
+def test_census_cache_requires_every_exact_binding():
+    lanes = rc.LANES[cc.PLAN_MODE]
+    manifests = [payload(lane(name)) for name in lanes]
+    binding = handlers._census_cache_binding(
+        mode=cc.PLAN_MODE, snapshot="snapshot", stakes="stakes", body="body",
+        active_classes=[],
+    )
+    state = {"census_cache":{**binding, "manifests":manifests}}
+
+    def validate(text, lane_name):
+        return rc.parse_lane(text, lane=lane_name)
+
+    assert handlers._cached_census_manifests(
+        state, binding=binding, lanes=lanes, validate=validate,
+    ) == manifests
+    for key in binding:
+        changed = dict(binding)
+        changed[key] = f"different-{binding[key]}"
+        assert handlers._cached_census_manifests(
+            state, binding=changed, lanes=lanes, validate=validate,
+        ) is None
+    incomplete = {"census_cache":{**binding, "manifests":manifests[:-1]}}
+    assert handlers._cached_census_manifests(
+        incomplete, binding=binding, lanes=lanes, validate=validate,
+    ) is None
+
+
 def assert_five_headings(text):
     assert [line for line in text.splitlines() if line.startswith("## ")] == list(HEADINGS)
 
@@ -177,6 +204,34 @@ def test_existing_class_disposition_cannot_contradict_satisfied_or_closed_state(
             assessment_verdicts={"abc":"satisfied"},
             class_states={"abc":(cc.CLOSED, False, "MAJOR")},
         )
+
+
+def test_open_unmechanized_satisfied_class_gets_deterministic_close():
+    assert "currently open and unmechanized must also have" in (
+        prompts.STAGED_CONSOLIDATION_INSTRUCTIONS
+    )
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[], findings=[], debt=[], class_dispositions=[],
+        assessment_dispositions=[{"assessment_id":"abc", "governing_id":None}],
+        class_records=[],
+    )
+    parsed = rc.parse_settlement(
+        wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+        assessment_verdicts={"abc":"satisfied"},
+        class_states={"abc":(cc.OPEN, False, "MAJOR")},
+    )
+    assert parsed["class_records"] == [{"op":"close", "class_id":"abc"}]
+    register = rc.register_from_records(parsed["class_records"], mechanized=False)
+    assert register.transitions[0].kind == "CLOSED"
+
+    with pytest.raises(rc.CensusError, match="mechanized open class cannot be model-closed"):
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+            assessment_verdicts={"abc":"satisfied"},
+            class_states={"abc":(cc.OPEN, True, "MAJOR")},
+        )
+
 
 def test_correction_existing_class_binding_requires_a_matching_violated_assessment():
     value = payload(settlement())
@@ -652,7 +707,7 @@ def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
         ),
     )
     assert parsed["debt"][0]["id"] == "D1"
-    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+    assert [row.outcome for row in attempts] == ["validation-invalid", "completed"]
 
 
 def test_staged_retry_repeats_exact_shapes_after_multirow_schema_drift(tmp_path):
@@ -686,7 +741,7 @@ def test_staged_retry_repeats_exact_shapes_after_multirow_schema_drift(tmp_path)
         ),
     )
     assert parsed["findings"][0]["remedy"] == "fix it"
-    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+    assert [row.outcome for row in attempts] == ["validation-invalid", "completed"]
 
 
 def test_malformed_referenced_new_class_row_stays_in_bounded_format_retry(tmp_path):
@@ -716,7 +771,7 @@ def test_malformed_referenced_new_class_row_stays_in_bounded_format_retry(tmp_pa
         ),
     )
     assert parsed["class_dispositions"][0]["kind"] == "one_off"
-    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+    assert [row.outcome for row in attempts] == ["validation-invalid", "completed"]
 
 
 def test_staged_retry_names_advisory_class_debt_invariant(tmp_path):
@@ -754,7 +809,7 @@ def test_staged_retry_names_advisory_class_debt_invariant(tmp_path):
         ),
     )
     assert parsed["debt"][0]["severity"] == "OUT-OF-SCOPE"
-    assert [row.outcome for row in attempts] == ["format-invalid", "completed"]
+    assert [row.outcome for row in attempts] == ["validation-invalid", "completed"]
 
 
 def test_violated_class_cannot_be_replaced_at_lower_severity():
@@ -891,7 +946,7 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
         "census-domain", "census-domain-format-retry",
     ]
     assert [attempt.sequence for attempt in attempts] == [None, None]
-    assert [attempt.outcome for attempt in attempts] == ["format-invalid", "completed"]
+    assert [attempt.outcome for attempt in attempts] == ["validation-invalid", "completed"]
     assert all(attempt.response_sha256 and attempt.response_excerpt for attempt in attempts)
 
 
@@ -1278,6 +1333,80 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     third_audit = json.loads(next((tmp_path / "logs").glob("T3-critique_plan-*.json")).read_text())
     assert [row["role"] for row in second_audit["attempt_ledger"]] == ["correction"]
     assert [row["role"] for row in third_audit["attempt_ledger"]] == ["final"]
+
+
+def test_branch_reuses_complete_census_after_settlement_rejection(
+    repo_with_branch, tmp_path, monkeypatch,
+):
+    calls: list[str] = []
+    accept_settlement = False
+
+    def invalid_settlement():
+        return wire(rc.SETTLEMENT_MARKER, {"role":"census"})
+
+    def valid_settlement():
+        return wire(rc.SETTLEMENT_MARKER, {
+            "role":"census", "source_dispositions":[],
+            "assessment_dispositions":[], "findings":[], "debt":[],
+            "debt_updates":[], "class_dispositions":[], "class_records":[],
+        })
+
+    def run(self, prompt, *args, **kwargs):
+        nonlocal accept_settlement
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            calls.append(f"lane:{lane_name}")
+            value = payload(lane(lane_name))
+            for row in value["coverage"]:
+                row["evidence"] = ["repository/README.md:1"]
+            text = wire(rc.LANE_MARKER, value)
+        else:
+            calls.append("consolidation")
+            text = valid_settlement() if accept_settlement else invalid_settlement()
+        return Review(text=text, session_ref="cache-session", raw=text)
+
+    def resume(self, *args, **kwargs):
+        calls.append("consolidation-retry")
+        text = invalid_settlement()
+        return Review(text=text, session_ref="cache-session", raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    monkeypatch.setattr(handlers.eng.CodexEngine, "resume", resume)
+    args = {
+        "repo_path":str(repo_with_branch), "base_ref":"main", "head_ref":"feature",
+        "lineage":"cached-census-branch", "stakes":"trusted local tool",
+    }
+    first = handlers.critique_branch(
+        {**args, "round":1}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda: "C1",
+    )
+    assert "STRUCTURAL-ERROR" in first
+    lineage = cc.load_lineage(
+        cc.default_state_root(), "cached-census-branch", stamp="C2",
+        mode=cc.BRANCH_MODE,
+    )
+    assert len(lineage.review_state["census_cache"]["manifests"]) == 3
+    assert calls.count("consolidation") == 1
+    assert sum(call.startswith("lane:") for call in calls) == 3
+
+    accept_settlement = True
+    second = handlers.critique_branch(
+        {**args, "round":2}, engine=handlers.eng.CodexEngine(),
+        log_dir=tmp_path / "logs", now=lambda: "C2",
+    )
+    assert "CONVERGENCE: NOT-BLOCKED" in second
+    assert calls.count("consolidation") == 2
+    assert sum(call.startswith("lane:") for call in calls) == 3
+    lineage = cc.load_lineage(
+        cc.default_state_root(), "cached-census-branch", stamp="C3",
+        mode=cc.BRANCH_MODE,
+    )
+    assert "census_cache" not in lineage.review_state
+    audit = json.loads(next((tmp_path / "logs").glob("C2-critique_branch-*.json")).read_text())
+    assert [row["role"] for row in audit["attempt_ledger"]] == ["consolidation"]
 
 
 def test_branch_codex_runs_the_staged_census_path(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -5,9 +5,11 @@ import subprocess
 import pytest
 
 from paranoia_local import (
-    class_closure as cc, handlers, plan_claims as pc, prompts, review_census as rc,
+    class_closure as cc, engines, handlers, plan_claims as pc, prompts,
+    review_census as rc,
 )
 from paranoia_local.engines import Review
+from paranoia_local.runner import RunResult
 
 
 HEADINGS = (
@@ -855,6 +857,49 @@ def test_staged_execution_failure_preserves_exact_message():
     assert error.stage_role == "consolidation"
     assert error.failure_kind == "execution"
     assert str(error) == message
+
+
+@pytest.mark.parametrize(
+    ("engine_name", "stdout"),
+    [
+        (
+            "codex",
+            '{"type":"item.completed","item":{"type":"agent_message",'
+            '"text":"partial"}}\n',
+        ),
+        (
+            "claude",
+            '{"is_error":false,"result":"partial","session_id":"s"}',
+        ),
+    ],
+)
+def test_empty_stderr_process_exit_reaches_staged_trailer(
+    tmp_path, engine_name, stdout,
+):
+    engine = engines.get_engine(engine_name)
+
+    def runner(argv, stdin_text, cwd, timeout):
+        return RunResult(returncode=9, stdout=stdout, stderr="")
+
+    review = engine.run(
+        "p", tmp_path, engine.default_model, "high", False, runner=runner,
+    )
+    expected = f"{engine_name} exited with return code 9"
+    assert review.text == "partial"
+    assert review.failure_detail == expected
+    error = handlers._engine_failure_error(review, role="consolidation")
+    closure = handlers._PlanClassClosure(
+        f"empty-stderr-{engine_name}", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"consolidation", "kind":"execution", "message":expected,
+    }
+    assert f"STRUCTURAL-ERROR: {expected}" in trailer
 
 
 def test_oversized_class_preflight_persists_exact_validation_identity(tmp_path):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -857,6 +857,28 @@ def test_staged_execution_failure_preserves_exact_message():
     assert str(error) == message
 
 
+def test_oversized_class_preflight_persists_exact_validation_identity(tmp_path):
+    with pytest.raises(rc.CensusError, match="STATE-OVERSIZED") as caught:
+        handlers._staged_class_context(["x" * (rc.MAX_CLASS_CONTEXT_CHARS + 1)])
+    assert caught.value.stage_role == "active-class-preflight"
+    assert caught.value.failure_kind == "validation"
+    closure = handlers._PlanClassClosure(
+        "oversized-classes", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    failure = closure.lineage.review_state["staged_failure"]
+    assert failure == {
+        "role":"active-class-preflight", "kind":"validation",
+        "message":str(caught.value),
+    }
+    assert f"STRUCTURAL-ERROR: {caught.value}" in trailer
+    assert "STRUCTURAL-FAILURE: role=active-class-preflight kind=validation" in trailer
+
+
 def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
     invalid = payload(settlement())
     invalid["debt"][0]["id"] = ""

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -732,6 +732,69 @@ def test_no_session_validation_failure_is_not_mislabeled_as_format(tmp_path):
     assert [row.outcome for row in caught.value.attempts] == ["validation-invalid"]
 
 
+def test_staged_timeout_preserves_kind_message_state_and_trailer(tmp_path):
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            return Review(
+                text="[paranoia-local error] timed out after 1800s",
+                session_ref=None, raw="timed out after 1800s", returncode=124, error=True,
+            )
+
+    with pytest.raises(rc.CensusError, match="timed out after 1800s") as caught:
+        handlers._staged_call(
+            role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=1800, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: {},
+        )
+    assert caught.value.stage_role == "consolidation"
+    assert caught.value.failure_kind == "timeout"
+    closure = handlers._PlanClassClosure(
+        "timeout-failure", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    _, trailer, _ = handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert closure.lineage.review_state["staged_failure"] == {
+        "role":"consolidation", "kind":"timeout",
+        "message":"consolidation timeout: [paranoia-local error] timed out after 1800s",
+    }
+    assert "STRUCTURAL-FAILURE: role=consolidation kind=timeout" in trailer
+    assert "CONVERGENCE: BLOCKED — staged timeout failure did not settle." in trailer
+
+
+def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(rc.SETTLEMENT_MARKER, {"role":"census"})
+            return Review(text=text, session_ref="s", raw=text)
+
+        def resume(self, *args, **kwargs):
+            return Review(
+                text="reviewer timed out", session_ref="s", raw="reviewer timed out",
+                returncode=124, error=True,
+            )
+
+    with pytest.raises(rc.CensusError, match="validation-retry timeout") as caught:
+        handlers._staged_call(
+            role="consolidation", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=1800, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=[], assessment_ids=[],
+            ),
+        )
+    assert caught.value.stage_role == "consolidation-validation-retry"
+    assert caught.value.failure_kind == "timeout"
+    assert not handlers._cacheable_consolidation_error(caught.value)
+
+
 def test_empty_debt_id_gets_one_same_session_format_retry(tmp_path):
     invalid = payload(settlement())
     invalid["debt"][0]["id"] = ""

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -34,10 +34,11 @@ def test_staged_timeouts_are_generous_and_reserves_cover_full_retry_paths():
 def test_census_cache_requires_every_exact_binding():
     lanes = rc.LANES[cc.PLAN_MODE]
     manifests = [payload(lane(name)) for name in lanes]
+    lane_prompts = {name:f"prompt-{name}" for name in lanes}
     binding = handlers._census_cache_binding(
         mode=cc.PLAN_MODE, snapshot="snapshot", stakes="stakes", body="body",
         active_classes=[], existing_debt=[], engine_name="codex", model="model",
-        effort="high", web_search=False, plan_lines=3,
+        effort="high", web_search=False, plan_lines=3, lane_prompts=lane_prompts,
     )
     state = {"census_cache":{**binding, "manifests":manifests}}
 
@@ -56,6 +57,16 @@ def test_census_cache_requires_every_exact_binding():
     incomplete = {"census_cache":{**binding, "manifests":manifests[:-1]}}
     assert handlers._cached_census_manifests(
         incomplete, binding=binding, lanes=lanes, validate=validate,
+    ) is None
+    changed_contract = handlers._census_cache_binding(
+        mode=cc.PLAN_MODE, snapshot="snapshot", stakes="stakes", body="body",
+        active_classes=[], existing_debt=[], engine_name="codex", model="model",
+        effort="high", web_search=False, plan_lines=3,
+        lane_prompts={**lane_prompts, lanes[0]:"updated instructions"},
+    )
+    assert changed_contract["input_digest"] != binding["input_digest"]
+    assert handlers._cached_census_manifests(
+        state, binding=changed_contract, lanes=lanes, validate=validate,
     ) is None
 
 
@@ -1055,7 +1066,7 @@ def test_anchor_rejection_gets_one_same_session_retry_with_diagnostics(tmp_path)
         retry_guidance=prompts.STAGED_LANE_RETRY_GUIDANCE,
     )
     assert [attempt.role for attempt in attempts] == [
-        "census-domain", "census-domain-format-retry",
+        "census-domain", "census-domain-validation-retry",
     ]
     assert [attempt.sequence for attempt in attempts] == [None, None]
     assert [attempt.outcome for attempt in attempts] == ["validation-invalid", "completed"]


### PR DESCRIPTION
## Summary
- derive deterministic closure for satisfied open unmechanized classes
- retain and reuse complete validated census lane manifests only after terminal consolidation validation rejection under exact effective-input binding
- preserve structured staged failure role, kind, and terminal diagnostics across preflight, deadline, provider, process, timeout, and cancellation paths
- align operator and design documentation with cache and failure semantics

## Validation
- 763 pytest tests passed
- paranoia-local Codex CODE convergence round 16: 0 open / 5 closed classes, 0 structural debt, CONVERGENCE: NOT-BLOCKED

## Stakes
Trusted single operator and OS; repository/model content is untrusted data. No hostile local race, compromised OS/provider, multi-tenancy, generalized hardening, or unrelated scope expansion.