### PR TITLE
Preserve staged rejection diagnostics

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,16 @@ and message, not validation debt. Preserve timeout, unavailable executable, prov
 other execution outcomes distinctly, including the validation-retry role.
 Attempt telemetry must use that same `*-validation-retry` role.
 Terminal validation debt must persist and render the identical structured role, kind, and message.
+Persist terminally rejected staged model replies separately from provider envelopes as bounded
+head-and-tail excerpts plus full-reply SHA-256 in both lineage failure/debt state and the top-level
+audit record. Correction instructions and retry diagnostics must state the exact two-key
+`assessment_id`/`governing_id` disposition shape at the point of use.
+Parallel staged failure fan-in must preserve rejected replies from every failed lane in deterministic
+attempt-sequence order. Attach diagnostics to the closure before lineage persistence so a failed
+state write cannot remove them from either branch or plan audit output.
+Hash rejected extracted model text with a total, documented encoding for every Python string the
+engine JSON parser can produce, including unpaired surrogates; do not change historical structural
+or state digest encoding as a side effect of diagnostic capture.
 
 Preserve full class-closure semantics on every tracked staged plan and branch path. Every governing
 finding must have exactly one explicit disposition: genuine one-off, new reusable class, or existing

--- a/README.md
+++ b/README.md
@@ -226,7 +226,17 @@ older census cache and cannot authorize reuse. Engine outcomes retain `timeout`,
 `provider`, or `execution` rather than being flattened into an exit-code label; a failed validation
 retry and its attempt-ledger event use the same `*-validation-retry` role.
 Terminal validation debt retains that same structured role, kind, and message in lineage state and
-the convergence trailer.
+the convergence trailer. Terminal staged validation rejection also persists each rejected extracted
+model reply as a bounded head-and-tail excerpt plus its full SHA-256 in lineage state and the audit
+log's top-level `rejected_payloads`; provider-envelope excerpts in `attempt_ledger` remain separate.
+Correction prompts give the non-null `assessment_dispositions` row literally and require exactly
+`assessment_id` plus `governing_id`, so the validation retry can remove any analogized extra keys.
+Concurrent lane failure fan-in retains replies from every failed lane in attempt-sequence order,
+and diagnostics are attached to the closure before lineage persistence so a save failure cannot
+erase them from the still-available branch or plan audit log.
+Rejected extracted-reply digests use UTF-8 `surrogatepass`, making diagnostic capture total for
+unpaired surrogates that a provider's JSON string can legally decode; structural state digests keep
+their existing encoding contract.
 Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
 Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
 repository symlinks remain invalid. Disabling plan claim verification makes retained claim state

--- a/docs/exhaustive_review_census_plan.md
+++ b/docs/exhaustive_review_census_plan.md
@@ -306,6 +306,17 @@ message; consolidation preflight validation does the same. Engine outcomes prese
 unavailable executable, in-band provider error, and other execution failure distinctly, including
 the same `*-validation-retry` role in failure state and attempt telemetry. They cannot authorize reuse.
 Terminal validation debt also persists and renders that structured role, kind, and message.
+Every terminal staged validation rejection retains the extracted model reply, independently of the
+provider envelope, as a bounded head-and-tail excerpt with a digest of the full reply in both the
+structured failure/debt state and top-level audit record. Disposition shape diagnostics name the row
+index and actual keys, and correction instructions show the exact two-key non-null assessment
+disposition beside its paired four-key class assessment.
+Parallel lane failure fan-in aggregates rejected replies from every failed lane in deterministic
+attempt-sequence order. The closure receives those diagnostics before lineage persistence is
+attempted, preserving them for both branch and plan audit sinks even when the state write fails.
+The rejected-reply SHA-256 uses UTF-8 `surrogatepass` so every Python string produced by provider
+JSON decoding, including an unpaired surrogate, remains diagnosable without changing the existing
+structural/state digest contract.
 
 The supported local runtime is a trusted execution boundary, not an externally researched factual
 premise. Preflight uses the exact rendered request bytes and the tool's existing conservative local

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -126,6 +126,9 @@ def _staged_call(
     try:
         return review, parser(review.text), attempts
     except rc.CensusError as first:
+        rejected = [rc.rejected_payload(
+            role, review.text, sequence=attempts[-1].sequence,
+        )]
         attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
         if not review.session_ref:
             error = rc.CensusError(
@@ -134,6 +137,7 @@ def _staged_call(
             error.stage_role = role  # type: ignore[attr-defined]
             error.failure_kind = "validation"  # type: ignore[attr-defined]
             error.attempts = attempts  # type: ignore[attr-defined]
+            error.rejected_payloads = rejected  # type: ignore[attr-defined]
             raise error from first
         retry_sequence = next_sequence() if next_sequence else None
         retry = engine.resume(
@@ -153,14 +157,20 @@ def _staged_call(
                 retry, role=f"{role}-validation-retry",
             )
             error.attempts = attempts  # type: ignore[attr-defined]
+            error.rejected_payloads = rejected  # type: ignore[attr-defined]
             raise error from first
         try:
             parsed = parser(retry.text)
         except rc.CensusError as second:
+            rejected.append(rc.rejected_payload(
+                f"{role}-validation-retry", retry.text,
+                sequence=attempts[-1].sequence,
+            ))
             attempts[-1] = replace(attempts[-1], outcome="validation-invalid")
             second.stage_role = f"{role}-validation-retry"  # type: ignore[attr-defined]
             second.failure_kind = "validation"  # type: ignore[attr-defined]
             second.attempts = attempts  # type: ignore[attr-defined]
+            second.rejected_payloads = rejected  # type: ignore[attr-defined]
             raise
         return retry, parsed, attempts
 
@@ -284,6 +294,7 @@ def _settle_staged_failure(
     state.pop("staged_failure", None)
     state.pop("format_debt", None)
     cache = getattr(error, "census_cache", None)
+    rejected_payloads = getattr(error, "rejected_payloads", [])
     if isinstance(cache, dict):
         state["validation_debt"] = {
             "role":getattr(error, "stage_role", "consolidation-validation-retry"),
@@ -296,9 +307,14 @@ def _settle_staged_failure(
             "kind":getattr(error, "failure_kind", "unknown"),
             "message":str(error),
         }
+    failure_key = "validation_debt" if isinstance(cache, dict) else "staged_failure"
+    if rejected_payloads:
+        state[failure_key]["rejected_payloads"] = deepcopy(rejected_payloads)
     if isinstance(cache, dict):
         state["census_cache"] = deepcopy(cache)
     closure.lineage.review_state = state
+    closure.staged_manifests = getattr(error, "manifests", [])
+    closure.rejected_payloads = deepcopy(rejected_payloads)
     try:
         cc.save_lineage(closure.state_root, closure.lineage)
     except cc.StateUnavailable as exc:
@@ -318,7 +334,6 @@ def _settle_staged_failure(
         return review, trailer, [a.json() for a in getattr(error, "attempts", [])]
     closure._settled = True
     closure.register_status = f"staged rejected: {error}"
-    closure.staged_manifests = getattr(error, "manifests", [])
     attempts = [a.json() for a in getattr(error, "attempts", [])]
     review = Review(
         text=rc.render_error_review(
@@ -545,23 +560,39 @@ def _staged_structural_review(
         )
         if manifests is None:
             lane_rows = []
-            lane_errors: list[rc.CensusError] = []
+            lane_errors: list[tuple[str, rc.CensusError]] = []
             with ThreadPoolExecutor(max_workers=3) as pool:
                 pending = {pool.submit(run_lane, lane): lane for lane in lanes}
                 for future in as_completed(pending):
                     try:
                         lane_rows.append(future.result())
                     except rc.CensusError as error:
-                        lane_errors.append(error)
+                        lane_errors.append((pending[future], error))
             lane_rows.sort(key=lambda row: lanes.index(row[0]))
             if lane_errors:
+                lane_errors.sort(key=lambda row: lanes.index(row[0]))
                 all_attempts = [a for row in lane_rows for a in row[3]]
                 all_attempts.extend(
-                    a for error in lane_errors for a in getattr(error, "attempts", [])
+                    a for _, error in lane_errors for a in getattr(error, "attempts", [])
                 )
                 all_attempts.sort(key=lambda item: item.sequence or 0)
-                first_error = lane_errors[0]
+                rejected_payloads = [
+                    (lanes.index(lane_name), position, payload)
+                    for lane_name, error in lane_errors
+                    for position, payload in enumerate(
+                        getattr(error, "rejected_payloads", [])
+                    )
+                ]
+                rejected_payloads.sort(key=lambda row: (
+                    row[2].get("sequence") is None,
+                    row[2].get("sequence") or 0,
+                    row[0], row[1],
+                ))
+                first_error = lane_errors[0][1]
                 first_error.attempts = all_attempts  # type: ignore[attr-defined]
+                first_error.rejected_payloads = [  # type: ignore[attr-defined]
+                    payload for _, _, payload in rejected_payloads
+                ]
                 first_error.manifests = [  # type: ignore[attr-defined]
                     row[2] for row in lane_rows
                 ]
@@ -1098,6 +1129,7 @@ def _converge_branch_review(
           # the audit record; the original review only carries the malformed attempt.
           "retry_register": closure.retry_register if closure else None,
           "attempt_ledger": attempt_ledger,
+          "rejected_payloads": getattr(closure, "rejected_payloads", None) if closure else None,
           "staged_manifests": getattr(closure, "staged_manifests", None) if closure else None,
           "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None})
     body = _footer(review, engine)
@@ -1457,6 +1489,7 @@ def critique_plan(
         # (rejected) block alone would misreport the round.
         "retry_register": closure.retry_register if closure else None,
         "attempt_ledger": attempt_ledger,
+        "rejected_payloads": getattr(closure, "rejected_payloads", None) if closure else None,
         "staged_manifests": getattr(closure, "staged_manifests", None) if closure else None,
         "staged_settlement": getattr(closure, "staged_settlement", None) if closure else None,
     })

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -390,7 +390,11 @@ Correction returns empty source dispositions. Consolidate all occurrences of the
 class into at most one existing_class governing finding per active class per settlement. For each
 active class with that one governing finding, class_assessments and assessment_dispositions contain
 exactly one violated row; they contain no other classes. The assessment finding_id and disposition
-governing_id both name the consolidated finding.
+governing_id both name the consolidated finding. In correction the exact disposition shape is
+assessment_dispositions=[{"assessment_id":"class-id","governing_id":"G1"}] — exactly these
+two keys, with no class_id, finding_id, verdict, disposition, or other extra key. Its paired
+assessment is class_assessments=[{"class_id":"class-id","verdict":"violated",
+"evidence":["path:1"],"finding_id":"G1"}].
 Final returns empty source dispositions and one assessment disposition per active class. A closed
 unmechanized class also requires reopen and a closed mechanized class requires replace. The task's
 checklist array is governing. The exact
@@ -421,7 +425,9 @@ STAGED_SETTLEMENT_RETRY_GUIDANCE = (
     "one_off adds reason, new_class adds record_index, existing_class adds class_id. Every new "
     "class record is referenced once. Correction consolidates same-class occurrences into one "
     "governing finding; each existing_class finding also needs one matching violated "
-    "class_assessments row and assessment_dispositions row. Class records are "
+    "class_assessments row and an assessment_dispositions row with exactly assessment_id and "
+    "governing_id — never class_id, finding_id, verdict, disposition, or another extra key. "
+    "Class records are "
     "operations: close/reopen have only op,class_id; reclassify adds severity; new/replace use "
     "the exact invariant and severity plus procedure or pattern/pathspec as allowed by the mode "
     "and predecessor mechanism. A violated closed mechanized class uses replace, not reopen. "

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -31,6 +31,7 @@ MAX_ANCHOR_CHARS = 512
 MAX_CLASS_CONTEXT_CHARS = 64_000
 MAX_STAGED_PROMPT_CHARS = 5_000_000
 MAX_CONSOLIDATION_PROMPT_CHARS = 400_000
+MAX_REJECTED_PAYLOAD_CHARS = 12_000
 PHASES = frozenset({"census", "correction", "final", "clear"})
 CENSUS_CACHE_VERSION = 1
 
@@ -57,6 +58,31 @@ class Attempt:
 
 def digest(text: str) -> str:
     return hashlib.sha256(text.encode("utf-8", "surrogateescape")).hexdigest()
+
+
+def rejected_payload(
+    role: str, text: str, *, sequence: int | None = None,
+) -> dict[str, Any]:
+    """Bound one rejected extracted reply; hash every string JSON can decode."""
+    if len(text) <= MAX_REJECTED_PAYLOAD_CHARS:
+        excerpt = text
+    else:
+        half = MAX_REJECTED_PAYLOAD_CHARS // 2
+        excerpt = (
+            text[:half]
+            + "\n… [bounded rejected staged output] …\n"
+            + text[-half:]
+        )
+    return {
+        "role":role, "sequence":sequence,
+        # Engine JSON extraction can legally produce unpaired surrogates.  This
+        # diagnostic digest is deliberately separate from structural digest(),
+        # whose historical surrogateescape contract keys durable state.
+        "sha256":hashlib.sha256(
+            text.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "excerpt":excerpt,
+    }
 
 
 def render_error_review(message: str) -> str:
@@ -800,19 +826,39 @@ def _exact_dispositions(rows: Sequence[Any], expected: Sequence[str], targets: s
     seen: set[str] = set()
     seen_pairs: set[tuple[str, str | None]] = set()
     expected_set = set(expected)
-    for row in rows:
-        if not isinstance(row, dict) or set(row) != {key, "governing_id"}:
-            raise CensusError(f"invalid {key} disposition")
+    required = {key, "governing_id"}
+    for index, row in enumerate(rows):
+        if not isinstance(row, dict):
+            raise CensusError(
+                f"invalid {key} disposition at index {index}: expected an object with "
+                f"exactly {sorted(required)!r}, got {type(row).__name__}"
+            )
+        if set(row) != required:
+            actual = sorted(repr(item) for item in row)
+            raise CensusError(
+                f"invalid {key} disposition at index {index}: expected exactly "
+                f"{sorted(required)!r}, got keys [{', '.join(actual)}]"
+            )
         source = row[key]
         target = row["governing_id"]
         pair = (source, target)
-        if (
-            source not in expected_set
-            or pair in seen_pairs
-            or (source in seen and not allow_fanout)
-            or (target not in targets and not (allow_null and target is None))
-        ):
-            raise CensusError(f"invalid or duplicate {key} disposition")
+        if source not in expected_set:
+            raise CensusError(
+                f"invalid {key} disposition at index {index}: unknown {key} {source!r}"
+            )
+        if pair in seen_pairs:
+            raise CensusError(
+                f"duplicate {key} disposition at index {index}: repeated mapping "
+                f"{source!r} to {target!r}"
+            )
+        if source in seen and not allow_fanout:
+            raise CensusError(
+                f"duplicate {key} disposition at index {index}: repeated {key} {source!r}"
+            )
+        if target not in targets and not (allow_null and target is None):
+            raise CensusError(
+                f"invalid {key} disposition at index {index}: unknown governing_id {target!r}"
+            )
         seen.add(source)
         seen_pairs.add(pair)
     if seen != expected_set:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1,3 +1,4 @@
+import hashlib
 import json
 import os
 import subprocess
@@ -197,6 +198,32 @@ def test_settlement_rejects_dropped_sources_and_blockers_without_debt():
                             assessment_ids=[])
     with pytest.raises(rc.CensusError, match="open debt"):
         rc.parse_settlement(settlement(debt=[]), source_ids=["domain-1"], assessment_ids=[])
+
+
+def test_assessment_disposition_shape_error_names_index_and_actual_keys():
+    value = payload(settlement())
+    value.update(
+        source_dispositions=[],
+        assessment_dispositions=[{
+            "assessment_id":"abc", "governing_id":"C1",
+            "disposition":"existing_class",
+        }],
+    )
+    with pytest.raises(rc.CensusError) as caught:
+        rc.parse_settlement(
+            wire(rc.SETTLEMENT_MARKER, value), source_ids=[], assessment_ids=["abc"],
+        )
+    message = str(caught.value)
+    assert "invalid assessment_id disposition at index 0" in message
+    assert "expected exactly ['assessment_id', 'governing_id']" in message
+    assert "'disposition'" in message
+
+
+def test_correction_prompt_gives_literal_non_null_two_key_disposition():
+    instructions = prompts.STAGED_FOLLOWUP_INSTRUCTIONS
+    assert 'assessment_dispositions=[{"assessment_id":"class-id","governing_id":"G1"}]' in instructions
+    assert "exactly these\ntwo keys" in instructions
+    assert "no class_id, finding_id, verdict, disposition" in instructions
 
 
 def test_settlement_requires_an_explicit_class_disposition_for_every_finding():
@@ -848,6 +875,162 @@ def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
     assert not handlers._cacheable_consolidation_error(caught.value)
 
 
+def test_terminal_correction_validation_retains_extracted_replies(tmp_path):
+    invalid = payload(settlement())
+    invalid.update(
+        role="correction", source_dispositions=[],
+        assessment_dispositions=[{
+            "assessment_id":"abc", "governing_id":"C1",
+            "disposition":"existing_class",
+        }],
+    )
+    first_text = wire(rc.SETTLEMENT_MARKER, invalid)
+    retry_text = first_text.replace('"disposition": "existing_class"', '"verdict": "violated"')
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            return Review(text=first_text, session_ref="s", raw="provider-envelope-first")
+
+        def resume(self, *args, **kwargs):
+            return Review(text=retry_text, session_ref="s", raw="provider-envelope-retry")
+
+    with pytest.raises(rc.CensusError) as caught:
+        handlers._staged_call(
+            role="correction", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=10, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=[], assessment_ids=["abc"], role="correction",
+            ),
+        )
+    rejected = caught.value.rejected_payloads
+    assert [item["role"] for item in rejected] == [
+        "correction", "correction-validation-retry",
+    ]
+    assert rejected[0]["sha256"] == rc.digest(first_text)
+    assert rejected[0]["excerpt"] == first_text
+    assert rejected[1]["sha256"] == rc.digest(retry_text)
+    assert "provider-envelope" not in rejected[0]["excerpt"]
+
+    closure = handlers._PlanClassClosure(
+        "rejected-correction", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    failure = closure.lineage.review_state["staged_failure"]
+    assert failure["role"] == "correction-validation-retry"
+    assert failure["rejected_payloads"] == rejected
+    assert closure.rejected_payloads == rejected
+
+
+def test_rejected_payload_bounds_head_and_tail_with_full_digest():
+    raw = "HEAD" + ("x" * rc.MAX_REJECTED_PAYLOAD_CHARS) + "TAIL"
+    payload_row = rc.rejected_payload("correction", raw)
+    assert payload_row["sha256"] == rc.digest(raw)
+    assert payload_row["excerpt"].startswith("HEAD")
+    assert payload_row["excerpt"].endswith("TAIL")
+    assert "bounded rejected staged output" in payload_row["excerpt"]
+
+
+def test_staged_rejection_with_unpaired_surrogate_retries_and_persists(tmp_path):
+    first_text = "invalid staged reply \ud800"
+    retry_text = "still invalid \udcff"
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            return Review(
+                text=first_text, session_ref="s",
+                raw='{"result":"invalid staged reply \\ud800"}',
+            )
+
+        def resume(self, *args, **kwargs):
+            return Review(
+                text=retry_text, session_ref="s",
+                raw='{"result":"still invalid \\udcff"}',
+            )
+
+    with pytest.raises(rc.CensusError) as caught:
+        handlers._staged_call(
+            role="correction", engine=Engine(), prompt="p", cwd=tmp_path,
+            model="m", effort="high", timeout=10, on_progress=None,
+            retry_guidance=prompts.STAGED_SETTLEMENT_RETRY_GUIDANCE,
+            parser=lambda text: rc.parse_settlement(
+                text, source_ids=[], assessment_ids=[], role="correction",
+            ),
+        )
+    rejected = caught.value.rejected_payloads
+    assert [item["excerpt"] for item in rejected] == [first_text, retry_text]
+    assert rejected[0]["sha256"] == hashlib.sha256(
+        first_text.encode("utf-8", "surrogatepass")
+    ).hexdigest()
+    assert [row.outcome for row in caught.value.attempts] == [
+        "validation-invalid", "validation-invalid",
+    ]
+
+    closure = handlers._PlanClassClosure(
+        "surrogate-rejected", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+    assert closure.lineage.review_state["staged_failure"]["rejected_payloads"] == rejected
+
+
+def test_parallel_lane_failure_fan_in_retains_all_rejected_payloads_in_sequence_order(
+    tmp_path, monkeypatch,
+):
+    closure = handlers._PlanClassClosure(
+        "parallel-rejected", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+
+    def staged_call(**kwargs):
+        role = kwargs["role"]
+        lane_name = role.removeprefix("census-")
+        if lane_name in {"domain", "execution"}:
+            sequence = 3 if lane_name == "domain" else 1
+            error = rc.CensusError(f"{lane_name} invalid")
+            error.stage_role = f"{role}-validation-retry"  # type: ignore[attr-defined]
+            error.failure_kind = "validation"  # type: ignore[attr-defined]
+            error.attempts = [  # type: ignore[attr-defined]
+                rc.Attempt(role, "fake", "s", "validation-invalid", None, None,
+                           sequence=sequence),
+            ]
+            error.rejected_payloads = [  # type: ignore[attr-defined]
+                rc.rejected_payload(role, f"{lane_name}-reply", sequence=sequence),
+            ]
+            raise error
+        text = lane(lane_name)
+        return (
+            Review(text=text, session_ref="s", raw=text), payload(text),
+            [rc.Attempt(role, "fake", "s", "completed", None, None, sequence=2)],
+        )
+
+    monkeypatch.setattr(handlers, "_staged_call", staged_call)
+    with pytest.raises(rc.CensusError, match="domain invalid") as caught:
+        handlers._staged_structural_review(
+            engine=type("Engine", (), {"name":"fake"})(), cwd=tmp_path,
+            model="m", effort="high", mode=cc.PLAN_MODE, body="artifact",
+            closure=closure, stakes="s", snapshot="p", round_no=1,
+            on_progress=None, plan_lines=1,
+        )
+    assert [item["role"] for item in caught.value.rejected_payloads] == [
+        "census-execution", "census-domain",
+    ]
+    assert [item["sequence"] for item in caught.value.rejected_payloads] == [1, 3]
+    assert [item.sequence for item in caught.value.attempts] == [1, 2, 3]
+    closure.release()
+
+
 def test_staged_execution_failure_preserves_exact_message():
     message = "engine failed\nwith useful detail"
     error = handlers._engine_failure_error(
@@ -1420,8 +1603,14 @@ def test_staged_format_debt_save_failure_also_retains_latch(tmp_path, monkeypatc
         cc, "save_lineage",
         lambda *args, **kwargs: (_ for _ in ()).throw(cc.StateUnavailable("ambiguous write")),
     )
+    error = rc.CensusError("bad format")
+    error.stage_role = "correction-validation-retry"  # type: ignore[attr-defined]
+    error.failure_kind = "validation"  # type: ignore[attr-defined]
+    error.rejected_payloads = [  # type: ignore[attr-defined]
+        rc.rejected_payload("correction", "rejected correction", sequence=1),
+    ]
     review, trailer, attempts = handlers._settle_staged_failure(
-        closure, stakes="s", snapshot="p", error=rc.CensusError("bad format"),
+        closure, stakes="s", snapshot="p", error=error,
         mode=cc.PLAN_MODE,
     )
     closure.release()
@@ -1429,6 +1618,7 @@ def test_staged_format_debt_save_failure_also_retains_latch(tmp_path, monkeypatc
     assert_five_headings(review.text)
     assert "CLASS-REGISTER: staged rejected; failure state persistence unavailable" in trailer
     assert "STATE-UNAVAILABLE" in trailer
+    assert closure.rejected_payloads == error.rejected_payloads
     assert (cc.lineage_dir(tmp_path) / "format-save-fail.pending").exists()
     cc.clear_latch(tmp_path, "format-save-fail")
 
@@ -1749,9 +1939,18 @@ def test_branch_reuses_complete_census_after_settlement_rejection(
         "consolidation-validation-retry"
     )
     assert lineage.review_state["validation_debt"]["kind"] == "validation"
+    rejected = lineage.review_state["validation_debt"]["rejected_payloads"]
+    assert [item["role"] for item in rejected] == [
+        "consolidation", "consolidation-validation-retry",
+    ]
+    assert all(item["excerpt"] == invalid_settlement() for item in rejected)
     assert "staged_failure" not in lineage.review_state
     assert calls.count("consolidation") == 1
     assert sum(call.startswith("lane:") for call in calls) == 3
+    failed_audit = json.loads(
+        next((tmp_path / "logs").glob("C1-critique_branch-*.json")).read_text()
+    )
+    assert failed_audit["rejected_payloads"] == rejected
 
     accept_settlement = True
     second = handlers.critique_branch(


### PR DESCRIPTION
## Summary
- show correction reviewers the exact two-key non-null assessment disposition shape
- report disposition validation failures with row indexes and actual keys
- retain bounded extracted rejected replies plus full SHA-256 in lineage state and audit logs
- preserve diagnostics across concurrent lane failures, state persistence failures, and unpaired-surrogate text

## Verification
- 769 tests passed
- primary staged branch-review lifecycle exercised end to end
- Codex CODE review converged with final CONVERGENCE: NOT-BLOCKED
- production diff: +94/-17 across handlers.py, prompts.py, and review_census.py