### PR TITLE
Fix arbitration reliability and audit provenance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,8 @@ and message, not validation debt. Preserve timeout, unavailable executable, prov
 other execution outcomes distinctly, including the validation-retry role.
 Attempt telemetry must use that same `*-validation-retry` role.
 Terminal validation debt must persist and render the identical structured role, kind, and message.
+Every failed engine Review projected into staged or claim state must also retain return code, raw
+stdout, structured failure detail, and process stderr as distinct bounded, hashed channels.
 Persist terminally rejected staged model replies separately from provider envelopes as bounded
 head-and-tail excerpts plus full-reply SHA-256 in both lineage failure/debt state and the top-level
 audit record. Correction instructions and retry diagnostics must state the exact two-key
@@ -121,6 +123,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   become visible debt rather than an hours-long run.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.
+  Captured binding failure debt must retain raw provider stdout, structured failure detail, and
+  process stderr as distinct hashed and bounded channels, including initial and correction calls.
 - The evidence register is mechanically external-only. Retain atomic, load-bearing external
   facts; design principles/requirements issued by a governing external authority; and behavior
   promised by an external API, dependency, platform, protocol, service, or runtime. Reject
@@ -189,6 +193,33 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   computed `CONVERGENCE: NOT-BLOCKED` line.
 
 ## Delivery discipline
+
+Arbitration deciders operate only on separate inert materializations of the pinned snapshot and
+its bounded snapshot-derived history. Ref movement during snapshot construction fails before
+spend; movement after that boundary is audit provenance (`REFS-MOVED: yes`), not grounds to discard
+an otherwise valid decision. A terminal research validation failure must retain bounded raw and
+extracted replies plus the exact parser errors for both the initial attempt and its single retry,
+and all accepted discovery, capture, session, usage, and duration artifacts accumulated before it;
+an execution failure must preserve the engine's structured failure detail. Once snapshot or
+cleaning state exists, a research failure must render and persist that actual run provenance rather
+than preflight defaults, including binding-input and shared packet validation, with exact baseline
+and final ref digests. Successful and failed lanes use the same structured attempt and accepted-
+artifact ledger; never rebuild a successful corrected lane in a way that drops its initial parser
+error. Establish the run record immediately after snapshot setup and route every later ordinary
+failure through it. Transition that record after every cleaner/attester attempt, label assignment,
+fan-out, and carried-evidence step so later failure cannot erase completed artifacts. Do not add a
+third research retry. Store round-two carried bytes before starting either second-round call, and
+record the prompt for an initial decider execution failure.
+After shared research normalization succeeds, every later failure must retain the exact rendered
+packet bytes and computed digest in addition to the lane ledger.
+Treat normalization/rendering as establishment before reserved-token validation, so rejection of
+the rendered packet retains its exact bytes and digest.
+Open every research attempt record before provider invocation with phase, intended session, and
+prompt digest/excerpt; complete that same record from either the Review or caught exception so call
+counts and retry diagnostics remain exact.
+Apply the same before-invocation ledger rule to cleaner and attester calls. Mark research running
+only after deadline admission, and keep established packet digest computation total on
+model-controlled Unicode so the failure serializer cannot throw.
 
 Use `apply_patch` for edits and preserve unrelated user changes. Add focused tests for root
 invariants and the real model-facing schema. Model JSON examples must contain concrete valid

--- a/README.md
+++ b/README.md
@@ -619,8 +619,9 @@ What it does, in order:
    Every Git evidence read—including citation resolution, label scans, refs, trees, symlinks,
    and blobs—uses the shared inert launcher with lazy fetching disabled, so a missing promised
    object cannot execute a repository-configured transport.
-   Git refs and the reflog are digested before and after; if anything moved, the
-   run returns `FAILED` rather than reporting agreement it cannot describe.
+   Git refs and the reflog are digested before and after. Movement while the snapshot
+   is being built fails before model spend; later movement is reported as
+   `REFS-MOVED: yes` provenance and cannot change the inert views the deciders saw.
 2. **Neutralizes the framing** with an Opus agent — advocacy stripped, options
    equalized in detail — then has the *other* vendor attest that field by field.
    `stakes` is passed through verbatim, never rewritten.
@@ -695,6 +696,57 @@ only how much of it is adopted and what follows. ~800 chars each is typical.
 - **`SNAPSHOT` is provenance, not a replay handle.** The snapshot commit is
   unreferenced and `git gc` reclaims it. The audit log holds both prompts, both
   replies, and the carried evidence. `retain_snapshot: true` pins it behind a ref.
+- **`REFS-MOVED` is provenance after snapshot setup.** Deciders receive no live Git
+  directory: each sees a separate inert tree and bounded history rendered from
+  `SNAPSHOT`. A later branch advance therefore does not invalidate their votes. If
+  the initial or final ref/reflog observation fails, the run reports
+  `REFS-MOVED: unavailable` and records null digests plus the structured error; it
+  never aliases unavailable provenance to `no`.
+- **Research failures keep the state already established.** Their trailer and audit
+  retain the real snapshot, order seed, cleaning/attestation result, final ref digest,
+  completed peer research, bounded attempt replies, accepted discovery/capture
+  artifacts, bindings, sessions, usage, durations, and the engine or parser diagnostic.
+  Raw provider envelopes are stored as SHA-256 plus bounded excerpts. Structured
+  provider failure detail and process stderr remain distinct. Shared packet-union
+  and reserved-token failures use the same stateful path. If the durable audit sink
+  fails, the response includes a bounded, hashed fallback record containing the
+  accumulated attempts and accepted artifacts before the machine trailer.
+- **Captured claim-binding debt preserves all engine diagnostic channels.** Initial
+  and correction binding failures hash and bound provider stdout, structured failure
+  detail, and process stderr separately, so timeout and unavailable-executable debt
+  remains actionable even when the provider emitted no stdout.
+- **Every ordinary failure after snapshot setup uses that stateful path.** Cleaner,
+  attester, budget, label, evidence-resolution, and decision-setup failures therefore
+  cannot fall back to `SNAPSHOT: none` or erase cleaner/attester attempts, completed
+  research, label maps, decider prompts/replies/votes, or carried evidence.
+  Round-two carried bytes are recorded before either second-round call starts, and
+  even an initial execution failure retains the exact prompt as an attempt.
+  Failed staged attempts and their durable failure record retain return code, raw provider
+  stdout, structured failure detail, and process stderr as distinct bounded, hashed channels.
+  Once shared research completes, later failures retain the normalized packet bytes
+  and real `RESEARCH-DIGEST` as well as the per-lane ledger.
+  The packet becomes established immediately after normalization/rendering, so a
+  subsequent reserved-token rejection audits the exact rejected bytes and digest.
+- **Research attempts start before provider invocation.** The ledger binds phase,
+  intended session, and bounded prompt/digest before `run` or `resume`; a thrown
+  provider exception therefore counts as the attempted call and retains its binding.
+  Immediately before every discovery/binding invocation or validation resume, the
+  handler admits that attempt's full cap against the remaining monotonic whole-run
+  deadline; a refused call retains the already-established lane attempts. Research
+  JSON accepts markdown fencing and one measured terminal truncation only: a complete
+  outer object missing its final `}`. Internal or multi-character JSON damage remains
+  invalid and receives the one same-session correction before failing closed.
+- **Attempt state distinguishes preparation from spend.** Cleaner, attester,
+  research, and decider records expose whether a prompt was prepared, admitted,
+  invoked, completed, refused by the deadline, or blocked during inert-workspace
+  setup. Call counts include only attempts that crossed the provider boundary.
+- **Cleaned packet audits are complete.** Success and late-failure records retain
+  cleaned decision, context, hints, and statements plus one digest of that exact
+  normalized packet. Bounded cleaner and attester reply copies carry full-reply
+  digests.
+- **Cleaner and attester attempts use the same before-call discipline.** Provider
+  exceptions retain prompt bindings. Research becomes `running` only after deadline
+  admission, and packet digesting remains total on model-controlled Unicode.
 - **On divergence, only a decider that *moved* must ground in the carried
   evidence.** One that held its round-1 position needs only a citation that
   resolves — provided its round-1 decisive citation resolved too. A holder that
@@ -819,7 +871,7 @@ or missing entailment blocks; it never becomes an empty successful register.
 | `BLOCKED` | They agree on an option and one of them tags it `[MAJOR]`/`[FATAL]` |
 | `REFRAME_REQUIRED` | A decider surfaced a better unlisted option. Give it an id and re-run |
 | `UNRESOLVED` | Still split, or agreement nobody could substantiate |
-| `FAILED` | Preflight, cleaning, parsing, or the repo's refs moved mid-run |
+| `FAILED` | Preflight, execution, cleaning, parsing, capture, or protocol failure |
 
 The reply ends with a machine-readable trailer whose fields are always present:
 `ARBITRATION`, `SELECTED`, `ADVISORY`, `AUTHORITY-POLICY`, `CLEANING`, `SNAPSHOT`,
@@ -928,7 +980,9 @@ regression gate.
 
 `arbitrate` is the expensive one and the only tool that spends from **both**
 subscriptions in a single call. Research is on unless `research: false` explicitly
-selects repository-only mode. A parser-rejected decider reply receives one
+selects repository-only mode. Both modes validate each decider's exact supported
+evidence-isolation CLI profile before snapshot creation or model spend. A
+parser-rejected decider reply receives one
 complete correction attempt while the sibling result and completed cleaning/research
 work are retained. If correction still fails, the audit records both rejected replies,
 the completed sibling, and the actual phase provenance; execution failures are not
@@ -937,6 +991,17 @@ retried. Every attempt remains subject to the phase cap and 7,200-second whole-c
 ---
 
 ## Development
+
+Validate a checked-in arbitration acceptance record against its exact durable audit
+and current production sources before treating it as release evidence:
+
+```bash
+python scripts/validate_arbitration_acceptance.py \
+  docs/arbitration_reliability_acceptance_2026-08-12.json .
+```
+
+The command fails on stale provider-call counts, packet identities/count/digest,
+audit digest, outcome/selection/snapshot, or production hashes.
 
 ```bash
 pip install -e '.[dev]'

--- a/docs/arbitration_plan.md
+++ b/docs/arbitration_plan.md
@@ -62,9 +62,9 @@ The caller hands over a decision: 2–4 options **each with its own stable id**,
 context, stakes, the repo, and the files that bear on it. The server:
 
 1. **Pins the evidence.** One immutable snapshot commit of the working tree,
-   materialized as a worktree per decider. Both search freely; both search the
-   same pinned tree, and ref movement during the run is detected and fails the
-   run rather than passing unrecorded (§3.1).
+   materialized as a separate inert tree per decider. Both search the same pinned
+   bytes and snapshot-derived bounded history. Ref movement during setup fails;
+   later movement is reported without changing the pinned verdict (§3.1).
 2. **Cleans** the framing with an Opus agent — strips advocacy, equalizes the
    options, normalizes format. Never touches `stakes`. Never judges the merits.
 3. **Attests** the cleaned framing with the *other* vendor, field by field. One
@@ -234,7 +234,8 @@ prevent.
      label strings are searched for in the final framing (including hint paths),
      the pinned snapshot's **blob contents** (`git grep -F` over the snapshot
      commit) and its **pathnames** (`git ls-tree -r --name-only`), and reachable
-     **commit messages** (`git log --all --format=%B`). On any hit, the next label
+     **commit messages** (`git log --all --format=%B`, a conservative superset of
+     the bounded snapshot history exposed to deciders). On any hit, the next label
      set is derived from the seed and the scan repeats; after a bounded number of
      attempts the run fails. Deterministic given the seed, so a replay derives the
      same labels.
@@ -243,21 +244,15 @@ prevent.
      the other decider is **not a member of the receiving decider's set**, so rule
      5 rejects it outright — a loud `FAILED` rather than a silent mapping.
 
-   **What the scan does not cover, stated rather than implied.** Revision 4
-   claimed a label echoed "from anywhere" would fail membership. That was too
-   strong twice over: `git grep <commit>` reads blob contents only — not
-   pathnames, not commit messages — and the Claude engine is granted `Glob`,
-   `git ls-files`, `git log`, and `git show` (`engines.py:243-248`), so a decider
-   can see more than one blob scan covers. The first three of those channels are
-   now scanned. **Historical blob contents (`git log -p` over prior revisions) are
-   not**, because scanning every historical blob is unbounded work for a 64-bit
-   accidental-collision risk. The residual is: an own-set label would have to
-   occur in a prior revision's contents *and* the decider would have to emit it as
-   a reference to that occurrence. At 64 bits, with no adversarial input in scope,
-   that is negligible — but it is a residual, not a proof, and the README says so.
-   Restricting deciders to a snapshot-only evidence environment would close it and
-   is declined: git history is legitimate decision evidence, and this repo's own
-   review prompt treats reading it as a duty (`prompts.py:53`).
+   **What the scan covers.** `git grep <commit>` reads blob contents only — not
+   pathnames or commit messages — so those channels are scanned separately.
+   Deciders receive only the inert snapshot tree and a bounded metadata-only
+   history derived from the snapshot; they cannot browse historical blobs or live
+   refs. Scanning all current commit messages is therefore conservative. The
+   64-bit labels remain an accidental-collision control under the supported stakes,
+   not a defense against an active input author choosing a colliding token.
+   Snapshot-derived metadata history remains available because this repo's own
+   review prompt treats reading relevant history as a duty (`prompts.py:53`).
 
    Cost: less readable transcripts. The report prints both maps beside each
    transcript, and the operator reads caller-stable ids everywhere else.
@@ -485,8 +480,8 @@ drift, or agreement on a state that no longer exists, with a verdict nobody can
 reproduce. This repo already treats mixed-revision evidence as unacceptable and
 solves it: `handlers.py:198` materializes an immutable worktree for exactly this
 reason, over `orientation.snapshot_tree` / `wrap_commit` / `worktree.worktree_at`.
-Closed by one snapshot commit resolved at request time, one worktree per decider,
-and every citation read against that commit (§3.1). Independent search is
+Closed by one snapshot commit resolved at request time, one inert materialization
+per decider, and every citation read against that commit (§3.1). Independent search is
 preserved in full; only the bytes are pinned.
 
 **`clean: false` silently restored the anchoring vector.** It removes all
@@ -569,39 +564,25 @@ gave the schema no way to choose, so an implementation could return unanimous
 decisions about stale bytes while the operator meant current uncommitted work.
 Current code makes that choice explicitly through `target.is_dirty`
 (`handlers.py:202`); `arbitrate` removes the choice instead, at the cost of one
-deterministic wrapper commit. One worktree per decider from that commit; every
-decider turn, both rounds, and every citation read use it. Teardown is the
-existing best-effort `worktree_at` contract. `repo_path` is **required**.
+deterministic wrapper commit. Each decider receives a separately materialized,
+read-only tree plus a bounded `HISTORY.txt` rendered from that commit. No live
+`.git` directory is exposed, and every citation read resolves against the same
+pinned objects. `repo_path` is **required**.
 
-**Ref movement during the run is detected and fails the run.** The snapshot pins
-a *tree*, not the repository: `worktree_at` runs `git worktree add --detach`
-against the original repo (`worktree.py:31-40`), so a decider's `git log --all` /
-`git show` — both allowlisted (`engines.py:243-248`) — sees any commit the
-operator lands mid-run. Revision 5 claimed both deciders "search the same bytes",
-which is false for history, and a `CONVERGED` reached partly on post-snapshot
-commits while the record reports the old `SNAPSHOT` is precisely the audit
-laundering this design exists to prevent.
-
-The server therefore digests `git for-each-ref` **and `git reflog --all`** before
-the snapshot, again immediately after it (a commit landing during snapshot setup
-would otherwise become part of the baseline, leaving it invisible), and once more
-after the last decider returns. If either changed, the
-trailer carries `REFS-MOVED: yes` and the outcome is `FAILED`. The reflog is
-included because comparing ref tips alone is defeated by an advance-and-restore
-cycle — a rebase that lands and then resets a branch inside the window leaves both
-endpoint digests identical while the deciders could have read the transient commit.
-Residual: a repository with reflogs disabled loses that detection. Failing costs one call; the stakes are explicit that a
-self-announcing failure is cheap and a silently wrong `CONVERGED` is not.
-Freezing refs properly — a temporary namespace or local clone materialized per
-arbitration — would *prevent* rather than detect, and is declined: it adds a clone
-plus cleanup per call and changes the history the deciders legitimately read
-(restricting that was already declined in §2.4). Detection is the proportionate
-control here, and it makes the failure loud.
+**Ref movement is provenance once snapshot setup completes.** The server digests
+`git for-each-ref` and `git reflog --all` before the snapshot, immediately after
+it, and after the last decider returns. A change during snapshot construction
+fails before model spend because it makes the setup boundary ambiguous. Movement
+after that boundary renders `REFS-MOVED: yes`, but it does not alter the outcome:
+the later commit cannot enter either inert decider view, its metadata history, or
+citation resolution. An advance-and-restore cycle remains visible when reflogs are
+enabled. `retain_snapshot: true` may safely create the durable ref after the final
+digest because it preserves exactly the already-decided snapshot.
 
 **File hints must live inside the snapshot.** Every `files` entry is required to
 be a normalized, repo-relative path **present in the snapshot tree**; anything
 else is rejected before spending. Two concrete holes this closes: an absolute or
-`../` path points both deciders at live mutable bytes outside the worktree, and
+`../` path would point outside the evidence tree, and
 `git add -A` excludes *ignored untracked* files (`orientation.py:63-76`), so a
 hint naming one would silently reference something the recorded commit does not
 contain. Rejection is preferred over force-capturing the ignored file, which would
@@ -609,16 +590,10 @@ change what a snapshot means.
 
 **Escaping symlinks are rejected, because tree membership does not bound what a
 path resolves to.** Revision 6 claimed membership closed the escape; it does not.
-This repository already records the hole: *"a touched **symlink** is embedded as
-its target string without being flagged as a symlink; `ChangeEntry` carries no git
-object mode, so a reviewer could follow a link to live/external bytes rather than
-the snapshot"* (`docs/orientation_reuse_plan.md:77`). `worktree_at` materializes
-symlinks normally (`worktree.py:39`) and the Claude decider has `Read`, `Grep`,
-`Glob` (`engines.py:243-248`), so a *tracked* symlink whose target is absolute or
-escapes the root passes membership while both deciders read the same mutable,
-unrecorded file. Ref digests do not move, so the run would return `CONVERGED` with
-a `SNAPSHOT` that does not contain the evidence that produced the agreement — the
-one failure class these stakes single out.
+The server validates targets before materialization, then renders accepted
+symlinks as inert target text rather than executable filesystem links. This keeps
+the validation invariant explicit and prevents either decider from following a
+tracked path into mutable bytes outside the snapshot.
 
 Before spending, the server enumerates the snapshot's mode-`120000` entries
 (`git ls-tree -r`), reads each target string, and **rejects the run if any target
@@ -701,8 +676,8 @@ says it is a text auditor.
 ### 3.4 The deciders
 
 Both receive the attested packet — identical but for option order and local
-labels (§2.3, §2.4) — plus the file hints, and each searches its own worktree of
-the pinned snapshot freely: **shared revision, independent search**.
+labels (§2.3, §2.4) — plus the file hints, and each searches its own inert
+materialization of the pinned snapshot: **shared revision, independent search**.
 
 The search asymmetry is deliberate and the one real measurement supports it. The
 P12 probe (adjudication §5) found round-1 divergence came *not* from disagreement
@@ -713,9 +688,10 @@ discovery that made the mechanism work. **Identity belongs in the framing and th
 revision, where drift is noise; not in the search path, where asymmetry is the
 product.**
 
-Six verbatim trailing lines. Adjudication §5 establishes empirically that both
-engines honour a trailing-format contract: *"Both engines emitted `SELECTED:` and
-`CLASSIFICATION:` in exact verbatim position, parseable, on every trial."*
+Ten verbatim trailing lines. The original adjudication established that both
+engines honour a trailing-format contract; the shipped grammar extends it with
+three cold source judgements so a captured source cannot govern merely because a
+decider named its packet id.
 
 ```
 SELECTED: <one of the OPTION-xxxxxxxx labels issued to you above, verbatim>
@@ -723,7 +699,10 @@ SELECTED-RISK: NONE | [MINOR] <one line> | [MAJOR] <one line> | [FATAL] <one lin
 AUTHORITY: technical | human-owner
 NEW-OPTION: NONE | <one-line description of an unlisted option that is strictly better>
 CONSTRAINT: <one decisive fact about the system, in prose>
-DECISIVE-CITATION: NONE | <path>:<line>
+PUBLISHER-AUTHORITY: YES | NO — <reason>
+PASSAGE-ENTAILMENT: YES | NO — <reason>
+DECISION-RELEVANCE: YES | NO — <reason>
+DECISIVE-CITATION: NONE | <path>:<line> | SOURCE:<packet-id>
 CITATIONS: NONE | <path>:<line>[, …]   (max 3, supporting, non-gating)
 ```
 
@@ -787,7 +766,7 @@ Unanimity across all registered engines; currently two.
 | `BLOCKED` | same option, but some decider tags it `[MAJOR]`/`[FATAL]` |
 | `REFRAME_REQUIRED` | any decider surfaced a `NEW-OPTION`, at any round (§2.8) |
 | `UNRESOLVED` | selections differ after round 2; divergence with no novel evidence to reconcile (§2.11); **or agreement that is not substantiated** |
-| `FAILED` | preflight, cleaner `INSUFFICIENT`, failed attestation, unparseable trailer, non-member `SELECTED`, refs moved during the run (§3.1), or an engine error |
+| `FAILED` | preflight, cleaner `INSUFFICIENT`, failed attestation, unparseable trailer, non-member `SELECTED`, ambiguous snapshot setup, or an engine error |
 
 **Substantiation: convergence must be *reached* on evidence, not merely *offered*
 it.** Revision 8's headline claim — no convergence except on evidence — was false,
@@ -835,12 +814,12 @@ already demands *"the single decisive constraint behind your selection, with a
 `file:line` citation"*; a vote that cannot point at anything is not a technical
 adjudication.
 
-**Consequence, stated rather than discovered later:** a decision that genuinely
-does not turn on repository-verifiable grounds will never return `CONVERGED` here.
-That is consistent with the rest of the design — `repo_path` is required and every
-constraint must be repo-verifiable — so `arbitrate` is for decisions with evidence
-in the tree, and the README says so. The cost is cheap, visible non-convergence
-when a model does not substantiate its vote.
+**Consequence, stated rather than discovered later:** a decision must turn on
+pinned evidence. That may be a line in the inert repository snapshot or a governing
+server-captured `SOURCE:<packet-id>`. A source reference substantiates only when its
+publisher-authority, passage-entailment, and decision-relevance judgements are all
+`YES`; repository-authored URLs and unknown packet ids do not qualify. The cost of
+missing support is cheap, visible non-convergence.
 
 **Evaluation order**, since several conditions can hold at once: `FAILED` →
 `REFRAME_REQUIRED` → selections differ → `BLOCKED` → unsubstantiated → `CONVERGED`.
@@ -887,14 +866,16 @@ field is a pure token and always present**, so nothing is signalled by absence:
 ```
 ARBITRATION: CONVERGED | BLOCKED | REFRAME_REQUIRED | UNRESOLVED | FAILED
 SELECTED: <caller-stable-id> | none
-ADVISORY: none | human-owner (flagged by: codex) | human-owner (flagged by: both) | split
+ADVISORY: none | human-owner (flagged by: codex) | human-owner (flagged by: claude) | human-owner (flagged by: both)
 AUTHORITY-POLICY: advisory — a Parallax CLASSIFICATION:B would escalate; this tool does not
-CLEANING: attested | attested-after-retry | skipped
-SNAPSHOT: <commit-id>
-REFS-MOVED: no | yes
+CLEANING: not reached | cleaning | cleaner-rejected | cleaned-awaiting-attestation | attestation-rejected | attested | attested-after-retry | skipped
+SNAPSHOT: <commit-id> | none
+REFS-MOVED: no | yes | unavailable
 ORDER-SEED: <seed>
 AUDIT: <path> | FAILED <reason>
-ROUNDS: 1 | 2
+ROUNDS: 0 | 1 | 2
+RESEARCH: not reached | running | failed | complete <N> packets | repository-only
+RESEARCH-DIGEST: <sha256> | none
 ```
 
 `AUDIT` exists because `logs.write_log` swallows every failure and returns `None`
@@ -941,12 +922,16 @@ was installed into — a prerequisite change from today, where `--engine codex` 
 Claude Code needs only `codex`. Checked before anything is spent; the missing
 binary is named. No degraded single-vendor mode: two rounds against one vendor is
 not arbitration, and Parallax's rule is unambiguous — *"never run the driver's own
-vendor twice."*
+vendor twice."* Every mode, including `research: false`, also admits both deciders
+against the exact supported evidence-isolation CLI profile before snapshotting or
+model spend.
 
 **Time budget.** The client's tool timeout bounds the *whole* arbitration, not
 each subprocess, so `DEFAULT_TIMEOUT_SEC = 7200` per call is not a budget.
-Per-phase timeouts (cleaner and attester 420s each, ×2 for the retry; deciders
-1,800s per round) put the worst serial path below 7,200s. `engines.Engine.run`
+Per-attempt caps are cleaner and attester 420s, discovery 240s, binding 360s,
+and deciders 1,800s. Each permitted validation retry uses the same cap. The handler
+checks the remaining monotonic whole-run deadline immediately before every model
+invocation and refuses an attempt whose complete cap cannot fit. `engines.Engine.run`
 already accepts `timeout` and `runner.run_capture` enforces it. Progress is also
 not the reassurance revision 1 assumed — notifications require a client progress
 token (`server.py:269`) and the Claude engine emits one JSON blob at completion
@@ -977,8 +962,8 @@ own reading. That is what a function removes.
 | Ids meaning different things across calls | Caller-supplied stable ids are the only ids in the record. |
 | A label collision between id spaces | Disjoint namespace + three rejection rules (§2.4). |
 | Unstated stakes silently changing severity | `stakes` required, verbatim, screened for advocacy. `stakes: "unstated"` injects one fixed sentence, identical every call. |
-| Evidence changing under the deciders | One pinned snapshot, one worktree each (§3.1). |
-| History drifting past the snapshot | `git for-each-ref` digest before and after; `REFS-MOVED: yes` → `FAILED` (§3.1). |
+| Evidence changing under the deciders | One pinned snapshot, one inert materialization each (§3.1). |
+| History drifting past the snapshot | Inert per-decider trees and snapshot-derived bounded history; `REFS-MOVED` records later movement (§3.1). |
 | Hints pointing outside the snapshot | Every hint must be a repo-relative path present in the snapshot tree (§3.1). |
 | Symlinks resolving outside the snapshot | Mode-`120000` targets enumerated and escaping ones rejected before spending (§3.1). |
 | Stale-vs-current evidence ambiguity | Always snapshot the working tree (§3.1). |
@@ -1025,18 +1010,20 @@ verdict, verbatim record"** — not "no interpretation".
 | Clean | 1 | `text_only`, 420s |
 | Attest | 1 | `text_only`, `effort: low`, 420s |
 | Clean + attest retry, if it fires | 2 | 420s each |
-| Round 1 (parallel) | 2 | snapshot worktree, `effort: medium`, 1,800s |
+| Shared research (parallel) | 4 typical; up to 8 with validation retries | discovery, capture, same-session binding |
+| Round 1 (parallel) | 2 | inert snapshot materialization, `effort: medium`, 1,800s |
 | Round 2, gated (parallel) | 2 | 1,800s |
-| **Typical** | **4** | |
-| **Worst case** | **8** | retry *and* gated-through divergence |
+| **Typical** | **8** | cleaner, attester, four research calls, two deciders |
+| **Maximum call count** | **20** | four framing, eight research, and eight decider attempts; the whole-run deadline may stop this path before all calls start |
 
-Only decider runs are expensive. Wall clock is
-`clean + attest + max(decider) [+ max(decider)]` — rounds fan out in parallel, new
+Research and decider calls dominate cost. Wall clock is
+`clean + attest + research groups + max(decider) [+ max(decider)]` — vendor lanes fan out in parallel, new
 for this repo, whose handlers are all a single `engine.run`. Realistically 5–18
-minutes; the 7,200-second whole-call deadline remains the hard stop. `clean: false` drops to 2 or 4 runs;
+minutes; the 7,200-second whole-call deadline remains the hard stop. With default research,
+`clean: false` removes two typical framing calls but still uses four research calls and two
+round-one deciders (six typical calls, up to sixteen across all validation retries and round 2);
 `REFRAME_REQUIRED` and the §2.11 gate both terminate early. The README's
-rate-limit section needs a line: one arbitration is up to eight agent turns across
-two subscriptions.
+rate-limit section accounts for bounded research and validation turns across two subscriptions.
 
 ---
 
@@ -1083,7 +1070,7 @@ injected.
   `text_only` capability profile; pinned `CLEANER_MODEL` / attester constants.
 - **`handlers.py`**: `arbitrate` — preflight → snapshot → clean (skipped on
   `clean: false`) → attest → fan out → verdict → §2.11 gate → maybe round 2 →
-  verdict → report. Fan-out via `ThreadPoolExecutor`, one worktree per decider; a
+  verdict → report. Fan-out via `ThreadPoolExecutor`, one inert tree per decider; a
   single decider failure does not lose the other's work (`FAILED`, naming the
   engine).
 - **`server.py`**: fifth `Tool`, own dispatch path (§3.8). Schema: `options`
@@ -1198,8 +1185,9 @@ where `BLOCKED` and unsubstantiated both hold and `BLOCKED` wins, and one where
 *Verdict.* Every table row, including `BLOCKED` from a single `[MAJOR]` on an
 otherwise unanimous pick; `REFRAME_REQUIRED` at round 1 *or* round 2, evaluated
 before the selection comparison, including when selections agreed; `human-owner`
-changes no outcome but appears on `ADVISORY:`, including on `UNRESOLVED`; `split`
-renders on disagreement; `ARBITRATION:` is always a bare enum token; every trailer
+changes no outcome but appears on `ADVISORY:`, including on `UNRESOLVED`; selection
+disagreement is represented by `ARBITRATION: UNRESOLVED`, not an advisory token;
+`ARBITRATION:` is always a bare enum token; every trailer
 field is always present; unparseable or missing trailer → `FAILED`; hard stop at
 two rounds.
 
@@ -1210,16 +1198,13 @@ free-text `options` rejected; missing `stakes` or `repo_path` rejected;
 and reports `CLEANING: skipped`; the record block contains no model-authored prose.
 
 **Process.** Both deciders run against the same snapshot commit, and a live-repo
-edit mid-run changes neither worktree; the snapshot is taken from the working tree
+edit mid-run changes neither inert materialization; the snapshot is taken from the working tree
 even when clean.
 
-*Pinning limits (§3.1).* A **branch advanced mid-run** changes the
-`git for-each-ref` digest, so the trailer reports `REFS-MOVED: yes` and the
-outcome is `FAILED` — asserted with a real commit landed between snapshot and
-teardown, not just a file edit, since the existing pinning test only rewrites a
-checked-out file (`tests/test_snapshot.py:120-126`). An **advance-and-restore**
-cycle, which leaves the ref digest identical, is caught by the reflog digest and
-also reports `REFS-MOVED: yes`. A hint path that is
+*Pinning limits (§3.1).* A **branch advanced mid-run** changes the digest, so the
+trailer reports `REFS-MOVED: yes` while a valid decision over the inert snapshot
+remains valid. An **advance-and-restore** cycle, which leaves the ref-tip digest
+identical, is caught by the reflog digest when reflogs are enabled. A hint path that is
 **absolute**, escapes the repo via `../`, or names an **ignored untracked file**
 (absent from the snapshot because `git add -A` skips it — distinct from the
 ordinary-untracked and tracked-but-ignored cases already covered at
@@ -1236,8 +1221,8 @@ linked worktree (this repo is used from a linked worktree); per-phase timeouts f
 under 7,200s; a `logs.write_log` failure yields `AUDIT: FAILED …` and still returns
 the verdict; preflight fails when either binary is absent and spends nothing; a
 single decider failure names its engine. Integration against the existing fake
-CLIs on `PATH`: both engines invoked once per round, in parallel; no worktree
-leaked (`git worktree list` clean).
+CLIs on `PATH`: both engines invoked once per round, in parallel; no evidence
+materialization or worktree registration leaked (`git worktree list` clean).
 
 Mutation pass on `presentation_for`, `canonical_order`, `derive_labels`,
 `parse_verdict`, `parse_citations`, `merge_regions`, `gains_for`,

--- a/docs/arbitration_reliability_acceptance_2026-08-12.json
+++ b/docs/arbitration_reliability_acceptance_2026-08-12.json
@@ -1,0 +1,136 @@
+{
+  "date": "2026-08-12",
+  "implementation_branch": "codex/fix-arbitration-reliability",
+  "frozen_stakes": "Trusted single operator and OS; repository, report, model, and fetched content are untrusted data; normal tests and configured reviewer CLIs may execute; no hostile local path race or compromised OS; ordinary concurrency and existing network boundary; tens to low hundreds of findings or claims; useful evidence within minutes; false convergence, wrong evidence binding, and lost diagnostics are high impact while recoverable blocking is acceptable; excludes multi-tenancy, hostile same-user processes, deliberate state corruption recovery, formal proof, and unrelated hardening.",
+  "environment": {
+    "codex_cli": "0.144.6",
+    "codex_model": "gpt-5.6-sol",
+    "claude_cli": "2.1.197",
+    "claude_model": "claude-opus-5"
+  },
+  "delivery_metrics": {
+    "production_diff": {
+      "files": 9,
+      "lines_added": 1269,
+      "lines_removed": 226,
+      "net_lines": 1043
+    },
+    "largest_production_modules": [
+      {"path": "src/paranoia_local/handlers.py", "lines": 2661},
+      {"path": "src/paranoia_local/arbitrate_handler.py", "lines": 2603},
+      {"path": "src/paranoia_local/plan_claims.py", "lines": 1399},
+      {"path": "src/paranoia_local/class_closure.py", "lines": 1021},
+      {"path": "src/paranoia_local/arbitration.py", "lines": 990},
+      {"path": "src/paranoia_local/review_census.py", "lines": 894}
+    ],
+    "architecture_checkpoint": {
+      "trigger": "The production change is 1,269 additions and 226 removals across nine files, concentrated in the 2,603-line arbitration handler.",
+      "patterns_reviewed": [
+        "established-run provenance and terminal serialization",
+        "research and decider attempt ledgers",
+        "immutable snapshot and post-snapshot ref provenance",
+        "cleaner and attester lifecycle state"
+      ],
+      "disposition": "Keep one orchestration owner in arbitrate_handler.py for this correction rather than introduce a new subsystem or persistence protocol. The added records share one established-run state and one failure renderer; extracting them during the reliability repair would widen the trust and serialization boundary. Limit this PR to the report's arbitration invariants and schedule any handler decomposition as a behavior-preserving follow-up after these audited schemas settle."
+    }
+  },
+  "primary_path": {
+    "decision": "Choose how Python should parse a decimal string when the represented base-10 value must remain exact.",
+    "research": true,
+    "clean": true,
+    "cleaning": "attested-after-retry",
+    "result": "CONVERGED",
+    "selected": "choice-decimal",
+    "rounds": 1,
+    "snapshot": "cd0c0f6e210ecec67938b99193f3e369680172e6",
+    "production_source_sha256": {
+      "src/paranoia_local/arbitrate_handler.py": "91216c5f443ff7e7ddb21d546cdedd3789425d76d67b6ec623945934f86be8f9",
+      "src/paranoia_local/arbitration.py": "a578be1fd4cec518570a2947fa54bebb818c47e5cc666c1bc41c96612df0c8fd",
+      "src/paranoia_local/arbitration_research.py": "0b40a6b035b09f904969c49b7f9b5b08e7bf582810034a5dfd1a2624f6f53cb9",
+      "src/paranoia_local/engines.py": "2e2f8eedaf618af2cf0aa2f683132976c5ab39a5a1d9fed5daaed85527dd6db1",
+      "src/paranoia_local/evidence.py": "661f204c8a5521f67a7c5a3485fe11cd775db7f555a8b8b739628e9fdff7f0a3",
+      "src/paranoia_local/external_sources.py": "b203a5efbcc16af295568bda227c4b5cf47ec414468fe0905fae2977ee49c4ec",
+      "src/paranoia_local/handlers.py": "825b46ff3877a3efce408cae71c3c9d2b437436e41b56cc0dc91babf5ed237e1",
+      "src/paranoia_local/plan_claims.py": "daa490ddb9b5be6b8996670a79b1e03f2dae55c3eb984def9c805e0b996a41fe",
+      "src/paranoia_local/review_census.py": "d786b087a1bec1880e5ab97e0552f3377097304837478fe0b5441279e182c833"
+    },
+    "refs_moved": false,
+    "elapsed_seconds": 195.0,
+    "model_calls": {
+      "research": {
+        "codex": 2,
+        "claude": 2
+      },
+      "deciders": {
+        "codex": 1,
+        "claude": 1
+      },
+      "cleaner": 2,
+      "attester": 2,
+      "total": 10
+    },
+    "captured_packets": [
+      "src-cb21c77725651035",
+      "src-174c6b779afa3c3a",
+      "src-4ad4bb010b4be20c",
+      "src-66e6c7a9f0d8b101",
+      "src-ff5e1f384998790d",
+      "src-985081c11236fba8",
+      "src-4571c1fc33ee707b"
+    ],
+    "captured_urls": [
+      "https://docs.python.org/3/tutorial/floatingpoint.html",
+      "https://docs.python.org/3/tutorial/floatingpoint.html#representation-error"
+    ],
+    "research_digest": "aa1b5f3f2daec2481d910349eb07a295d056eb0f1774feead8af14587be29a07",
+    "decisive_evidence": {
+      "codex": "SOURCE:src-174c6b779afa3c3a",
+      "claude": "README.md:4"
+    },
+    "audit": "/tmp/paranoia-arbitration-profile-deadline-acceptance-logs/20260812T230000-arbitrate-ef42ef6b.json",
+    "audit_reconciliation": {
+      "audit_sha256": "a9b450b8a8f055e6921fa6545f6fb33f9516da799bef325d640085b7193c8209",
+      "research_attempts": {"codex": 2, "claude": 2},
+      "framing_attempts": 4,
+      "decider_attempts": 2,
+      "total_provider_calls": 10,
+      "packet_count": 7,
+      "packet_digest_matches": true,
+      "packet_ids_match": true,
+      "production_hashes_match": true
+    },
+    "preceding_failed_closed_attempt": {
+      "result": "FAILED",
+      "reason": "research failure — claude binding-validation-retry validation failed: invalid JSON after === EVIDENCE BINDING JSON ===: Expecting ',' delimiter: line 1 column 1970 (char 1969)",
+      "cleaning": "attested-after-retry",
+      "snapshot": "cd0c0f6e210ecec67938b99193f3e369680172e6",
+      "audit": "/tmp/paranoia-arbitration-profile-deadline-acceptance-logs/20260812T230000-arbitrate-07865b43.json",
+      "audit_sha256": "ad49752c75651c266c7814e31eb6664477efd0f20590dc84bbed17866903ded3"
+    },
+    "observations": [
+      "Both signed-in providers completed the current branch's snapshot, shared research, server capture, same-session binding, and cold independent decider path. The audit mechanically reconciles two research calls per vendor, four framing calls, two decider calls, seven packets, and ten calls overall.",
+      "The default path completed one bounded cleaner/attester correction before research; the final independent attester reported preserved fidelity, neutral framing, and no stakes advocacy.",
+      "An earlier failed-closed Opus run retained both malformed binding replies; the successful run exercised the narrow one-character terminal recovery without weakening schema validation.",
+      "A Fable attempt failed before discovery with a structured usage-credit diagnostic, which the audit preserved without retrying or substituting partial output.",
+      "Both deciders received the identical normalized seven-packet research corpus with live web disabled and independently selected the same option from pinned evidence.",
+      "The result remained bound to the immutable snapshot and recorded the post-decision refs comparison as provenance.",
+      "The recorded production-source digests bind the run to the final handler, engine adapter, and arbitration modules; only this acceptance record changed after the successful run."
+    ]
+  },
+  "failure_provenance": {
+    "result": "verified by current-branch focused acceptance tests",
+    "command": "/home/andy/tools/paranoia-local/.venv/bin/python -m pytest -q tests/test_arbitration_research.py tests/test_arbitrate_handler.py tests/test_acceptance_validator.py tests/test_plan_claims.py tests/test_review_census.py tests/test_converge.py",
+    "result_count": "365 passed",
+    "observations": [
+      "Cleaner and attester execution exceptions retain pre-call phase entries, prompt digests, prompt excerpts, attempt counts, and exact failure kinds and messages.",
+      "Discovery, binding, and validation-retry failures retain bounded raw and extracted replies, completed sibling lanes, captures, sessions, usage, durations, and the exact failing role.",
+      "Decider execution failures prefer bounded Review.failure_detail over partial model text or raw output, including provider credit exhaustion, without adding a retry.",
+      "Failures after snapshot establishment retain the real snapshot, seed, before and after ref digests, cleaning and attestation state, research state, labels, rounds, carried evidence, and phase attempts."
+    ]
+  },
+  "full_suite": {
+    "command": "env GIT_CONFIG_GLOBAL=/tmp/paranoia-local-test-gitconfig /home/andy/tools/paranoia-local/.venv/bin/python -m pytest -q",
+    "result": "872 passed",
+    "elapsed_seconds": 68.67
+  }
+}

--- a/docs/arbitration_research_plan.md
+++ b/docs/arbitration_research_plan.md
@@ -2,7 +2,7 @@
 
 ## Status
 
-Proposed for implementation after tracked plan convergence.
+Implemented and covered by the current arbitration acceptance record.
 
 ## Frozen stakes
 
@@ -11,7 +11,7 @@ framing, and fetched web text are untrusted data, but no repository-selected cod
 no hostile local process races files or refs. Both signed-in reviewer CLIs are available. An
 ordinary arbitration has 2–4 options, Git 2.36 or newer, a repository small enough for the existing
 pinned-snapshot workflow, 0–12 decision-critical external claims, and must remain useful within minutes and below
-the existing one-hour whole-call ceiling. A false `CONVERGED`, weak authority treated as
+the 7,200-second whole-call ceiling. A false `CONVERGED`, weak authority treated as
 governing, unequal evidence shown to the deciders, or external research that cannot be audited is
 high impact. A visible `UNRESOLVED` or failed run is recoverable.
 
@@ -251,6 +251,14 @@ corresponding captured text. Binding has the same one-resume correction rule for
 This makes Claude `WebSearch` sufficient for discovery without trusting `WebFetch` or asking the
 model to guess text it has not read.
 
+If either validation retry is rejected, the failure audit retains bounded raw and
+extracted excerpts, their digests, the parser error, phase, engine, model, and call
+count for both attempts, along with accepted discovery claims, captures, session
+references, usage, and durations accumulated before the failure. It does not make
+a third model call. Execution failures surface the engine's structured failure
+detail (for example provider quota or credit exhaustion) and retain a bounded
+terminal reply instead of collapsing to a generic discovery/binding failure.
+
 The research-only call seam returns a structured result containing final text, raw CLI output,
 session reference, usage, duration, engine, and model. Its injected resume callback consumes the
 exact preceding session reference for discovery correction, capture binding, and binding
@@ -304,6 +312,11 @@ The maximum accepted field payload plus fixed rendering overhead is below that u
 Exceeding a producer, field, capture, binding-input, or union budget fails visibly rather than
 truncating evidence and calling the result complete. These limits compose without assuming that
 independently worded claims deduplicate.
+
+The shared engine diagnostic contract also applies to captured plan-claim binding: durable debt
+stores provider stdout, structured failure detail, and process stderr as separate hashed, bounded
+channels for both the initial binding and its one correction. A timeout or missing executable has
+empty stdout but still leaves an actionable durable diagnostic.
 
 ### 4. Identical evidence for both deciders
 
@@ -375,14 +388,19 @@ result; the caller may improve the framing and start a new arbitration.
 
 Cleaner and attester calls use 420-second caps. Discovery calls use 240-second caps and binding
 calls use 360-second caps; each may have one same-session correction at the same cap. Server
-capture has a 240-second phase cap. The explicit worst path is therefore: cleaner initial/retry
-840 seconds, attester initial/retry 840, discovery initial/correction 480, capture 240, binding
-initial/correction 720, decision round one 1,800, and decision round two 1,800 = 6,720 seconds.
-Parallel vendors count once per group. This
-leaves 480 seconds of the 7,200-second whole-call ceiling for validation, git
-materialization, logging, and teardown. The handler tracks one monotonic whole-run deadline and
-will not start a phase whose cap plus reserved teardown margin cannot fit; that produces a visible
-bounded failure rather than a client timeout.
+capture has a 240-second phase cap. Cleaner initial/retry and attester initial/retry can each
+consume 840 seconds; discovery initial/correction 480; capture 240; and binding
+initial/correction 720. Each decider attempt has a 1,800-second cap, including the one permitted
+validation retry in either round. Those independent maxima cannot all fit inside one call.
+Parallel vendors count once per group, and the 7,200-second whole-call ceiling governs their
+composition. The handler tracks one monotonic whole-run deadline and reserves teardown time. It
+checks immediately before every discovery run, discovery validation resume, binding resume, and
+binding validation resume, as well as before each cleaner, attester, and decider call; it will not
+invoke a provider when that attempt's full cap cannot fit. The refusal preserves prior attempts in
+a visible bounded failure rather than drifting into a client timeout. Each prompt-bound attempt is
+opened before setup or admission and records prepared, admitted, invoked, and terminal status;
+call counts include only records that crossed the provider invocation boundary. Inert decider
+workspace setup failures therefore retain the prompt binding but count as zero provider calls.
 
 A parser-rejected decider reply receives one complete correction attempt against the same inert
 snapshot and shared research packet. The completed sibling vote and all cleaning and research work
@@ -391,17 +409,65 @@ provenance remain in the failure audit. This correction is still subject to the 
 and whole-call deadline; it is not additional unbounded budget. Provider execution failures are not
 retried.
 
+Research discovery and binding payloads use the same bounded correction policy. The parser accepts
+bare or markdown-fenced JSON and one mechanically unambiguous measured truncation: an otherwise
+complete outer object missing only its final `}`. It does not synthesize internal commas, quotes,
+brackets, or multi-character closures; those remain validation failures, retain the rejected reply,
+and receive at most the one same-session correction.
+
+The established cleaned-packet projection includes decision, context, normalized hints, and option
+statements plus a digest of their exact deterministic encoding on success and every late failure.
+Cleaner and attester replies may be excerpted for bounded diagnostics, but each excerpt is paired
+with the SHA-256 of the full reply.
+
+Checked-in acceptance summaries are not authoritative by assertion. Before delivery,
+`scripts/validate_arbitration_acceptance.py` reads the referenced durable audit and current source
+files and rejects disagreement in provider invocation counts, packet identities/count/digest,
+audit digest, outcome/selection/snapshot, or production hashes. Its focused test also proves a
+self-authored stale total fails the gate.
+
 ### 7. Audit and progress
 
-Add progress events for shared research and validation. Add trailer fields:
+Shared research and validation emit progress events. The trailer fields are:
 
-- `RESEARCH: complete <N> packets | repository-only`
+- `RESEARCH: not reached | running | failed | complete <N> packets | repository-only`
 - `RESEARCH-DIGEST: <sha256> | none`
+- `REFS-MOVED: no | yes | unavailable`
+- `AUDIT: <path> | FAILED could not write log`; an audit-write failure also returns a
+  bounded, hashed in-band fallback record before the trailer.
 
-The audit log records raw discovery, correction, binding, and binding-correction replies; every
+The audit log records raw discovery, correction, binding, and binding-correction replies; terminal
+validation failures retain bounded raw/extracted excerpts and errors for both rejected attempts;
+execution failures retain the engine's structured detail and bounded terminal reply; every
 capture result; normalized packets; packet digest; research model names; call count; duration; and
 the exact shared bytes shown to each decider. The existing snapshot/ref movement, cleaner,
 attestation, order, label, vote, and round records remain intact.
+Failures after snapshot and cleaning use that same stateful record and trailer; they never fall
+back to the preflight shell's `SNAPSHOT: none` or `CLEANING: not reached` defaults. This includes
+binding-input, shared packet-union, rendering, and reserved-token validation. The failure audit
+stores both the baseline and final ref digests, not only their comparison.
+The public handler establishes this record immediately after the snapshot boundary and uses it
+for every later ordinary exception, including cleaner, attester, budget, label, evidence, and
+decision setup. Attempt records are created once; a successfully corrected lane carries the exact
+initial parser rejection unchanged when it is serialized beside a failed peer.
+The same record transitions after every cleaner and attester attempt, label assignment, completed
+fan-out, and evidence-carry step. Its failure serializer emits those accumulated attempts, maps,
+prompts, replies, votes, and carried bytes rather than an empty-round placeholder.
+Round-two carried evidence transitions before fan-out. The specialized partial-decider failure
+record includes that evidence and the shared phase ledger, and records a prompt-bearing attempt
+even when a provider fails before returning its first reply.
+After packet normalization completes, the established run record owns the exact rendered packet
+and digest. Any later failure emits both in its audit and trailer instead of reducing completed
+research to lane telemetry with a `none` digest.
+Normalization/rendering is the packet-establishment boundary, before reserved-token validation;
+if that validation rejects the packet, the failure audit still binds the exact rejected bytes and
+digest.
+Every provider attempt is opened before invoking `run` or `resume`, with phase, intended session,
+and bounded prompt plus digest. The returned review or caught exception completes that same entry,
+so execution exceptions and failed validation retries are counted and bound without another retry.
+Cleaner and attester attempts follow the same before-invocation transition. Research changes to
+`running` only after its deadline admission succeeds. Packet digest encoding uses a total,
+deterministic surrogate-preserving policy so failure serialization cannot fail on model Unicode.
 
 ## Code shape
 
@@ -532,6 +598,11 @@ Codex/Claude versions and effective fresh/resumed tool inventories with the acce
 Run the complete local test suite, then Codex paranoia convergence over the implementation branch
 under the frozen stakes above. Open and merge a PR only after real acceptance, tests, documentation,
 and computed code-review convergence are all clear.
+
+The signed-in acceptance for the arbitration reliability correction is recorded in
+`docs/arbitration_reliability_acceptance_2026-08-12.json`. It captures the supported CLI/model
+versions, exact shared packet identities and digest, provider call counts, elapsed time, decisive
+citations, computed result, and the focused current-branch checks for terminal failure provenance.
 
 ## Acceptance criteria
 

--- a/scripts/validate_arbitration_acceptance.py
+++ b/scripts/validate_arbitration_acceptance.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+"""Fail unless an arbitration acceptance summary is derived from its exact audit."""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import sys
+from pathlib import Path
+
+PRODUCTION_SOURCES = frozenset({
+    "src/paranoia_local/arbitrate_handler.py",
+    "src/paranoia_local/arbitration.py",
+    "src/paranoia_local/arbitration_research.py",
+    "src/paranoia_local/engines.py",
+    "src/paranoia_local/evidence.py",
+    "src/paranoia_local/external_sources.py",
+    "src/paranoia_local/handlers.py",
+    "src/paranoia_local/plan_claims.py",
+    "src/paranoia_local/review_census.py",
+})
+ENGINES = frozenset({"codex", "claude"})
+
+
+def _sha256(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def _invoked_count(attempts: list[dict]) -> int:
+    values = [attempt.get("invoked") for attempt in attempts]
+    if any(type(value) is not bool for value in values):
+        raise ValueError("every invoked ledger value must be an exact boolean")
+    return sum(values)
+
+
+def validate(artifact_path: Path, repo: Path) -> None:
+    artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
+    primary = artifact["primary_path"]
+    reconciliation = primary["audit_reconciliation"]
+    audit_path = Path(primary["audit"])
+    if not audit_path.is_file():
+        raise ValueError(f"referenced audit does not exist: {audit_path}")
+    audit = json.loads(audit_path.read_text(encoding="utf-8"))
+    preceding = primary["preceding_failed_closed_attempt"]
+    preceding_path = Path(preceding["audit"])
+    if not preceding_path.is_file():
+        raise ValueError(f"referenced preceding audit does not exist: {preceding_path}")
+    preceding_audit = json.loads(preceding_path.read_text(encoding="utf-8"))
+
+    if _sha256(audit_path) != reconciliation["audit_sha256"]:
+        raise ValueError("audit_sha256 does not match referenced audit")
+    source_hashes = primary["production_source_sha256"]
+    if set(source_hashes) != PRODUCTION_SOURCES:
+        raise ValueError("production_source_sha256 does not name the complete source set")
+    for relative, expected in source_hashes.items():
+        if _sha256(repo / relative) != expected:
+            raise ValueError(f"production hash mismatch: {relative}")
+
+    research_rows = audit["research"]["runs"]
+    research_engines = [row["engine"] for row in research_rows]
+    if len(research_engines) != len(set(research_engines)) or set(research_engines) != ENGINES:
+        raise ValueError("research runs must contain each engine exactly once")
+    research_calls = {row["engine"]: _invoked_count(row["attempts"])
+                      for row in research_rows}
+    if any(row.get("calls") != research_calls[row["engine"]] for row in research_rows):
+        raise ValueError("research run calls disagree with invoked attempt ledger")
+    phase_roles = [item["role"] for item in audit["phase_attempts"]]
+    if phase_roles not in (["cleaner", "attester"],
+                            ["cleaner", "attester", "cleaner", "attester"]):
+        raise ValueError("phase attempts must contain one or two ordered cleaner/attester pairs")
+    framing_calls = {role: _invoked_count([item for item in audit["phase_attempts"]
+                                          if item["role"] == role])
+                     for role in ("cleaner", "attester")}
+    decider_calls = {engine: 0 for engine in ENGINES}
+    for round_record in audit["rounds"]:
+        if set(round_record) != ENGINES:
+            raise ValueError("every round must contain each decider exactly once")
+        for engine, cast in round_record.items():
+            decider_calls[engine] += _invoked_count(cast["attempts"])
+    total_calls = sum(research_calls.values()) + sum(framing_calls.values()) + sum(decider_calls.values())
+    packet_bytes = audit["research"]["packets"].encode("utf-8", errors="surrogatepass")
+    computed_packet_digest = hashlib.sha256(packet_bytes).hexdigest()
+    packets = json.loads(packet_bytes)
+    packet_ids = [item["packet_id"] for item in packets]
+    packet_urls = sorted({item["source"]["url"] for item in packets})
+    decisive = {engine: audit["rounds"][-1][engine]["decisive"] for engine in ENGINES}
+
+    expected_calls = primary["model_calls"]
+    checks = {
+        "research attempts": research_calls == expected_calls["research"],
+        "cleaner attempts": framing_calls["cleaner"] == expected_calls["cleaner"],
+        "attester attempts": framing_calls["attester"] == expected_calls["attester"],
+        "decider attempts": decider_calls == expected_calls["deciders"],
+        "total calls": total_calls == expected_calls["total"],
+        "packet count": len(packets) == len(primary["captured_packets"]),
+        "packet ids": packet_ids == primary["captured_packets"],
+        "packet urls": packet_urls == primary["captured_urls"],
+        "packet digest": computed_packet_digest == audit["research"]["digest"] == primary["research_digest"],
+        "decisive evidence": decisive == primary["decisive_evidence"],
+        "audit outcome": audit["outcome"] == primary["result"],
+        "audit selection": audit["selected"] == primary["selected"],
+        "audit snapshot": audit["snapshot"] == primary["snapshot"],
+        "cleaning": audit["cleaning"] == primary["cleaning"],
+        "round count": len(audit["rounds"]) == primary["rounds"],
+        "refs moved": audit["refs_moved"] is primary["refs_moved"],
+        "preceding audit digest": _sha256(preceding_path) == preceding["audit_sha256"],
+        "preceding result": preceding_audit["outcome"] == preceding["result"],
+        "preceding reason": preceding_audit["reason"] == preceding["reason"],
+        "preceding cleaning": preceding_audit["cleaning"] == preceding["cleaning"],
+        "preceding snapshot": preceding_audit["snapshot"] == preceding["snapshot"],
+    }
+    failed = [name for name, passed in checks.items() if not passed]
+    if failed:
+        raise ValueError("acceptance reconciliation failed: " + ", ".join(failed))
+
+    expected_reconciliation = {
+        "research_attempts": research_calls,
+        "framing_attempts": sum(framing_calls.values()),
+        "decider_attempts": sum(decider_calls.values()),
+        "total_provider_calls": total_calls,
+        "packet_count": len(packets),
+    }
+    for key, value in expected_reconciliation.items():
+        if reconciliation[key] != value:
+            raise ValueError(f"reconciliation field mismatch: {key}")
+    for key in ("packet_digest_matches", "packet_ids_match", "production_hashes_match"):
+        if reconciliation.get(key) is not True:
+            raise ValueError(f"reconciliation field mismatch: {key}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 3:
+        raise SystemExit("usage: validate_arbitration_acceptance.py ARTIFACT REPO")
+    try:
+        validate(Path(sys.argv[1]), Path(sys.argv[2]))
+    except (KeyError, TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise SystemExit(str(exc)) from exc

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -16,6 +16,7 @@ itself read.
 from __future__ import annotations
 
 import hashlib
+import json
 import re
 import shutil
 import tempfile
@@ -33,7 +34,6 @@ from . import engines as eng
 from . import evidence, external_sources, inert_git, inert_tree, logs, orientation, prompts
 from .arbitration import ArbitrationError, Citation, Option, Presentation, Region, Vote
 from .config import load_repo_config, resolve
-from .worktree import worktree_at
 
 Clock = Callable[[], str]
 
@@ -47,6 +47,9 @@ WHOLE_TIMEOUT_SEC = 7200
 TEARDOWN_RESERVE_SEC = 120
 
 SNAPSHOT_REF_PREFIX = "refs/paranoia/arbitrate"
+MAX_REJECTED_RESEARCH_CHARS = 12_000
+MAX_AUDIT_FALLBACK_CHARS = 1_000_000
+MAX_AUDIT_COLLECTION_ITEMS = 24
 
 
 def _default_clock() -> str:
@@ -55,11 +58,17 @@ def _default_clock() -> str:
 
 @dataclass(frozen=True)
 class DeciderAttempt:
-    """One complete decider reply, including why a superseded reply was rejected."""
+    """One provider attempt with an exact composed-prompt binding and outcome."""
 
     body: str
     raw: str
     rejection: str | None = None
+    prompt_sha256: str = ""
+    prompt_excerpt: str = ""
+    failure: dict[str, Any] | None = None
+    status: str = "provider-completed"
+    admitted: bool = True
+    invoked: bool = True
 
 
 @dataclass(frozen=True)
@@ -114,6 +123,24 @@ class Packet:
     research_enabled: bool = False
 
 
+def _cleaned_packet_record(packet: Packet) -> dict[str, Any]:
+    fields = {
+        "decision": packet.decision,
+        "context": packet.context,
+        "hints": list(packet.hints),
+        "statements": dict(packet.statements),
+    }
+    encoded = json.dumps(
+        fields, ensure_ascii=False, sort_keys=True, separators=(",", ":"),
+    )
+    return {
+        **fields,
+        "sha256": hashlib.sha256(
+            encoded.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+    }
+
+
 @dataclass(frozen=True)
 class ResearchRun:
     engine: str
@@ -126,6 +153,259 @@ class ResearchRun:
     calls: int
     usage: tuple[dict | None, ...]
     durations_ms: tuple[int | None, ...]
+    attempts: tuple[dict[str, Any], ...] = ()
+
+
+class ResearchFailure(ArbitrationError):
+    """One researcher's terminal failure with bounded accumulated artifacts."""
+
+    def __init__(self, message: str, *, record: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.record = dict(record)
+
+
+class InitialRefProvenanceError(ArbitrationError):
+    """The run could not establish its initial ref/reflog observation."""
+
+
+class EngineCallError(ArbitrationError):
+    def __init__(self, message: str, record: Mapping[str, Any]) -> None:
+        super().__init__(message)
+        self.record = dict(record)
+
+
+class ProviderAdmissionError(ArbitrationError):
+    """A prepared prompt was refused before crossing the provider boundary."""
+
+
+def _attach_engine_failure(attempt: dict[str, Any], exc: Exception) -> None:
+    """Retain the engine adapter's distinct bounded diagnostic channels."""
+    if isinstance(exc, EngineCallError):
+        attempt["engine_failure"] = dict(exc.record)
+
+
+def _bounded_research_text(text: str) -> str:
+    if len(text) <= MAX_REJECTED_RESEARCH_CHARS:
+        return text
+    half = MAX_REJECTED_RESEARCH_CHARS // 2
+    return text[:half] + "\n… [bounded research output] …\n" + text[-half:]
+
+
+def _bounded_audit_value(
+    value: Any, *, string_limit: int = 2_000,
+    item_limit: int = MAX_AUDIT_COLLECTION_ITEMS,
+    depth_limit: int = 8, depth: int = 0,
+) -> Any:
+    """Bound every free-form string while retaining an exact digest."""
+    if depth >= depth_limit and isinstance(value, (Mapping, list, tuple)):
+        serialized = json.dumps(value, sort_keys=True, separators=(",", ":"), default=str)
+        return {
+            "_omitted_nested": True,
+            "_omitted_sha256": hashlib.sha256(
+                serialized.encode("utf-8", "surrogatepass")
+            ).hexdigest(),
+            "_omitted_chars": len(serialized),
+        }
+    if isinstance(value, str) and len(value) > string_limit:
+        half = string_limit // 2
+        return {
+            "sha256": hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest(),
+            "excerpt": value[:half] + "\n… [bounded] …\n" + value[-half:],
+            "original_chars": len(value),
+        }
+    if isinstance(value, Mapping):
+        items = list(value.items())
+        kept = {
+            str(key): _bounded_audit_value(
+                item, string_limit=string_limit, item_limit=item_limit,
+                depth_limit=depth_limit, depth=depth + 1,
+            ) for key, item in items[:item_limit]
+        }
+        if len(items) > item_limit:
+            omitted = json.dumps(
+                dict(items[item_limit:]), sort_keys=True, separators=(",", ":"), default=str,
+            )
+            kept["_omitted_fields"] = len(items) - item_limit
+            kept["_omitted_fields_sha256"] = hashlib.sha256(
+                omitted.encode("utf-8", "surrogatepass")
+            ).hexdigest()
+        return kept
+    if isinstance(value, (list, tuple)):
+        kept = [
+            _bounded_audit_value(
+                item, string_limit=string_limit, item_limit=item_limit,
+                depth_limit=depth_limit, depth=depth + 1,
+            ) for item in value[:item_limit]
+        ]
+        if len(value) > item_limit:
+            omitted = json.dumps(
+                list(value[item_limit:]), sort_keys=True, separators=(",", ":"), default=str,
+            )
+            kept.append({
+                "_omitted_items": len(value) - item_limit,
+                "_omitted_sha256": hashlib.sha256(
+                    omitted.encode("utf-8", "surrogatepass")
+                ).hexdigest(),
+            })
+        return kept
+    return value
+
+
+def _write_bounded_audit(
+    log_dir: Path, *, record: Mapping[str, Any], timestamp: str,
+) -> tuple[Path | None, str | None]:
+    audit = logs.write_log(
+        log_dir, tool="arbitrate", record=dict(record), timestamp=timestamp,
+    )
+    if audit is not None:
+        return audit, None
+    bounded = _bounded_audit_value(dict(record))
+    serialized = json.dumps(bounded, sort_keys=True, separators=(",", ":"), default=str)
+    for string_limit, item_limit, depth_limit in ((512, 12, 6), (128, 4, 3)):
+        if len(serialized) <= MAX_AUDIT_FALLBACK_CHARS:
+            break
+        bounded = _bounded_audit_value(
+            dict(record), string_limit=string_limit, item_limit=item_limit,
+            depth_limit=depth_limit,
+        )
+        serialized = json.dumps(
+            bounded, sort_keys=True, separators=(",", ":"), default=str,
+        )
+    if len(serialized) > MAX_AUDIT_FALLBACK_CHARS:
+        serialized = json.dumps({
+            key: _bounded_audit_value(
+                value, string_limit=64, item_limit=2, depth_limit=2,
+            ) for key, value in list(record.items())[:MAX_AUDIT_COLLECTION_ITEMS]
+        }, sort_keys=True, separators=(",", ":"), default=str)
+    return None, serialized
+
+
+def _research_reply_record(
+    phase: str, review: eng.Review, error: Exception | str, *,
+    prompt: str = "", intended_session_ref: str | None = None,
+) -> dict[str, Any]:
+    extracted = review.text or ""
+    raw = review.raw or ""
+    return {
+        "phase": phase,
+        "status": "provider-failed" if review.error else "provider-completed",
+        "admitted": True,
+        "invoked": True,
+        "error": str(error),
+        "extracted_sha256": hashlib.sha256(
+            extracted.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "extracted_excerpt": _bounded_research_text(extracted),
+        "raw_sha256": hashlib.sha256(
+            raw.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "raw_excerpt": _bounded_research_text(raw),
+        "session_ref": review.session_ref,
+        "returncode": review.returncode,
+        "execution_error": review.error,
+        "failure_detail": _bounded_research_text(review.failure_detail or ""),
+        "failure_detail_sha256": hashlib.sha256(
+            (review.failure_detail or "").encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "stderr": _bounded_research_text(review.stderr or ""),
+        "stderr_sha256": hashlib.sha256(
+            (review.stderr or "").encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "usage": review.usage,
+        "duration_ms": review.duration_ms,
+        "prompt_sha256": hashlib.sha256(
+            prompt.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "prompt_excerpt": _bounded_research_text(prompt),
+        "intended_session_ref": intended_session_ref,
+    }
+
+
+def _pending_research_attempt(
+    phase: str, prompt: str, session_ref: str | None,
+) -> dict[str, Any]:
+    return {
+        "phase": phase,
+        "status": "prepared",
+        "admitted": False,
+        "invoked": False,
+        "error": "pending",
+        "extracted_sha256": None,
+        "extracted_excerpt": "",
+        "raw_sha256": None,
+        "raw_excerpt": "",
+        "session_ref": None,
+        "returncode": None,
+        "execution_error": None,
+        "failure_detail": "",
+        "failure_detail_sha256": None,
+        "stderr": "",
+        "stderr_sha256": None,
+        "usage": None,
+        "duration_ms": None,
+        "prompt_sha256": hashlib.sha256(
+            prompt.encode("utf-8", "surrogatepass")
+        ).hexdigest(),
+        "prompt_excerpt": _bounded_research_text(prompt),
+        "intended_session_ref": session_ref,
+    }
+
+
+def _fail_pending_attempt(attempt: dict[str, Any], exc: Exception) -> None:
+    detail = f"{type(exc).__name__}: {exc}"
+    invoked = bool(attempt.get("invoked"))
+    attempt.update({
+        "status": "provider-failed" if invoked else "admission-refused",
+        "error": detail,
+        "execution_error": invoked,
+        "failure_detail": _bounded_research_text(detail),
+    })
+
+
+def _research_failure(
+    *, engine: eng.Engine, model: str, phase: str, kind: str, message: str,
+    attempts: Sequence[Mapping[str, Any]],
+    rejected: Sequence[Mapping[str, Any]],
+    claims: Sequence[research_core.DiscoveryClaim] = (),
+    captures: Sequence[external_sources.Capture] = (),
+) -> ResearchFailure:
+    bounded_message = _bounded_research_text(message)
+    return ResearchFailure(
+        f"{engine.name} {phase} {kind} failed: {bounded_message}",
+        record={
+            "engine": engine.name,
+            "model": model,
+            "phase": phase,
+            "kind": kind,
+            "message": bounded_message,
+            "calls": sum(bool(attempt.get("invoked")) for attempt in attempts),
+            "rejected_replies": [dict(item) for item in rejected],
+            "attempts": [dict(attempt) for attempt in attempts],
+            "accepted_claims": [asdict(claim) for claim in claims],
+            "captures": [asdict(capture) for capture in captures],
+        },
+    )
+
+
+def _research_execution_failure(
+    *, engine: eng.Engine, model: str, phase: str,
+    attempts: list[dict[str, Any]], review: eng.Review,
+    rejected: Sequence[Mapping[str, Any]],
+    claims: Sequence[research_core.DiscoveryClaim] = (),
+    captures: Sequence[external_sources.Capture] = (),
+) -> ResearchFailure:
+    detail = review.failure_detail or review.text or review.raw or "engine returned no detail"
+    pending = attempts[-1]
+    completed = _research_reply_record(
+        phase, review, detail, intended_session_ref=pending.get("intended_session_ref"),
+    )
+    completed["prompt_sha256"] = pending["prompt_sha256"]
+    completed["prompt_excerpt"] = pending["prompt_excerpt"]
+    attempts[-1] = completed
+    return _research_failure(
+        engine=engine, model=model, phase=phase, kind="execution", message=detail,
+        attempts=attempts, rejected=rejected, claims=claims, captures=captures,
+    )
 
 
 # --- preflight and snapshot -------------------------------------------------
@@ -467,7 +747,7 @@ def render_trailer(
     cleaning: str,
     snapshot: str,
     seed: str,
-    refs_moved: bool,
+    refs_moved: bool | None,
     audit: str,
     rounds: int,
     research: str = "repository-only",
@@ -486,12 +766,25 @@ def render_trailer(
             f"CLEANING: {cleaning}",
             f"SNAPSHOT: {snapshot}",
             f"ORDER-SEED: {seed}",
-            f"REFS-MOVED: {'yes' if refs_moved else 'no'}",
+            f"REFS-MOVED: {'unavailable' if refs_moved is None else ('yes' if refs_moved else 'no')}",
             f"AUDIT: {audit}",
             f"ROUNDS: {rounds}",
             f"RESEARCH: {research}",
             f"RESEARCH-DIGEST: {research_digest}",
         ]
+    )
+
+
+def _attach_audit_fallback(report: str, fallback: str | None) -> str:
+    if fallback is None:
+        return report
+    marker = "\nARBITRATION: "
+    body, separator, trailer = report.rpartition(marker)
+    if not separator:
+        return report + "\n\n## Audit fallback\n\n```json\n" + fallback + "\n```"
+    return (
+        body + "\n\n## Audit fallback\n\n```json\n" + fallback + "\n```\n"
+        + "ARBITRATION: " + trailer
     )
 
 
@@ -548,13 +841,31 @@ def arbitrate(
     deciders = list(engines) if engines is not None else list(eng.all_engines())
     agent = run_agent or _run_agent
     progress = on_progress or (lambda _msg: None)
+    established: dict[str, Any] = {}
 
     try:
         return _arbitrate(
             arguments, deciders, agent, run_research or _research_one,
-            log_dir, now, progress,
+            log_dir, now, progress, established,
         )
-    except ArbitrationError as exc:
+    except Exception as exc:  # every ordinary failure becomes an auditable FAILED result
+        if established:
+            return _failed_established_report(
+                reason=str(exc),
+                failures=[{
+                    "engine": "server", "phase": "established-run",
+                    "kind": type(exc).__name__, "message": str(exc),
+                }],
+                completed=established.get("research_runs", ()),
+                repo=established["repo"], snapshot=established["snapshot"],
+                refs_before=established["refs_before"], seed=established["seed"],
+                packet=established["packet"], originals=established["originals"],
+                decision=established["decision"], stakes=established["stakes"],
+                context=established["context"], hints=established["hints"],
+                log_dir=log_dir, now=now,
+                research_status=established.get("research_status", "not reached"),
+                artifacts=established,
+            )
         # A failure still returns the full trailer. "Every field is always present"
         # must hold on the error path too, or a caller that parses `ARBITRATION:`
         # gets nothing and has to fall back to reading prose.
@@ -563,14 +874,20 @@ def arbitrate(
         # framings and left nothing on disk, so gate churn could only be reconstructed
         # from terminal scrollback (issue #8, fix 7). A rejection is the cheapest thing
         # this tool produces and the most useful thing to count.
-        audit = logs.write_log(
+        ref_error = f"{type(exc).__name__}: {exc}" if isinstance(
+            exc, InitialRefProvenanceError
+        ) else None
+        audit, fallback = _write_bounded_audit(
             log_dir,
-            tool="arbitrate",
             record={
                 "outcome": arb.FAILED,
                 "reason": str(exc),
                 "gate": type(exc).__name__,
                 "rounds": [],
+                "refs_before": None if ref_error else "not observed",
+                "refs_after": None if ref_error else "not observed",
+                "ref_provenance_error": ref_error,
+                "refs_moved": None if ref_error else False,
                 "raw_input": {
                     k: arguments.get(k)
                     for k in ("decision", "options", "context", "stakes", "files")
@@ -578,24 +895,25 @@ def arbitrate(
             },
             timestamp=now(),
         )
-        return "\n".join(
-            [
+        parts = [
                 "# Arbitration: FAILED",
                 "",
                 str(exc),
                 "",
-                render_trailer(
+        ]
+        if fallback is not None:
+            parts.extend(["## Audit fallback", "", "```json", fallback, "```", ""])
+        parts.append(render_trailer(
                     arb.Outcome(arb.FAILED, None, str(exc)),
                     advisory="none",
                     cleaning="not reached",
                     snapshot="none",
                     seed=str(arguments.get("order_seed") or "none"),
-                    refs_moved=False,
-                    audit=str(audit) if audit else "none",
+                    refs_moved=None if ref_error else False,
+                    audit=str(audit) if audit else "FAILED could not write log",
                     rounds=0,
-                ),
-            ]
-        )
+                ))
+        return "\n".join(parts)
 
 
 def _arbitrate(
@@ -606,16 +924,35 @@ def _arbitrate(
     log_dir: Path,
     now: Clock,
     progress: Callable[[str], None],
+    established: dict[str, Any],
 ) -> str:
     deadline = time.monotonic() + WHOLE_TIMEOUT_SEC
 
     def budgeted_agent(**kwargs: Any) -> str:
+        lifecycle = kwargs.pop("_attempt_lifecycle", None)
         cap = int(kwargs.get("timeout", 0))
         if time.monotonic() + cap + TEARDOWN_RESERVE_SEC > deadline:
-            raise ArbitrationError(
+            if lifecycle is not None:
+                lifecycle.update(status="admission-refused", admitted=False, invoked=False)
+            raise ProviderAdmissionError(
                 f"whole-run deadline leaves insufficient time to start a {cap}s agent phase"
             )
-        return agent(**kwargs)
+        if lifecycle is not None:
+            lifecycle.update(status="admitted", admitted=True, invoked=False)
+        if lifecycle is not None and agent is not _run_agent:
+            lifecycle.update(status="provider-invoked", invoked=True)
+        try:
+            result = (
+                agent(**kwargs, _attempt_lifecycle=lifecycle)
+                if agent is _run_agent else agent(**kwargs)
+            )
+        except Exception:
+            if lifecycle is not None and lifecycle.get("invoked"):
+                lifecycle["status"] = "provider-failed"
+            raise
+        if lifecycle is not None:
+            lifecycle["status"] = "provider-completed"
+        return result
 
     repo_path = arguments.get("repo_path")
     if not repo_path:
@@ -646,6 +983,10 @@ def _arbitrate(
     do_research = bool(arguments.get("research", True))
     if do_research and not web_search:
         raise ArbitrationError("research: true requires web_search: true")
+    raw_hints = list(arguments.get("files") or [])
+    if any(not isinstance(item, Mapping) for item in raw_hints):
+        raise ArbitrationError("every file hint must be an object with a path and optional reason")
+    raw_hints = [dict(item) for item in raw_hints]
 
     # Input-only defects, checked before a single agent call: three of the first four
     # production invocations died after two Opus attempts each on exactly these
@@ -657,25 +998,48 @@ def _arbitrate(
     _preflight(deciders)
     try:
         inert_git.require_supported_version()
-        if do_research:
-            for engine in deciders:
-                eng.require_evidence_profile(engine)
+        for engine in deciders:
+            eng.require_evidence_profile(engine)
     except RuntimeError as exc:
         raise ArbitrationError(str(exc)) from exc
 
     progress("snapshotting the working tree")
-    # Digest BEFORE the snapshot, and again after it: a commit landing while the
-    # snapshot is being built would otherwise become part of the baseline, so both
-    # deciders could read it through `git log --all` and the run would still report
-    # REFS-MOVED: no against an older SNAPSHOT.
-    refs_at_start = evidence.refs_digest(repo)
+    # Digest BEFORE the snapshot, and again after it. A ref landing while tree and
+    # bounded-history inputs are being assembled makes the setup boundary ambiguous,
+    # so reject it before either inert decider view is materialized.
+    try:
+        refs_at_start = evidence.refs_digest(repo)
+    except Exception as exc:
+        raise InitialRefProvenanceError(
+            f"initial ref provenance unavailable: {type(exc).__name__}: {exc}"
+        ) from exc
     snapshot = _snapshot(repo)
-    refs_before = evidence.refs_digest(repo)
+    originals = {o.id: o.statement for o in canonical}
+    established.update({
+        "repo": repo, "snapshot": snapshot, "refs_before": refs_at_start,
+        "seed": seed, "decision": decision, "stakes": stakes, "context": context,
+        "hints": raw_hints, "originals": originals,
+        "packet": Packet(
+            decision=decision, stakes=stakes, context=context, hints=raw_hints,
+            statements=dict(originals), cleaning="not reached", attestation="not reached",
+        ),
+        "research_runs": [], "research_status": "not reached",
+    })
+    try:
+        refs_before = evidence.refs_digest(repo)
+    except Exception as exc:
+        error = f"{type(exc).__name__}: {exc}"
+        established["final_ref_observation"] = (None, None, error)
+        raise ArbitrationError(
+            f"post-snapshot setup ref provenance unavailable: {error}"
+        ) from exc
     if refs_before != refs_at_start:
+        established["final_ref_observation"] = (refs_before, True, None)
         raise ArbitrationError(
             "repository refs moved while the snapshot was being taken, so the "
             "snapshot cannot describe what the deciders would read"
         )
+    established["refs_before"] = refs_before
     # The post-snapshot digest IS the baseline — re-reading it would reopen the very
     # window just closed, letting a commit that landed in between become accepted
     # history. The opt-in retain ref is therefore created after the final check, at
@@ -692,7 +1056,9 @@ def _arbitrate(
             "deciders could read unrecorded bytes: "
             + ", ".join(evidence.printable(e) for e in escaping)
         )
-    hints = evidence.validate_hints(repo, snapshot, list(arguments.get("files") or []))
+    hints = evidence.validate_hints(repo, snapshot, raw_hints)
+    established["hints"] = hints
+    established["packet"].hints = hints
 
     # Caller-side token hygiene: option ids may not appear in anything a decider
     # reads. Options are shown in DIFFERENT orders, so a statement referring to
@@ -707,7 +1073,7 @@ def _arbitrate(
     }
     arb.reject_reserved_tokens(visible, caller_ids)
 
-    originals = {o.id: o.statement for o in canonical}
+    established["packet"].cleaning = "in progress"
     packet, cleaning_note = _clean_and_attest(
         agent=budgeted_agent,
         repo=repo,
@@ -719,7 +1085,11 @@ def _arbitrate(
         do_clean=do_clean,
         cleaner_model=cleaner_model,
         progress=progress,
+        established=established,
     )
+    established["packet"] = packet
+    if not do_research:
+        established["research_status"] = "repository-only"
 
     research_runs: list[ResearchRun] = []
     if do_research:
@@ -727,6 +1097,7 @@ def _arbitrate(
             raise ArbitrationError(
                 "whole-run deadline leaves insufficient time to start shared research"
             )
+        established["research_status"] = "running"
         progress("shared research: discovering and capturing authoritative sources")
         orders = _research_orders(shown=arb.canonical_order(
             Option(id=o.id, statement=packet.statements[o.id]) for o in canonical
@@ -746,20 +1117,61 @@ def _arbitrate(
                 for engine in deciders
             }
         failures: list[str] = []
+        failure_records: list[dict[str, Any]] = []
         for name, future in futures.items():
             try:
                 research_runs.append(future.result())
+                established["research_runs"] = list(research_runs)
+            except ResearchFailure as exc:
+                failures.append(str(exc))
+                failure_records.append(dict(exc.record))
             except Exception as exc:  # noqa: BLE001
                 failures.append(f"{name}: {type(exc).__name__}: {exc}")
+                failure_records.append({
+                    "engine":name, "kind":"unexpected", "message":str(exc),
+                    "rejected_replies":[],
+                })
         if failures:
-            raise ArbitrationError("research failure — " + "; ".join(failures))
-        normalized = research_core.packets(
-            [(run.claims, run.bound) for run in research_runs]
-        )
-        packet.research_packets = normalized
-        packet.research_text = research_core.render(normalized)
-        arb.reject_reserved_tokens({"research packet": packet.research_text}, caller_ids)
-        packet.research_enabled = True
+            return _failed_established_report(
+                reason="research failure — " + "; ".join(failures),
+                failures=failure_records, completed=research_runs,
+                repo=repo, snapshot=snapshot, refs_before=refs_before,
+                seed=seed, packet=packet, originals=originals,
+                decision=decision, stakes=stakes, context=context, hints=hints,
+                log_dir=log_dir, now=now, research_status="failed",
+                artifacts=established,
+            )
+        try:
+            normalized = research_core.packets(
+                [(run.claims, run.bound) for run in research_runs]
+            )
+            packet.research_packets = normalized
+            packet.research_text = research_core.render(normalized)
+            # Normalization and rendering establish these exact bytes even if the
+            # next server-side safety validation rejects them. Failure provenance
+            # must retain what was rejected, not pretend no packet existed.
+            packet.research_enabled = True
+            established["packet"] = packet
+            arb.reject_reserved_tokens({"research packet": packet.research_text}, caller_ids)
+        except Exception as exc:
+            return _failed_established_report(
+                reason=f"research packet validation failed: {type(exc).__name__}: {exc}",
+                failures=[{
+                    "engine": "shared",
+                    "phase": "packet-validation",
+                    "kind": "validation",
+                    "message": str(exc),
+                }],
+                completed=research_runs, repo=repo, snapshot=snapshot,
+                refs_before=refs_before, seed=seed, packet=packet,
+                originals=originals, decision=decision, stakes=stakes,
+                context=context, hints=hints, log_dir=log_dir, now=now,
+                research_status="failed",
+                artifacts=established,
+            )
+        established["packet"] = packet
+        established["research_runs"] = list(research_runs)
+        established["research_status"] = "complete"
         progress(f"shared research: {len(normalized)} captured packet(s) ready")
 
     # Present the CLEANED statements, not the caller's originals — the presentation
@@ -779,7 +1191,13 @@ def _arbitrate(
         deciders=deciders,
         seed=seed,
         packet=packet,
+        established=established,
     )
+    established["label_maps"] = {
+        presentation.engine: dict(presentation.label_to_id)
+        for presentation in presentations
+    }
+    established["label_attempts"] = attempts
 
     engine_names = [p.engine for p in presentations]
     progress(f"round 1: {', '.join(engine_names)}")
@@ -795,12 +1213,13 @@ def _arbitrate(
             refs_before=refs_before, cleaning_note=cleaning_note, packet=packet,
             research_runs=research_runs, presentations=presentations,
             label_attempts=attempts, log_dir=log_dir,
-            now=now, raw_input={
+            now=now, artifacts=established, raw_input={
                 "decision": decision, "stakes": stakes, "context": context,
                 "options": originals, "files": hints,
             },
         )
     round1 = [c.vote for c in casts1]
+    established["transcripts"] = [casts1]
 
     def resolve_region(citation: Citation) -> Region | None:
         got = evidence.resolve_citation(
@@ -830,7 +1249,8 @@ def _arbitrate(
         union = arb.region_union(own)
         if arb.round_two_permitted(union, own):
             progress("round 2: reconciling on carried evidence")
-            carried_bodies = _read_union(repo, union)
+            established["carried_evidence"] = []
+            carried_bodies = _read_union(repo, union, established=established)
             # Substantiate against what was ACTUALLY carried, not the pre-transport
             # union: a region whose bytes failed to read was never sent, so it
             # cannot be the evidence a vote was reconciled by.
@@ -848,13 +1268,14 @@ def _arbitrate(
                     seed=seed, refs_before=refs_before, cleaning_note=cleaning_note,
                     packet=packet, research_runs=research_runs,
                     presentations=presentations, label_attempts=attempts,
-                    log_dir=log_dir, now=now, raw_input={
+                    log_dir=log_dir, now=now, artifacts=established, raw_input={
                         "decision": decision, "stakes": stakes, "context": context,
                         "options": originals, "files": hints,
                     },
                 )
             round2 = [c.vote for c in casts2]
             transcripts.append(casts2)
+            established["transcripts"] = list(transcripts)
             per_round.append({v.engine: v for v in round2})
             gained = {e: arb.gains_for(e, sent, own[e]) for e in own}
             # Carried grounding is anti-capitulation, so it is owed only by a vendor
@@ -885,76 +1306,77 @@ def _arbitrate(
                 "so a second round would be a fresh sample rather than a reconciliation"
             )
 
-    refs_moved = evidence.refs_digest(repo) != refs_before
-    if retain and not refs_moved:
+    refs_after, refs_moved, refs_error = _final_ref_observation(repo, refs_before)
+    established["final_ref_observation"] = (refs_after, refs_moved, refs_error)
+    if refs_error:
+        raise ArbitrationError(f"final ref provenance unavailable: {refs_error}")
+    if retain:
         # The ONE mode that writes a ref, and only once the run is known clean:
         # `wrap_commit` deliberately creates none and the README promises as much,
         # so durable evidence replay is opt-in rather than a promise quietly broken.
         evidence.retain_snapshot(repo, snapshot, now())
     final_votes = list(per_round[-1].values())
-    if refs_moved:
-        outcome = arb.compute_outcome(
-            final_votes,
-            substantiated={v.engine: True for v in final_votes},
-            refs_moved=True,
-        )
-
     advisory = arb.advisory_line(final_votes)
     record = render_record_block(
         outcome, subject=subject, rounds=rounds, per_round=per_round, advisory=advisory
     )
-    audit = logs.write_log(
-        log_dir,
-        tool="arbitrate",
-        record={
-            "repo": str(repo),
-            "snapshot": snapshot,
-            "order_seed": seed,
-            "label_attempts": attempts,
-            "cleaning": cleaning_note,
-            "attestation": packet.attestation,
-            "research": _research_record(packet, research_runs),
-            "raw_input": {
-                "decision": decision, "stakes": stakes, "context": context,
-                "options": originals, "files": hints,
-            },
-            "cleaned": {
-                "decision": packet.decision, "context": packet.context,
-                "statements": packet.statements,
-            },
-            "label_maps": {p.engine: dict(p.label_to_id) for p in presentations},
-            # The prompts, the replies, and the bytes that crossed — everything the
-            # decision was actually made on. `SNAPSHOT` is provenance only (the
-            # wrapper commit is unreferenced and gc reclaims it), so if this record
-            # does not hold them, the run is unauditable once that happens.
-            "rounds": [
-                {
-                    cast.vote.engine: _cast_record(cast)
-                    for cast in casts
-                }
-                for casts in transcripts
-            ],
-            "carried_evidence": [
-                {
-                    "commit": region.commit, "path": region.path,
-                    "lo": region.lo, "hi": region.hi, "body": body,
-                }
-                for region, body in carried_regions
-            ],
-            "outcome": outcome.outcome,
-            "selected": outcome.selected,
-            "reason": outcome.reason,
-            "refs_moved": refs_moved,
+    audit_record = {
+        "repo": str(repo),
+        "snapshot": snapshot,
+        "order_seed": seed,
+        **_established_audit_fields(established),
+        "cleaning": cleaning_note,
+        "attestation": packet.attestation,
+        "research": _research_record(packet, research_runs),
+        "raw_input": {
+            "decision": decision, "stakes": stakes, "context": context,
+            "options": originals, "files": hints,
         },
-        timestamp=now(),
+        "cleaned": _cleaned_packet_record(packet),
+        "outcome": outcome.outcome,
+        "selected": outcome.selected,
+        "reason": outcome.reason,
+        "refs_before": refs_before,
+        "refs_after": refs_after,
+        "ref_provenance_error": None,
+        "refs_moved": refs_moved,
+    }
+    audit, fallback = _write_bounded_audit(
+        log_dir, record=audit_record, timestamp=now(),
     )
 
-    return _render_report(
+    report = _render_report(
         outcome=outcome, packet=packet, originals=originals, presentations=presentations,
         per_round=per_round, advisory=advisory, snapshot=snapshot, seed=seed,
         refs_moved=refs_moved, audit=str(audit) if audit else "FAILED could not write log",
         rounds=rounds, record=record, carried_note=carried_note,
     )
+    return _attach_audit_fallback(report, fallback)
+
+
+def _research_run_records(runs: Sequence[ResearchRun]) -> list[dict[str, Any]]:
+    return [
+        {
+            "engine": run.engine,
+            "model": run.model,
+            "discovery_raw_sha256": hashlib.sha256(
+                run.discovery_raw.encode("utf-8", "surrogatepass")
+            ).hexdigest(),
+            "discovery_raw_excerpt": _bounded_research_text(run.discovery_raw),
+            "binding_raw_sha256": hashlib.sha256(
+                run.binding_raw.encode("utf-8", "surrogatepass")
+            ).hexdigest(),
+            "binding_raw_excerpt": _bounded_research_text(run.binding_raw),
+            "calls": run.calls,
+            "usage": run.usage,
+            "durations_ms": run.durations_ms,
+            "captures": [asdict(capture) for capture in run.captures],
+            "claims": [asdict(claim) for claim in run.claims],
+            "bindings": [asdict(item) if item is not None else None for item in run.bound],
+            "attempts": [dict(item) for item in run.attempts],
+        }
+        for run in runs
+    ]
 
 
 def _research_record(packet: Packet, runs: Sequence[ResearchRun]) -> dict[str, Any]:
@@ -965,20 +1387,131 @@ def _research_record(packet: Packet, runs: Sequence[ResearchRun]) -> dict[str, A
             if packet.research_enabled else None
         ),
         "packets": packet.research_text if packet.research_enabled else None,
-        "runs": [
+        "runs": _research_run_records(runs),
+    }
+
+
+def _established_audit_fields(artifacts: Mapping[str, Any]) -> dict[str, Any]:
+    """One projection of incremental run state shared by every terminal outcome."""
+    return {
+        "phase_attempts": list(artifacts.get("phase_attempts", ())),
+        "label_attempts": artifacts.get("label_attempts"),
+        "label_attempt_records": list(artifacts.get("label_attempt_records", ())),
+        "label_maps": dict(artifacts.get("label_maps", {})),
+        "rounds": [
+            {cast.vote.engine: _cast_record(cast) for cast in casts}
+            for casts in artifacts.get("transcripts", ())
+        ],
+        "carried_evidence": [
             {
-                "engine": run.engine,
-                "model": run.model,
-                "discovery_raw": run.discovery_raw,
-                "binding_raw": run.binding_raw,
-                "calls": run.calls,
-                "usage": run.usage,
-                "durations_ms": run.durations_ms,
-                "captures": [asdict(capture) for capture in run.captures],
+                "commit": region.commit, "path": region.path,
+                "lo": region.lo, "hi": region.hi, "body": body,
             }
-            for run in runs
+            for region, body in artifacts.get("carried_evidence", ())
         ],
     }
+
+
+def _final_ref_observation(repo: Path, refs_before: str) -> tuple[str | None, bool | None, str | None]:
+    """A terminal audit must survive the observation failure it is reporting."""
+    try:
+        refs_after = evidence.refs_digest(repo)
+    except Exception as exc:  # noqa: BLE001 - preserve the exact unavailable diagnostic
+        return None, None, f"{type(exc).__name__}: {exc}"
+    return refs_after, refs_after != refs_before, None
+
+
+def _failed_established_report(
+    *,
+    reason: str,
+    failures: Sequence[Mapping[str, Any]],
+    completed: Sequence[ResearchRun],
+    repo: Path,
+    snapshot: str,
+    refs_before: str,
+    seed: str,
+    packet: Packet,
+    originals: Mapping[str, str],
+    decision: str,
+    stakes: str,
+    context: str,
+    hints: Sequence[Mapping[str, str]],
+    log_dir: Path,
+    now: Clock,
+    research_status: str,
+    artifacts: Mapping[str, Any] | None = None,
+) -> str:
+    """Fail after snapshot setup without erasing any established run state."""
+    recorded = (artifacts or {}).get("final_ref_observation")
+    if recorded is None:
+        refs_after, refs_moved, refs_error = _final_ref_observation(repo, refs_before)
+    else:
+        refs_after, refs_moved, refs_error = recorded
+    if refs_error:
+        reason = f"{reason}; final ref provenance unavailable: {refs_error}"
+    outcome = arb.Outcome(arb.FAILED, None, reason)
+    completed_digest = (
+        research_core.digest(packet.research_packets)
+        if packet.research_enabled else None
+    )
+    rendered_research_status = (
+        f"complete {len(packet.research_packets)} packets"
+        if research_status == "complete" and packet.research_enabled
+        else research_status
+    )
+    research = {
+        "enabled": research_status in {"running", "complete", "failed"},
+        "status": research_status,
+        "digest": completed_digest,
+        "packets": packet.research_text if packet.research_enabled else None,
+        "runs": _research_run_records(completed),
+        "failures": [dict(item) for item in failures],
+    }
+    artifacts = artifacts or {}
+    established_fields = _established_audit_fields(artifacts)
+    audit_record = {
+            "repo": str(repo),
+            "snapshot": snapshot,
+            "order_seed": seed,
+            "cleaning": packet.cleaning,
+            "attestation": packet.attestation,
+            **established_fields,
+            "research": research,
+            "raw_input": {
+                "decision": decision,
+                "stakes": stakes,
+                "context": context,
+                "options": dict(originals),
+                "files": list(hints),
+            },
+            "cleaned": _cleaned_packet_record(packet),
+            "outcome": outcome.outcome,
+            "selected": None,
+            "reason": reason,
+            "refs_before": refs_before,
+            "refs_after": refs_after,
+            "ref_provenance_error": refs_error,
+            "refs_moved": refs_moved,
+        }
+    audit, fallback = _write_bounded_audit(
+        log_dir, record=audit_record, timestamp=now(),
+    )
+    parts = [
+        "# Arbitration: FAILED",
+        "",
+        reason,
+        "",
+    ]
+    if fallback is not None:
+        parts.extend(["## Audit fallback", "", "```json", fallback, "```", ""])
+    parts.append(render_trailer(
+            outcome, advisory="none", cleaning=packet.cleaning,
+            snapshot=snapshot, seed=seed, refs_moved=refs_moved,
+            audit=str(audit) if audit else "FAILED could not write log",
+            rounds=len(established_fields["rounds"]), research=rendered_research_status,
+            research_digest=completed_digest or "none",
+        ))
+    return "\n".join(parts)
 
 
 def _failed_decision_report(
@@ -997,9 +1530,15 @@ def _failed_decision_report(
     raw_input: Mapping[str, Any],
     log_dir: Path,
     now: Clock,
+    artifacts: Mapping[str, Any] | None = None,
 ) -> str:
     """Report a failed decider round without erasing work completed before it."""
-    refs_moved = evidence.refs_digest(repo) != refs_before
+    refs_after, refs_moved, refs_error = _final_ref_observation(repo, refs_before)
+    failure_reason = str(failure)
+    if refs_error:
+        failure_reason += f"; final ref provenance unavailable: {refs_error}"
+    artifacts = artifacts or {}
+    established_fields = _established_audit_fields(artifacts)
     partial = {cast.vote.engine: _cast_record(cast) for cast in failure.casts}
     partial.update({
         item.engine: {
@@ -1009,38 +1548,30 @@ def _failed_decision_report(
         }
         for item in failure.failures
     })
-    audit = logs.write_log(
-        log_dir,
-        tool="arbitrate",
-        record={
+    audit_record = {
             "repo": str(repo),
             "snapshot": snapshot,
             "order_seed": seed,
-            "label_attempts": label_attempts,
+            **established_fields,
             "cleaning": cleaning_note,
             "attestation": packet.attestation,
             "research": _research_record(packet, research_runs),
             "raw_input": dict(raw_input),
-            "cleaned": {
-                "decision": packet.decision,
-                "context": packet.context,
-                "statements": packet.statements,
-            },
-            "label_maps": {p.engine: dict(p.label_to_id) for p in presentations},
-            "rounds": [
-                {cast.vote.engine: _cast_record(cast) for cast in casts}
-                for casts in completed
-            ],
+            "cleaned": _cleaned_packet_record(packet),
             "failed_round": {
                 "number": len(completed) + 1,
                 "deciders": partial,
             },
             "outcome": arb.FAILED,
             "selected": None,
-            "reason": str(failure),
+            "reason": failure_reason,
+            "refs_before": refs_before,
+            "refs_after": refs_after,
+            "ref_provenance_error": refs_error,
             "refs_moved": refs_moved,
-        },
-        timestamp=now(),
+        }
+    audit, fallback = _write_bounded_audit(
+        log_dir, record=audit_record, timestamp=now(),
     )
     research = (
         f"complete {len(packet.research_packets)} packets"
@@ -1050,13 +1581,16 @@ def _failed_decision_report(
         research_core.digest(packet.research_packets)
         if packet.research_enabled else "none"
     )
-    return "\n".join([
+    parts = [
         "# Arbitration: FAILED",
         "",
-        str(failure),
+        failure_reason,
         "",
-        render_trailer(
-            arb.Outcome(arb.FAILED, None, str(failure)),
+    ]
+    if fallback is not None:
+        parts.extend(["## Audit fallback", "", "```json", fallback, "```", ""])
+    parts.append(render_trailer(
+            arb.Outcome(arb.FAILED, None, failure_reason),
             advisory="none",
             cleaning=cleaning_note,
             snapshot=snapshot,
@@ -1066,8 +1600,8 @@ def _failed_decision_report(
             rounds=len(completed),
             research=research,
             research_digest=digest,
-        ),
-    ])
+        ))
+    return "\n".join(parts)
 
 
 def _cited(vote: Vote) -> list[Citation]:
@@ -1102,7 +1636,12 @@ def _cast_record(cast: Cast) -> dict[str, Any]:
     }
 
 
-def _read_union(repo: Path, union: Sequence[Region]) -> list[tuple[Region, str]]:
+def _read_union(
+    repo: Path,
+    union: Sequence[Region],
+    *,
+    established: dict[str, Any] | None = None,
+) -> list[tuple[Region, str]]:
     """Read each merged region as EXACTLY `lo..hi`.
 
     Re-deriving the window from the anchor would under-carry a merged region — two
@@ -1115,6 +1654,8 @@ def _read_union(repo: Path, union: Sequence[Region]) -> list[tuple[Region, str]]
         body = evidence.read_region(repo, region)
         if body:
             out.append((region, body))
+            if established is not None:
+                established.setdefault("carried_evidence", []).append((region, body))
     return out
 
 
@@ -1159,71 +1700,268 @@ def _research_one(
     effort: str,
     deadline: float | None = None,
 ) -> ResearchRun:
-    launch = Path(tempfile.mkdtemp(prefix=f"paranoia-research-{engine.name}-"))
+    launch: Path | None = None
     reviews: list[eng.Review] = []
+    attempts: list[dict[str, Any]] = []
     discovery_raw: list[str] = []
     binding_raw: list[str] = []
+    rejected: list[dict[str, Any]] = []
+    claims: tuple[research_core.DiscoveryClaim, ...] = ()
+    captures: tuple[external_sources.Capture, ...] = ()
+
+    def admit(phase: str, cap: int, attempt: dict[str, Any]) -> None:
+        if deadline is not None and time.monotonic() + cap > deadline:
+            attempt["status"] = "admission-refused"
+            raise ProviderAdmissionError(
+                f"whole-run deadline leaves insufficient time to start the {phase} "
+                f"research phase with its {cap}s cap"
+            )
+        attempt.update(status="admitted", admitted=True)
+
+    def invoke(attempt: dict[str, Any]) -> None:
+        attempt.update(status="provider-invoked", invoked=True)
+
     try:
-        discoverer = engine.for_role(eng.ROLE_DISCOVERY)
-        review = discoverer.run(
-            prompts.compose(
-                prompts.ARBITRATION_DISCOVERY_INSTRUCTIONS,
-                _research_body(packet, options),
-            ),
-            launch, model, effort, True, timeout=240,
+        discovery_prompt = prompts.compose(
+            prompts.ARBITRATION_DISCOVERY_INSTRUCTIONS,
+            _research_body(packet, options),
         )
+        attempts.append(_pending_research_attempt("discovery", discovery_prompt, None))
+        try:
+            discoverer = engine.for_role(eng.ROLE_DISCOVERY)
+            launch = Path(tempfile.mkdtemp(prefix=f"paranoia-research-{engine.name}-"))
+        except Exception as exc:
+            attempts[-1].update(
+                status="setup-failed", admitted=False, invoked=False,
+                error=f"{type(exc).__name__}: {exc}", execution_error=False,
+                failure_detail=_bounded_research_text(f"{type(exc).__name__}: {exc}"),
+            )
+            raise _research_failure(
+                engine=engine, model=model, phase="discovery", kind="setup",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected,
+            ) from exc
+        try:
+            admit("discovery", 240, attempts[-1])
+            invoke(attempts[-1])
+            review = discoverer.run(
+                discovery_prompt,
+                launch, model, effort, True, timeout=240,
+            )
+        except Exception as exc:
+            _fail_pending_attempt(attempts[-1], exc)
+            raise _research_failure(
+                engine=engine, model=model, phase="discovery",
+                kind="execution" if attempts[-1]["invoked"] else "admission",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected,
+            ) from exc
         reviews.append(review)
+        attempts[-1] = _research_reply_record(
+            "discovery", review, "", prompt=discovery_prompt,
+        )
         discovery_raw.append(review.raw)
-        if review.error or not review.session_ref:
-            raise ArbitrationError(f"{engine.name} discovery failed")
+        if review.error:
+            raise _research_execution_failure(
+                engine=engine, model=model, phase="discovery", attempts=attempts,
+                review=review, rejected=rejected,
+            )
         try:
             claims = research_core.parse_discovery(review.text, forbidden=forbidden)
         except research_core.ResearchError as first:
-            correction = discoverer.resume(
-                review.session_ref,
-                f"Your discovery JSON was rejected: {first}. Return one complete corrected "
-                f"{research_core.DISCOVERY_MARKER} object and nothing else.",
-                launch, model, effort, True, timeout=240,
+            attempts[-1] = _research_reply_record(
+                "discovery", review, first, prompt=discovery_prompt,
             )
+            rejected.append(dict(attempts[-1]))
+            if not review.session_ref:
+                raise _research_failure(
+                    engine=engine, model=model, phase="discovery", kind="validation",
+                    message=f"rejected without a resumable session: {first}",
+                    attempts=attempts, rejected=rejected,
+                ) from first
+            correction_prompt = (
+                f"Your discovery JSON was rejected: {first}. Return one complete corrected "
+                f"{research_core.DISCOVERY_MARKER} object and nothing else."
+            )
+            attempts.append(_pending_research_attempt(
+                "discovery-validation-retry", correction_prompt, review.session_ref,
+            ))
+            try:
+                admit("discovery-validation-retry", 240, attempts[-1])
+                invoke(attempts[-1])
+                correction = discoverer.resume(
+                    review.session_ref, correction_prompt,
+                    launch, model, effort, True, timeout=240,
+                )
+            except Exception as exc:
+                _fail_pending_attempt(attempts[-1], exc)
+                raise _research_failure(
+                    engine=engine, model=model, phase="discovery-validation-retry",
+                    kind="execution" if attempts[-1]["invoked"] else "admission",
+                    message=f"{type(exc).__name__}: {exc}",
+                    attempts=attempts, rejected=rejected,
+            ) from exc
             reviews.append(correction)
+            attempts[-1] = _research_reply_record(
+                "discovery-validation-retry", correction, "",
+                prompt=correction_prompt, intended_session_ref=review.session_ref,
+            )
             discovery_raw.append(correction.raw)
             if correction.error:
-                raise ArbitrationError(f"{engine.name} discovery correction failed")
-            claims = research_core.parse_discovery(correction.text, forbidden=forbidden)
+                raise _research_execution_failure(
+                    engine=engine, model=model, phase="discovery-validation-retry",
+                    attempts=attempts, review=correction, rejected=rejected,
+                )
+            try:
+                claims = research_core.parse_discovery(correction.text, forbidden=forbidden)
+            except research_core.ResearchError as second:
+                attempts[-1] = _research_reply_record(
+                    "discovery-validation-retry", correction, second,
+                    prompt=correction_prompt, intended_session_ref=review.session_ref,
+                )
+                rejected.append(dict(attempts[-1]))
+                raise _research_failure(
+                    engine=engine, model=model, phase="discovery-validation-retry",
+                    kind="validation", message=str(second), attempts=attempts,
+                    rejected=rejected,
+                ) from second
             session_ref = correction.session_ref or review.session_ref
         else:
+            if not review.session_ref:
+                raise _research_failure(
+                    engine=engine, model=model, phase="discovery", kind="protocol",
+                    message="valid discovery completed without a resumable session",
+                    attempts=attempts, rejected=rejected, claims=claims,
+                )
             session_ref = review.session_ref
 
-        captures = tuple(external_sources.capture_all(
-            [claim.candidate for claim in claims], deadline=deadline,
-        ))
-        rendered = research_core.binding_input(claims, captures)
-        binder = engine.for_role(eng.ROLE_BINDING)
-        binding = binder.resume(
-            session_ref,
-            prompts.compose(prompts.ARBITRATION_BINDING_INSTRUCTIONS, rendered),
-            launch, model, effort, False, timeout=360,
-        )
+        try:
+            captures = tuple(external_sources.capture_all(
+                [claim.candidate for claim in claims], deadline=deadline,
+            ))
+        except Exception as exc:
+            completed_captures = tuple(
+                getattr(exc, "completed", ())
+            )
+            raise _research_failure(
+                engine=engine, model=model, phase="capture", kind="execution",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected, claims=claims, captures=completed_captures,
+            ) from exc
+        try:
+            rendered = research_core.binding_input(claims, captures)
+        except Exception as exc:
+            raise _research_failure(
+                engine=engine, model=model, phase="binding-input", kind="validation",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected, claims=claims, captures=captures,
+            ) from exc
+        binding_prompt = prompts.compose(prompts.ARBITRATION_BINDING_INSTRUCTIONS, rendered)
+        attempts.append(_pending_research_attempt("binding", binding_prompt, session_ref))
+        try:
+            binder = engine.for_role(eng.ROLE_BINDING)
+        except Exception as exc:
+            attempts[-1].update(
+                status="setup-failed", admitted=False, invoked=False,
+                error=f"{type(exc).__name__}: {exc}", execution_error=False,
+                failure_detail=_bounded_research_text(f"{type(exc).__name__}: {exc}"),
+            )
+            raise _research_failure(
+                engine=engine, model=model, phase="binding", kind="setup",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected, claims=claims, captures=captures,
+            ) from exc
+        try:
+            admit("binding", 360, attempts[-1])
+            invoke(attempts[-1])
+            binding = binder.resume(
+                session_ref, binding_prompt,
+                launch, model, effort, False, timeout=360,
+            )
+        except Exception as exc:
+            _fail_pending_attempt(attempts[-1], exc)
+            raise _research_failure(
+                engine=engine, model=model, phase="binding",
+                kind="execution" if attempts[-1]["invoked"] else "admission",
+                message=f"{type(exc).__name__}: {exc}", attempts=attempts,
+                rejected=rejected, claims=claims, captures=captures,
+            ) from exc
         reviews.append(binding)
+        attempts[-1] = _research_reply_record(
+            "binding", binding, "", prompt=binding_prompt,
+            intended_session_ref=session_ref,
+        )
         binding_raw.append(binding.raw)
         if binding.error:
-            raise ArbitrationError(f"{engine.name} binding failed")
+            raise _research_execution_failure(
+                engine=engine, model=model, phase="binding", attempts=attempts,
+                review=binding, rejected=rejected, claims=claims, captures=captures,
+            )
         try:
             bound = research_core.parse_binding(binding.text, claims, captures)
         except research_core.ResearchError as first:
-            if not binding.session_ref:
-                raise
-            correction = binder.resume(
-                binding.session_ref,
-                f"Your binding JSON was rejected: {first}. Return one complete corrected "
-                f"{research_core.BINDING_MARKER} object and nothing else.\n\n{rendered}",
-                launch, model, effort, False, timeout=360,
+            attempts[-1] = _research_reply_record(
+                "binding", binding, first, prompt=binding_prompt,
+                intended_session_ref=session_ref,
             )
+            rejected.append(dict(attempts[-1]))
+            if not binding.session_ref:
+                raise _research_failure(
+                    engine=engine, model=model, phase="binding", kind="validation",
+                    message=f"rejected without a resumable session: {first}",
+                    attempts=attempts, rejected=rejected, claims=claims,
+                    captures=captures,
+                ) from first
+            correction_prompt = (
+                f"Your binding JSON was rejected: {first}. Return one complete corrected "
+                f"{research_core.BINDING_MARKER} object and nothing else. The captured text "
+                "and claim indexes are already present in this resumed session; do not add "
+                "commentary or repeat the capture packet."
+            )
+            attempts.append(_pending_research_attempt(
+                "binding-validation-retry", correction_prompt, binding.session_ref,
+            ))
+            try:
+                admit("binding-validation-retry", 360, attempts[-1])
+                invoke(attempts[-1])
+                correction = binder.resume(
+                    binding.session_ref, correction_prompt,
+                    launch, model, effort, False, timeout=360,
+                )
+            except Exception as exc:
+                _fail_pending_attempt(attempts[-1], exc)
+                raise _research_failure(
+                    engine=engine, model=model, phase="binding-validation-retry",
+                    kind="execution" if attempts[-1]["invoked"] else "admission",
+                    message=f"{type(exc).__name__}: {exc}",
+                    attempts=attempts, rejected=rejected, claims=claims,
+                    captures=captures,
+            ) from exc
             reviews.append(correction)
+            attempts[-1] = _research_reply_record(
+                "binding-validation-retry", correction, "",
+                prompt=correction_prompt, intended_session_ref=binding.session_ref,
+            )
             binding_raw.append(correction.raw)
             if correction.error:
-                raise ArbitrationError(f"{engine.name} binding correction failed")
-            bound = research_core.parse_binding(correction.text, claims, captures)
+                raise _research_execution_failure(
+                    engine=engine, model=model, phase="binding-validation-retry",
+                    attempts=attempts, review=correction, rejected=rejected, claims=claims,
+                    captures=captures,
+                )
+            try:
+                bound = research_core.parse_binding(correction.text, claims, captures)
+            except research_core.ResearchError as second:
+                attempts[-1] = _research_reply_record(
+                    "binding-validation-retry", correction, second,
+                    prompt=correction_prompt, intended_session_ref=binding.session_ref,
+                )
+                rejected.append(dict(attempts[-1]))
+                raise _research_failure(
+                    engine=engine, model=model, phase="binding-validation-retry",
+                    kind="validation", message=str(second), attempts=attempts,
+                    rejected=rejected, claims=claims, captures=captures,
+                ) from second
         return ResearchRun(
             engine=engine.name,
             model=model,
@@ -1235,9 +1973,11 @@ def _research_one(
             calls=len(reviews),
             usage=tuple(item.usage for item in reviews),
             durations_ms=tuple(item.duration_ms for item in reviews),
+            attempts=tuple(dict(attempt) for attempt in attempts),
         )
     finally:
-        shutil.rmtree(launch, ignore_errors=True)
+        if launch is not None:
+            shutil.rmtree(launch, ignore_errors=True)
 
 
 def _clear_labels(
@@ -1248,6 +1988,7 @@ def _clear_labels(
     deciders: Sequence[eng.Engine],
     seed: str,
     packet: Packet,
+    established: dict[str, Any] | None = None,
 ) -> tuple[tuple[Presentation, ...], int]:
     framing = "\n".join(
         [packet.decision, packet.stakes, packet.context, *packet.statements.values()]
@@ -1255,11 +1996,22 @@ def _clear_labels(
         + [packet.research_text]
     )
     names = [e.name for e in deciders]
+    ledger = established.setdefault("label_attempt_records", []) if established is not None else []
     for attempt in range(arb.MAX_LABEL_ATTEMPTS):
         presentations = arb.build_presentations(canonical, names, seed, attempt)
         labels = list(arb.all_labels(presentations))
         in_framing = [t for t in labels if t in framing]
+        record = {
+            "attempt": attempt,
+            "labels": labels,
+            "framing_collisions": in_framing,
+            "repository_collisions": None,
+            "status": "repository-scan-pending",
+        }
+        ledger.append(record)
         in_repo = evidence.scan_for_tokens(repo, snapshot, labels)
+        record["repository_collisions"] = list(in_repo)
+        record["status"] = "collision" if in_framing or in_repo else "selected"
         if not in_framing and not in_repo:
             return presentations, attempt
     raise ArbitrationError(
@@ -1280,6 +2032,7 @@ def _clean_and_attest(
     do_clean: bool,
     cleaner_model: str,
     progress: Callable[[str], None],
+    established: dict[str, Any] | None = None,
 ) -> tuple[Packet, str]:
     if not do_clean:
         return (
@@ -1303,17 +2056,46 @@ def _clean_and_attest(
 
     complaint = ""
     last_error: str | None = None
+    phase_attempts = established.setdefault("phase_attempts", []) if established is not None else []
     # One retry only, and deliberately: a longer loop would hill-climb the framing
     # against the attester until it passed, which is optimization, not attestation.
     for attempt in range(2):
         progress("cleaning the framing" if attempt == 0 else "re-cleaning after attestation")
-        cleaned_raw = agent(
-            engine_name=eng.CLEANER_ENGINE, model=cleaner_model,
-            instructions=prompts.CLEANER_INSTRUCTIONS,
-            body=_clean_body(decision, stakes, context, hints, originals, complaint),
-            cwd=None, effort="medium", web_search=False,
-            timeout=CLEAN_TIMEOUT_SEC, text_only=True,
-        )
+        if established is not None:
+            established["packet"].cleaning = "cleaning"
+        cleaner_body = _clean_body(decision, stakes, context, hints, originals, complaint)
+        cleaner_prompt = prompts.compose(prompts.CLEANER_INSTRUCTIONS, cleaner_body)
+        cleaner_record = {
+            "role": "cleaner", "attempt": attempt + 1,
+            "status": "prepared", "admitted": False, "invoked": False,
+            "prompt_sha256": hashlib.sha256(
+                cleaner_prompt.encode("utf-8", "surrogatepass")
+            ).hexdigest(),
+            "prompt_excerpt": _bounded_research_text(cleaner_prompt),
+            "reply": "", "reply_sha256": None, "rejection": "pending",
+        }
+        phase_attempts.append(cleaner_record)
+        try:
+            cleaned_raw = agent(
+                engine_name=eng.CLEANER_ENGINE, model=cleaner_model,
+                instructions=prompts.CLEANER_INSTRUCTIONS,
+                body=cleaner_body, cwd=None, effort="medium", web_search=False,
+                timeout=CLEAN_TIMEOUT_SEC, text_only=True,
+                _attempt_lifecycle=cleaner_record,
+            )
+        except Exception as exc:
+            _attach_engine_failure(cleaner_record, exc)
+            cleaner_record["rejection"] = (
+                f"{cleaner_record['status']}: {type(exc).__name__}: {exc}"
+            )
+            if established is not None:
+                established["packet"].cleaning = "cleaner-rejected"
+            raise ArbitrationError(cleaner_record["rejection"]) from exc
+        cleaner_record["reply"] = _bounded_research_text(cleaned_raw)
+        cleaner_record["reply_sha256"] = hashlib.sha256(
+            cleaned_raw.encode("utf-8", "surrogatepass")
+        ).hexdigest()
+        cleaner_record["rejection"] = None
         try:
             parsed = parse_cleaned_packet(
                 cleaned_raw, list(originals), caller_gave_context=bool(context)
@@ -1346,24 +2128,70 @@ def _clean_and_attest(
             )
         except ArbitrationError as exc:
             last_error = str(exc)
+            cleaner_record["rejection"] = last_error
+            if established is not None:
+                established["packet"].cleaning = "cleaner-rejected"
             complaint = f"Your previous attempt was rejected: {exc}\nFix exactly that."
             continue
 
+        if established is not None:
+            established["packet"] = Packet(
+                decision=parsed["decision"], stakes=stakes, context=parsed["context"],
+                hints=cleaned_hints, statements=parsed["statements"],
+                cleaning="cleaned-awaiting-attestation", attestation="not reached",
+            )
+
         progress("attesting the cleaned framing (cross-vendor)")
-        attested_raw = agent(
-            engine_name=eng.ATTESTER_ENGINE, model=eng.ATTESTER_MODEL,
-            instructions=prompts.ATTEST_INSTRUCTIONS,
-            body=_attest_body(decision, stakes, context, hints, cleaned_hints, originals, parsed),
-            cwd=None, effort="low", web_search=False,
-            timeout=CLEAN_TIMEOUT_SEC, text_only=True,
+        attester_body = _attest_body(
+            decision, stakes, context, hints, cleaned_hints, originals, parsed,
         )
+        attester_prompt = prompts.compose(prompts.ATTEST_INSTRUCTIONS, attester_body)
+        attester_record = {
+            "role": "attester", "attempt": attempt + 1,
+            "status": "prepared", "admitted": False, "invoked": False,
+            "prompt_sha256": hashlib.sha256(
+                attester_prompt.encode("utf-8", "surrogatepass")
+            ).hexdigest(),
+            "prompt_excerpt": _bounded_research_text(attester_prompt),
+            "reply": "", "reply_sha256": None, "rejection": "pending",
+        }
+        phase_attempts.append(attester_record)
+        try:
+            attested_raw = agent(
+                engine_name=eng.ATTESTER_ENGINE, model=eng.ATTESTER_MODEL,
+                instructions=prompts.ATTEST_INSTRUCTIONS,
+                body=attester_body, cwd=None, effort="low", web_search=False,
+                timeout=CLEAN_TIMEOUT_SEC, text_only=True,
+                _attempt_lifecycle=attester_record,
+            )
+        except Exception as exc:
+            _attach_engine_failure(attester_record, exc)
+            attester_record["rejection"] = (
+                f"{attester_record['status']}: {type(exc).__name__}: {exc}"
+            )
+            if established is not None:
+                established["packet"].cleaning = "attestation-rejected"
+            raise ArbitrationError(attester_record["rejection"]) from exc
+        attester_record["reply"] = _bounded_research_text(attested_raw)
+        attester_record["reply_sha256"] = hashlib.sha256(
+            attested_raw.encode("utf-8", "surrogatepass")
+        ).hexdigest()
+        attester_record["rejection"] = None
+        if established is not None:
+            established["packet"].attestation = attested_raw
         try:
             attestation = parse_attestation(attested_raw, attest_fields)
         except ArbitrationError as exc:
             last_error = f"attestation unusable: {exc}"
+            attester_record["rejection"] = last_error
+            if established is not None:
+                established["packet"].cleaning = "attestation-rejected"
             complaint = f"An independent auditor's reply was unusable: {exc}\nRe-clean and try again."
             continue
         if attestation.stakes_advocacy:
+            attester_record["rejection"] = attestation.stakes_advocacy
+            if established is not None:
+                established["packet"].cleaning = "attestation-rejected"
             raise ArbitrationError(
                 "the stakes text advocates for an option, and stakes is not the "
                 f"cleaner's to rewrite — fix it and re-run: {attestation.stakes_advocacy}"
@@ -1382,6 +2210,9 @@ def _clean_and_attest(
             f"fidelity changed: {attestation.changed}; neutrality: "
             f"{'PASS' if attestation.neutrality_pass else 'FAIL ' + attestation.neutrality_note}"
         )
+        attester_record["rejection"] = last_error
+        if established is not None:
+            established["packet"].cleaning = "attestation-rejected"
         complaint = f"An independent auditor rejected your previous attempt: {last_error}\nFix exactly that."
 
     raise ArbitrationError(f"cleaning failed attestation twice: {last_error}")
@@ -1475,11 +2306,48 @@ def _fan_out(
     def one(engine: eng.Engine) -> Cast:
         presentation = by_name[engine.name]
         body = render_decider_body(packet, presentation, tuple(carried.get(engine.name, ())))
-        with inert_tree.evidence_workspace(repo, snapshot) as workspace:
-            review_cwd = workspace.cwd_for(engine.name)
+        first_prompt = prompts.compose(prompts.ARBITRATE_INSTRUCTIONS, body)
+        attempts: list[DeciderAttempt] = [DeciderAttempt(
+            body, "", "pending",
+            hashlib.sha256(first_prompt.encode("utf-8", "surrogatepass")).hexdigest(),
+            _bounded_research_text(first_prompt), None, "prepared", False, False,
+        )]
+        try:
+            workspace_manager = inert_tree.evidence_workspace(repo, snapshot)
+            workspace = workspace_manager.__enter__()
+        except Exception as exc:
+            current = attempts[-1]
+            attempts[-1] = DeciderAttempt(
+                current.body, "", f"workspace setup failure: {exc}",
+                current.prompt_sha256, current.prompt_excerpt, None,
+                "setup-failed", False, False,
+            )
+            raise DeciderAttemptFailure(
+                f"workspace setup failed before provider invocation: "
+                f"{type(exc).__name__}: {exc}", attempts,
+            ) from exc
+        try:
+            try:
+                review_cwd = workspace.cwd_for(engine.name)
+            except Exception as exc:
+                current = attempts[-1]
+                attempts[-1] = DeciderAttempt(
+                    current.body, "", f"workspace setup failure: {exc}",
+                    current.prompt_sha256, current.prompt_excerpt, None,
+                    "setup-failed", False, False,
+                )
+                raise DeciderAttemptFailure(
+                    f"workspace setup failed before provider invocation: "
+                    f"{type(exc).__name__}: {exc}", attempts,
+                ) from exc
             attempt_body = body
-            attempts: list[DeciderAttempt] = []
             for attempt in range(2):
+                current = attempts[-1]
+                lifecycle = {
+                    "status": current.status,
+                    "admitted": current.admitted,
+                    "invoked": current.invoked,
+                }
                 try:
                     text = agent(
                         engine_name=engine.name,
@@ -1487,21 +2355,32 @@ def _fan_out(
                         instructions=prompts.ARBITRATE_INSTRUCTIONS,
                         body=attempt_body, cwd=review_cwd, effort=effort, web_search=False,
                         timeout=DECIDE_TIMEOUT_SEC, text_only=False, role=eng.ROLE_REPOSITORY,
+                        _attempt_lifecycle=lifecycle,
                     )
                 except Exception as exc:
-                    if attempts:
-                        attempts.append(DeciderAttempt(
-                            attempt_body, "", f"execution failure: {type(exc).__name__}: {exc}",
-                        ))
+                    failure_record = getattr(exc, "record", None)
+                    attempts[-1] = DeciderAttempt(
+                        attempt_body, "", f"{lifecycle['status']}: {exc}",
+                        current.prompt_sha256, current.prompt_excerpt,
+                        dict(failure_record) if failure_record is not None else None,
+                        lifecycle["status"], lifecycle["admitted"], lifecycle["invoked"],
+                    )
+                    if attempt:
                         raise DeciderAttemptFailure(
-                            f"correction execution failed after a rejected reply: "
+                            f"correction attempt failed after a rejected reply: "
                             f"{type(exc).__name__}: {exc}", attempts,
                         ) from exc
-                    raise
+                    raise DeciderAttemptFailure(
+                        f"initial attempt failed: {type(exc).__name__}: {exc}", attempts,
+                    ) from exc
                 try:
                     vote = arb.parse_verdict(text, presentation)
                 except ArbitrationError as exc:
-                    attempts.append(DeciderAttempt(attempt_body, text, str(exc)))
+                    attempts[-1] = DeciderAttempt(
+                        attempt_body, text, str(exc),
+                        current.prompt_sha256, current.prompt_excerpt, None,
+                        lifecycle["status"], lifecycle["admitted"], lifecycle["invoked"],
+                    )
                     if attempt == 1:
                         raise DeciderAttemptFailure(
                             f"reply remained invalid after one correction: {exc}", attempts,
@@ -1514,11 +2393,26 @@ def _fan_out(
                         "quote, preview, or discuss any trailer field name in the prose before "
                         "the final trailer block."
                     )
+                    next_prompt = prompts.compose(prompts.ARBITRATE_INSTRUCTIONS, attempt_body)
+                    attempts.append(DeciderAttempt(
+                        attempt_body, "", "pending",
+                        hashlib.sha256(
+                            next_prompt.encode("utf-8", "surrogatepass")
+                        ).hexdigest(),
+                        _bounded_research_text(next_prompt), None,
+                        "prepared", False, False,
+                    ))
                     continue
-                attempts.append(DeciderAttempt(attempt_body, text))
+                attempts[-1] = DeciderAttempt(
+                    attempt_body, text, None,
+                    current.prompt_sha256, current.prompt_excerpt, None,
+                    lifecycle["status"], lifecycle["admitted"], lifecycle["invoked"],
+                )
                 return Cast(
                     vote=vote, body=attempt_body, raw=text, attempts=tuple(attempts),
                 )
+        finally:
+            workspace_manager.__exit__(None, None, None)
         raise AssertionError("bounded decider correction loop did not return")
 
     with ThreadPoolExecutor(max_workers=max(1, len(deciders))) as pool:
@@ -1555,21 +2449,41 @@ def _run_agent(
     timeout: int,
     text_only: bool,
     role: str = eng.ROLE_DEFAULT,
+    _attempt_lifecycle: dict[str, Any] | None = None,
 ) -> str:
     import tempfile
 
-    engine = eng.get_engine(engine_name, text_only=text_only)
-    if hasattr(engine, "for_role"):
-        engine = engine.for_role(role)
-    # text_only roles get a fresh EMPTY directory: for Claude the empty allowlist is
-    # the boundary; for Codex, whose read-only sandbox paranoia cannot narrow, an
-    # empty cwd plus instruction is a bound, not a boundary.
-    scratch = tempfile.mkdtemp(prefix="paranoia-txt-") if cwd is None else None
-    where = Path(cwd) if cwd is not None else Path(scratch)
+    lifecycle = _attempt_lifecycle
+    scratch: str | None = None
     try:
-        review = engine.run(
-            prompts.compose(instructions, body), where, model, effort, web_search, timeout=timeout
-        )
+        if lifecycle is not None:
+            lifecycle["status"] = "setup-running"
+        engine = eng.get_engine(engine_name, text_only=text_only)
+        if hasattr(engine, "for_role"):
+            engine = engine.for_role(role)
+        # text_only roles get a fresh EMPTY directory: for Claude the empty allowlist is
+        # the boundary; for Codex, whose read-only sandbox paranoia cannot narrow, an
+        # empty cwd plus instruction is a bound, not a boundary.
+        scratch = tempfile.mkdtemp(prefix="paranoia-txt-") if cwd is None else None
+        where = Path(cwd) if cwd is not None else Path(scratch)
+    except Exception:
+        if lifecycle is not None:
+            lifecycle.update(status="setup-failed", invoked=False)
+        raise
+    try:
+        if lifecycle is not None:
+            lifecycle.update(status="provider-invoked", invoked=True)
+        try:
+            review = engine.run(
+                prompts.compose(instructions, body), where, model, effort, web_search,
+                timeout=timeout,
+            )
+        except Exception:
+            if lifecycle is not None:
+                lifecycle["status"] = "provider-failed"
+            raise
+        if lifecycle is not None:
+            lifecycle["status"] = "provider-completed"
     finally:
         if scratch:
             shutil.rmtree(scratch, ignore_errors=True)
@@ -1577,9 +2491,23 @@ def _run_agent(
     # deliberately preserves in-band error text (see tests/test_instrumentation.py),
     # so accepting non-empty output here would let a failed process cast a vote.
     if review.error:
-        raise ArbitrationError(
+        detail = _bounded_research_text(
+            review.failure_detail
+            or review.text
+            or review.raw
+            or "engine returned no detail"
+        )
+        record = {
+            "engine": engine_name,
+            "returncode": review.returncode,
+            "failure_detail": _bounded_audit_value(review.failure_detail or ""),
+            "text": _bounded_audit_value(review.text or ""),
+            "raw": _bounded_audit_value(review.raw or ""),
+            "stderr": _bounded_audit_value(review.stderr or ""),
+        }
+        raise EngineCallError(
             f"{engine_name} failed (exit {review.returncode}): "
-            f"{(review.text or '').strip()[:500]}"
+            f"{detail}", record,
         )
     return review.text
 

--- a/src/paranoia_local/arbitration.py
+++ b/src/paranoia_local/arbitration.py
@@ -861,7 +861,6 @@ def compute_outcome(
     votes: Sequence[Vote],
     *,
     substantiated: Mapping[str, bool],
-    refs_moved: bool = False,
     failure: str | None = None,
 ) -> Outcome:
     """The whole verdict, in evaluation order.
@@ -874,8 +873,6 @@ def compute_outcome(
     """
     if failure:
         return Outcome(FAILED, None, failure)
-    if refs_moved:
-        return Outcome(FAILED, None, "repository refs moved during the run")
     if not votes:
         return Outcome(FAILED, None, "no decider replies")
 

--- a/src/paranoia_local/arbitration_research.py
+++ b/src/paranoia_local/arbitration_research.py
@@ -62,10 +62,23 @@ def _json_after(text: str, marker: str) -> object:
     # deciders never voted and the run was lost to formatting. Same tolerance,
     # same helper, as the settlement and lane parsers.
     tail = unfence(text.split(marker, 1)[1].strip())
+    decoder = json.JSONDecoder()
     try:
-        value, end = json.JSONDecoder().raw_decode(tail)
+        value, end = decoder.raw_decode(tail)
     except json.JSONDecodeError as exc:
-        raise ResearchError(f"invalid JSON after {marker}: {exc}") from exc
+        # Claude has repeatedly emitted a complete binding array while omitting
+        # only the outer object's final `}` — including on the one permitted
+        # correction. Accept that single mechanically unambiguous truncation;
+        # schema and exact-row validation still run below. Do not guess at an
+        # internal quote, comma, bracket, or any multi-character repair.
+        if tail.startswith("{") and not tail.endswith("}"):
+            try:
+                value, end = decoder.raw_decode(tail + "}")
+                tail += "}"
+            except json.JSONDecodeError:
+                raise ResearchError(f"invalid JSON after {marker}: {exc}") from exc
+        else:
+            raise ResearchError(f"invalid JSON after {marker}: {exc}") from exc
     if tail[end:].strip():
         raise ResearchError(f"unexpected text after {marker} JSON")
     return value
@@ -240,4 +253,7 @@ def render(items: Sequence[Packet]) -> str:
 
 
 def digest(items: Sequence[Packet]) -> str:
-    return hashlib.sha256(render(items).encode("utf-8")).hexdigest()
+    # Model-controlled fields can contain lone surrogates. JSON can represent them,
+    # and audit logging escapes them; the digest must remain total on the same bytes
+    # instead of making the failure serializer fail while reporting their rejection.
+    return hashlib.sha256(render(items).encode("utf-8", "surrogatepass")).hexdigest()

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -58,6 +58,7 @@ class Review:
     usage: dict | None = None
     duration_ms: int | None = None
     failure_detail: str | None = None
+    stderr: str | None = None
 
 
 class Engine(ABC):
@@ -163,9 +164,10 @@ class Engine(ABC):
         # non-empty stdout, which the old "rc != 0 AND empty stdout" gate silently
         # swallowed, defeating any downstream fallback.
         failed = result.returncode != 0 or review.error
+        stderr = result.stderr if result.stderr else None
         failure_detail = (
             (
-                (result.stderr if result.stderr.strip() else None) or review.failure_detail
+                review.failure_detail or (result.stderr if result.stderr.strip() else None)
                 or f"{self.name} exited with return code {result.returncode}"
             ) if result.returncode != 0
             else review.failure_detail
@@ -178,14 +180,15 @@ class Engine(ABC):
                     f"{detail.strip()[:2000]}"
                 ),
                 session_ref=review.session_ref,
-                raw=result.stderr or result.stdout,
+                raw=result.stdout,
                 returncode=result.returncode,
                 error=True,
                 failure_detail=detail,
+                stderr=stderr,
             )
         return replace(
             review, returncode=result.returncode, error=failed,
-            failure_detail=failure_detail,
+            failure_detail=failure_detail, stderr=stderr,
         )
 
 

--- a/src/paranoia_local/evidence.py
+++ b/src/paranoia_local/evidence.py
@@ -84,8 +84,11 @@ def refs_digest(repo: Path) -> str:
     while the deciders could have read the transient commit. The reflog records the
     movement. A repository with reflogs disabled loses that half of the detection.
     """
-    refs = _git(["for-each-ref", "--format=%(refname) %(objectname)"], repo, check=False)
-    reflog = _git(["reflog", "--all", "--format=%H %gd"], repo, check=False)
+    try:
+        refs = _git(["for-each-ref", "--format=%(refname) %(objectname)"], repo)
+        reflog = _git(["reflog", "--all", "--format=%H %gd"], repo)
+    except RuntimeError as exc:
+        raise ArbitrationError(f"repository ref provenance unavailable: {exc}") from exc
     return hashlib.sha256((refs + "\n--\n" + reflog).encode("utf-8", "replace")).hexdigest()
 
 

--- a/src/paranoia_local/external_sources.py
+++ b/src/paranoia_local/external_sources.py
@@ -42,6 +42,14 @@ class SourceError(ValueError):
     pass
 
 
+class CaptureGroupError(RuntimeError):
+    """A capture task failed unexpectedly after zero or more siblings completed."""
+
+    def __init__(self, message: str, completed: tuple["Capture", ...]):
+        super().__init__(message)
+        self.completed = completed
+
+
 @dataclass(frozen=True)
 class CandidateSource:
     url: str
@@ -266,15 +274,32 @@ def capture_all(
     deadline: float | None = None,
     clock: Callable[[], float] = time.monotonic,
 ) -> list[Capture]:
-    from concurrent.futures import ThreadPoolExecutor
+    from concurrent.futures import CancelledError, ThreadPoolExecutor, as_completed
 
     rows = list(candidates)
     invoke = (
         (lambda candidate: capture(candidate, deadline=deadline, clock=clock))
         if capture_one is capture else capture_one
     )
+    completed: dict[int, Capture] = {}
+    failure: Exception | None = None
     with ThreadPoolExecutor(max_workers=min(workers, max(1, len(rows)))) as pool:
-        return list(pool.map(invoke, rows))
+        futures = {pool.submit(invoke, row): index for index, row in enumerate(rows)}
+        for future in as_completed(futures):
+            index = futures[future]
+            try:
+                completed[index] = future.result()
+            except CancelledError:
+                continue
+            except Exception as exc:  # unexpected capture implementation failure
+                if failure is None:
+                    failure = exc
+                    for pending in futures:
+                        pending.cancel()
+    ordered = tuple(completed[index] for index in sorted(completed))
+    if failure is not None:
+        raise CaptureGroupError(f"{type(failure).__name__}: {failure}", ordered) from failure
+    return list(ordered)
 
 
 def packet_id(proposition: str, source: BoundSource) -> str:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -83,12 +83,37 @@ def _allocate_fresh_debt_ids(
 def _attempt(
     role: str, engine: Engine, review: Review, *, sequence: int | None = None,
 ) -> rc.Attempt:
-    response = review.raw or review.text or ""
-    return rc.Attempt(role, engine.name, review.session_ref,
-                      "failed" if review.error else "completed",
-                      review.duration_ms, review.usage,
-                      rc.digest(response) if response else None,
-                      response[:4000] if response else None, sequence)
+    response = review.text or ""
+    projection = _review_failure_projection(review) if review.error else {}
+    return rc.Attempt(
+        role, engine.name, review.session_ref,
+        "failed" if review.error else "completed",
+        review.duration_ms, review.usage,
+        hashlib.sha256(response.encode("utf-8", "surrogatepass")).hexdigest()
+        if response else None,
+        response[:4000] if response else None, sequence,
+        **projection,
+    )
+
+
+def _review_failure_projection(review: Review) -> dict[str, Any]:
+    def channel(text: str | None) -> tuple[str, str]:
+        value = text or ""
+        return (
+            hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest(),
+            value[:4000],
+        )
+
+    raw_sha, raw_excerpt = channel(getattr(review, "raw", None))
+    detail_sha, detail_excerpt = channel(getattr(review, "failure_detail", None))
+    stderr_sha, stderr_excerpt = channel(getattr(review, "stderr", None))
+    return {
+        "returncode": getattr(review, "returncode", None),
+        "raw_sha256": raw_sha, "raw_excerpt": raw_excerpt,
+        "failure_detail_sha256": detail_sha,
+        "failure_detail_excerpt": detail_excerpt,
+        "stderr_sha256": stderr_sha, "stderr_excerpt": stderr_excerpt,
+    }
 
 
 def _engine_failure_error(review: Review, *, role: str) -> rc.CensusError:
@@ -103,6 +128,7 @@ def _engine_failure_error(review: Review, *, role: str) -> rc.CensusError:
     error = rc.CensusError(detail)
     error.stage_role = role  # type: ignore[attr-defined]
     error.failure_kind = kind  # type: ignore[attr-defined]
+    error.engine_failure = _review_failure_projection(review)  # type: ignore[attr-defined]
     return error
 
 
@@ -307,6 +333,9 @@ def _settle_staged_failure(
             "kind":getattr(error, "failure_kind", "unknown"),
             "message":str(error),
         }
+        engine_failure = getattr(error, "engine_failure", None)
+        if isinstance(engine_failure, dict):
+            state["staged_failure"]["engine_failure"] = deepcopy(engine_failure)
     failure_key = "validation_debt" if isinstance(cache, dict) else "staged_failure"
     if rejected_payloads:
         state[failure_key]["rejected_payloads"] = deepcopy(rejected_payloads)
@@ -924,6 +953,7 @@ def _log(
             "returncode": review.returncode,
             "error": review.error,
             "text": review.text,
+            **(_review_failure_projection(review) if review.error else {}),
             **extra,
         },
         timestamp=now(),
@@ -1580,7 +1610,10 @@ def _verify_plan_claims(
         attempt_ledger.append(_attempt("claim-audit", engine, review).json())
     if review.error:
         error = pc.AuditError(
-            f"claim-audit reviewer failed (exit {review.returncode})", review.raw or review.text
+            f"claim-audit reviewer failed (exit {review.returncode})",
+            review.raw,
+            failure_detail=review.failure_detail or "", stderr=review.stderr or "",
+            returncode=review.returncode,
         )
         return pc.with_debt(
             prior_state, error, round_no=round_no, plan_text=plan_text, frozen_ids=frozen,
@@ -1621,7 +1654,9 @@ def _verify_plan_claims(
             second = pc.AuditError(
                 f"initial audit invalid ({first.reason}); correction call failed "
                 f"(exit {retry.returncode})",
-                (review.text or "") + "\n--- CORRECTION ---\n" + (retry.raw or retry.text),
+                retry.raw,
+                failure_detail=retry.failure_detail or "", stderr=retry.stderr or "",
+                returncode=retry.returncode,
             )
             return pc.with_debt(
                 prior_state, second, round_no=round_no, plan_text=plan_text,
@@ -1782,7 +1817,9 @@ class _CapturedClaimEngine:
         except pc.AuditError as error:
             return Review(
                 text=f"[paranoia-local error] binding audit invalid: {error}",
-                session_ref=session_ref, raw="\n--- phase ---\n".join(raw_parts), error=True,
+                session_ref=session_ref, raw=error.raw, error=True,
+                failure_detail=error.failure_detail_raw, stderr=error.stderr_raw,
+                returncode=error.returncode if error.returncode is not None else 1,
             )
         raw_parts.extend(item.raw for item in binding_reviews)
 
@@ -1981,7 +2018,11 @@ class _CapturedClaimEngine:
             self._record("claim-binding", self.binding_engine, review)
             reviews.append(review)
             if review.error or not review.session_ref:
-                raise pc.AuditError("captured-text binding call failed", review.raw)
+                raise pc.AuditError(
+                    "captured-text binding call failed", review.raw,
+                    failure_detail=review.failure_detail or "", stderr=review.stderr or "",
+                    returncode=review.returncode,
+                )
             try:
                 parsed = self._parse_indexed_binding(review.text, batch, captures)
             except pc.AuditError as first:
@@ -1995,7 +2036,12 @@ class _CapturedClaimEngine:
                 self._record("claim-binding-retry", self.binding_engine, correction)
                 reviews.append(correction)
                 if correction.error or not correction.session_ref:
-                    raise pc.AuditError("captured-text binding correction failed", correction.raw)
+                    raise pc.AuditError(
+                        "captured-text binding correction failed", correction.raw,
+                        failure_detail=correction.failure_detail or "",
+                        stderr=correction.stderr or "",
+                        returncode=correction.returncode,
+                    )
                 parsed = self._parse_indexed_binding(correction.text, batch, captures)
                 review = correction
             decisions.update(parsed)

--- a/src/paranoia_local/plan_claims.py
+++ b/src/paranoia_local/plan_claims.py
@@ -46,18 +46,36 @@ UGC_HOSTS = sources.UGC_HOSTS
 class AuditError(ValueError):
     """The claim audit is absent, malformed, or makes an unsupported transition."""
 
-    def __init__(self, reason: str, raw: str = "") -> None:
+    def __init__(
+        self, reason: str, raw: str = "", *, failure_detail: str = "", stderr: str = "",
+        returncode: int | None = None,
+    ) -> None:
         self.reason = reason
+        self.raw = raw
+        self.failure_detail_raw = failure_detail
+        self.stderr_raw = stderr
+        self.returncode = returncode
         self.raw_sha256 = hashlib.sha256(raw.encode("utf-8", "replace")).hexdigest()
         self.excerpt = _excerpt(raw)
+        self.failure_detail_sha256 = hashlib.sha256(
+            failure_detail.encode("utf-8", "replace")
+        ).hexdigest()
+        self.failure_detail = _excerpt(failure_detail)
+        self.stderr_sha256 = hashlib.sha256(stderr.encode("utf-8", "replace")).hexdigest()
+        self.stderr = _excerpt(stderr)
         super().__init__(reason)
 
     def debt(self, round_no: int) -> dict[str, Any]:
         return {
             "round": round_no,
             "reason": self.reason,
+            "returncode": self.returncode,
             "raw_sha256": self.raw_sha256,
             "rejected_excerpt": self.excerpt,
+            "failure_detail_sha256": self.failure_detail_sha256,
+            "failure_detail": self.failure_detail,
+            "stderr_sha256": self.stderr_sha256,
+            "stderr": self.stderr,
         }
 
 

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -51,6 +51,13 @@ class Attempt:
     response_sha256: str | None = None
     response_excerpt: str | None = None
     sequence: int | None = None
+    returncode: int | None = None
+    raw_sha256: str | None = None
+    raw_excerpt: str | None = None
+    failure_detail_sha256: str | None = None
+    failure_detail_excerpt: str | None = None
+    stderr_sha256: str | None = None
+    stderr_excerpt: str | None = None
 
     def json(self) -> dict[str, Any]:
         return vars(self)

--- a/tests/test_acceptance_validator.py
+++ b/tests/test_acceptance_validator.py
@@ -1,0 +1,200 @@
+import hashlib
+import importlib.util
+import json
+from pathlib import Path
+
+import pytest
+
+
+_SCRIPT = Path(__file__).parents[1] / "scripts" / "validate_arbitration_acceptance.py"
+_SPEC = importlib.util.spec_from_file_location("acceptance_validator", _SCRIPT)
+assert _SPEC and _SPEC.loader
+validator = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(validator)
+
+
+def _sha(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
+def fixture(tmp_path: Path) -> tuple[Path, Path]:
+    repo = tmp_path / "repo"
+    hashes = {}
+    for relative in validator.PRODUCTION_SOURCES:
+        source = repo / relative
+        source.parent.mkdir(parents=True, exist_ok=True)
+        source.write_text(f"# {relative}\n")
+        hashes[relative] = _sha(source)
+    packets = json.dumps([{
+        "packet_id": "src-one", "source": {"url": "https://example.test/doc"},
+    }])
+    digest = hashlib.sha256(packets.encode()).hexdigest()
+    audit = tmp_path / "audit.json"
+    audit.write_text(json.dumps({
+        "snapshot": "abc", "outcome": "CONVERGED", "selected": "decimal",
+        "cleaning": "attested", "refs_moved": False,
+        "phase_attempts": [
+            {"role": "cleaner", "invoked": True},
+            {"role": "attester", "invoked": True},
+        ],
+        "research": {
+            "digest": digest,
+            "packets": packets,
+            "runs": [
+                {"engine": "codex", "calls": 1, "attempts": [{"invoked": True}]},
+                {"engine": "claude", "calls": 1, "attempts": [{"invoked": True}]},
+            ],
+        },
+        "rounds": [{
+            "codex": {"attempts": [{"invoked": True}], "decisive": "README.md:1"},
+            "claude": {"attempts": [{"invoked": True}], "decisive": "SOURCE:src-one"},
+        }],
+    }))
+    preceding_audit = tmp_path / "preceding.json"
+    preceding_audit.write_text(json.dumps({
+        "snapshot": "abc", "outcome": "FAILED", "reason": "provider failed",
+        "cleaning": "attested-after-retry",
+    }))
+    artifact = tmp_path / "acceptance.json"
+    artifact.write_text(json.dumps({"primary_path": {
+        "audit": str(audit), "result": "CONVERGED", "selected": "decimal",
+        "snapshot": "abc", "research_digest": digest, "cleaning": "attested",
+        "rounds": 1, "refs_moved": False,
+        "captured_packets": ["src-one"],
+        "captured_urls": ["https://example.test/doc"],
+        "decisive_evidence": {
+            "codex": "README.md:1", "claude": "SOURCE:src-one",
+        },
+        "production_source_sha256": hashes,
+        "model_calls": {
+            "research": {"codex": 1, "claude": 1},
+            "deciders": {"codex": 1, "claude": 1},
+            "cleaner": 1, "attester": 1, "total": 6,
+        },
+        "audit_reconciliation": {
+            "audit_sha256": _sha(audit),
+            "research_attempts": {"codex": 1, "claude": 1},
+            "framing_attempts": 2, "decider_attempts": 2,
+            "total_provider_calls": 6, "packet_count": 1,
+            "packet_digest_matches": True, "packet_ids_match": True,
+            "production_hashes_match": True,
+        },
+        "preceding_failed_closed_attempt": {
+            "audit": str(preceding_audit), "audit_sha256": _sha(preceding_audit),
+            "result": "FAILED", "reason": "provider failed",
+            "cleaning": "attested-after-retry", "snapshot": "abc",
+        },
+    }}))
+    return artifact, repo
+
+
+def test_acceptance_validator_reconciles_audit_and_sources(tmp_path: Path):
+    artifact, repo = fixture(tmp_path)
+    validator.validate(artifact, repo)
+
+
+def test_acceptance_validator_reconciles_one_framing_retry(tmp_path: Path):
+    artifact, repo = fixture(tmp_path)
+    acceptance = json.loads(artifact.read_text())
+    audit_path = Path(acceptance["primary_path"]["audit"])
+    audit = json.loads(audit_path.read_text())
+    audit["phase_attempts"] += [
+        {"role": "cleaner", "invoked": True},
+        {"role": "attester", "invoked": True},
+    ]
+    audit["cleaning"] = "attested-after-retry"
+    audit_path.write_text(json.dumps(audit))
+    primary = acceptance["primary_path"]
+    primary["audit_reconciliation"]["audit_sha256"] = _sha(audit_path)
+    primary["audit_reconciliation"]["framing_attempts"] = 4
+    primary["audit_reconciliation"]["total_provider_calls"] = 8
+    primary["model_calls"].update({"cleaner": 2, "attester": 2, "total": 8})
+    primary["cleaning"] = "attested-after-retry"
+    artifact.write_text(json.dumps(acceptance))
+
+    validator.validate(artifact, repo)
+
+
+def test_acceptance_validator_rejects_a_self_asserted_stale_total(tmp_path: Path):
+    artifact, repo = fixture(tmp_path)
+    data = json.loads(artifact.read_text())
+    data["primary_path"]["model_calls"]["total"] = 5
+    artifact.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="total calls"):
+        validator.validate(artifact, repo)
+
+
+@pytest.mark.parametrize(("mutation", "message"), [
+    (lambda a, d: a["primary_path"]["captured_packets"].append("src-two"), "packet count"),
+    (lambda a, d: a["primary_path"]["captured_packets"].__setitem__(0, "src-two"), "packet ids"),
+    (lambda a, d: a["primary_path"].__setitem__("research_digest", "stale"), "packet digest"),
+    (lambda a, d: a["primary_path"]["captured_urls"].clear(), "packet urls"),
+    (lambda a, d: a["primary_path"]["decisive_evidence"].__setitem__("codex", "README.md:2"), "decisive evidence"),
+    (lambda a, d: a["primary_path"]["model_calls"].__setitem__("cleaner", 0), "cleaner attempts"),
+    (lambda a, d: a["primary_path"]["model_calls"].__setitem__("attester", 0), "attester attempts"),
+    (lambda a, d: a["primary_path"]["model_calls"]["research"].__setitem__("codex", 2), "research attempts"),
+    (lambda a, d: a["primary_path"]["model_calls"]["deciders"].__setitem__("codex", 2), "decider attempts"),
+    (lambda a, d: d["research"]["runs"].append(d["research"]["runs"][0]), "each engine exactly once"),
+    (lambda a, d: d["research"]["runs"][0].__setitem__("calls", 2), "calls disagree"),
+    (lambda a, d: d["research"]["runs"][0]["attempts"][0].__setitem__("invoked", "false"), "exact boolean"),
+    (lambda a, d: a["primary_path"].__setitem__("result", "FAILED"), "audit outcome"),
+    (lambda a, d: a["primary_path"].__setitem__("selected", "float"), "audit selection"),
+    (lambda a, d: a["primary_path"].__setitem__("snapshot", "def"), "audit snapshot"),
+    (lambda a, d: a["primary_path"].__setitem__("cleaning", "skipped"), "cleaning"),
+    (lambda a, d: a["primary_path"].__setitem__("rounds", 99), "round count"),
+    (lambda a, d: a["primary_path"].__setitem__("refs_moved", True), "refs moved"),
+    (lambda a, d: a["primary_path"]["production_source_sha256"].pop(next(iter(validator.PRODUCTION_SOURCES))), "complete source set"),
+    (lambda a, d: a["primary_path"]["production_source_sha256"].__setitem__(next(iter(validator.PRODUCTION_SOURCES)), "0" * 64), "production hash mismatch"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("packet_ids_match", False), "packet_ids_match"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("packet_digest_matches", False), "packet_digest_matches"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("production_hashes_match", False), "production_hashes_match"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("framing_attempts", 1), "framing_attempts"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("decider_attempts", 1), "decider_attempts"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"]["research_attempts"].__setitem__("codex", 2), "research_attempts"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("total_provider_calls", 5), "total_provider_calls"),
+    (lambda a, d: a["primary_path"]["audit_reconciliation"].__setitem__("packet_count", 2), "packet_count"),
+])
+def test_acceptance_validator_rejects_each_independent_summary(
+    tmp_path: Path, mutation, message: str,
+):
+    artifact, repo = fixture(tmp_path)
+    acceptance = json.loads(artifact.read_text())
+    audit_path = Path(acceptance["primary_path"]["audit"])
+    audit = json.loads(audit_path.read_text())
+    mutation(acceptance, audit)
+    audit_path.write_text(json.dumps(audit))
+    acceptance["primary_path"]["audit_reconciliation"]["audit_sha256"] = _sha(audit_path)
+    artifact.write_text(json.dumps(acceptance))
+
+    with pytest.raises(ValueError, match=message):
+        validator.validate(artifact, repo)
+
+
+def test_acceptance_validator_rejects_stale_audit_hash(tmp_path: Path):
+    artifact, repo = fixture(tmp_path)
+    data = json.loads(artifact.read_text())
+    data["primary_path"]["audit_reconciliation"]["audit_sha256"] = "0" * 64
+    artifact.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match="audit_sha256"):
+        validator.validate(artifact, repo)
+
+
+@pytest.mark.parametrize(("field", "value", "message"), [
+    ("audit_sha256", "0" * 64, "preceding audit digest"),
+    ("result", "CONVERGED", "preceding result"),
+    ("reason", "different", "preceding reason"),
+    ("cleaning", "skipped", "preceding cleaning"),
+    ("snapshot", "def", "preceding snapshot"),
+])
+def test_acceptance_validator_rejects_stale_preceding_failure(
+    tmp_path: Path, field: str, value: str, message: str,
+):
+    artifact, repo = fixture(tmp_path)
+    data = json.loads(artifact.read_text())
+    data["primary_path"]["preceding_failed_closed_attempt"][field] = value
+    artifact.write_text(json.dumps(data))
+
+    with pytest.raises(ValueError, match=message):
+        validator.validate(artifact, repo)

--- a/tests/test_arbitrate_handler.py
+++ b/tests/test_arbitrate_handler.py
@@ -5,6 +5,7 @@ both deciders, that labels are cleared against the real repository, that the
 round-2 gate is consulted before spending, and that the trailer tells the truth.
 """
 
+import hashlib
 import json
 from pathlib import Path
 
@@ -46,6 +47,28 @@ class FakeEngine(eng.Engine):
 
     def parse_output(self, stdout):  # pragma: no cover - unused
         raise NotImplementedError
+
+
+class ScriptedResearchEngine(FakeEngine):
+    def __init__(self, name: str, reviews: list[eng.Review | Exception]):
+        super().__init__(name)
+        self.reviews = list(reviews)
+
+    def for_role(self, role: str):
+        self.role = role
+        return self
+
+    def run(self, *args, **kwargs):
+        item = self.reviews.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
+
+    def resume(self, *args, **kwargs):
+        item = self.reviews.pop(0)
+        if isinstance(item, Exception):
+            raise item
+        return item
 
 
 ENGINES = [FakeEngine("codex"), FakeEngine("claude")]
@@ -286,6 +309,8 @@ def test_decider_reply_fails_after_exactly_one_correction(
     failed = record["failed_round"]["deciders"]["claude"]
     assert failed["status"] == "failed"
     assert len(failed["attempts"]) == 2
+    assert len(record["refs_before"]) == 64
+    assert len(record["refs_after"]) == 64
 
 
 def test_decider_execution_failure_is_not_retried(repo: Path, tmp_path: Path):
@@ -304,6 +329,128 @@ def test_decider_execution_failure_is_not_retried(repo: Path, tmp_path: Path):
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "provider unavailable" in report
     assert claude_calls == 1
+
+
+def test_decider_path_prefers_structured_failure_detail_over_partial_text(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    class AdapterEngine:
+        def __init__(self, name: str):
+            self.name = name
+            self.calls = 0
+            self.prompts = []
+
+        def for_role(self, _role: str):
+            return self
+
+        def run(self, prompt, *args, **kwargs):
+            self.calls += 1
+            self.prompts.append(prompt)
+            if self.name == "claude":
+                return eng.Review(
+                    text="SELECTED: partial-provider-output\n",
+                    session_ref="partial-session",
+                    raw="raw provider envelope",
+                    returncode=1,
+                    error=True,
+                    failure_detail="provider credit exhausted before completion",
+                )
+            label = next(
+                line.split(":", 1)[0]
+                for line in prompt.splitlines()
+                if line.startswith(arb.LABEL_PREFIX) and "Decimal" in line
+            )
+            return eng.Review(
+                text=decider_reply(label), session_ref="codex-session", raw="", returncode=0,
+            )
+
+    adapters = {name: AdapterEngine(name) for name in ("codex", "claude")}
+    monkeypatch.setattr(
+        ah.eng, "get_engine", lambda name, text_only=False: adapters[name]
+    )
+
+    report = ah.arbitrate(
+        {**BASE, "repo_path": str(repo), "clean": False},
+        log_dir=tmp_path / "logs", engines=ENGINES,
+        now=lambda: "20260727T120000",
+    )
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "provider credit exhausted before completion" in report
+    assert "partial-provider-output" not in report
+    assert adapters["claude"].calls == 1
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    failed = record["failed_round"]["deciders"]["claude"]
+    assert "provider credit exhausted before completion" in failed["error"]
+    assert "provider credit exhausted before completion" in failed["attempts"][0]["rejection"]
+    assert "partial-provider-output" not in failed["error"]
+    attempt = failed["attempts"][0]
+    exact_prompt = adapters["claude"].prompts[0]
+    assert attempt["prompt_sha256"] == hashlib.sha256(
+        exact_prompt.encode("utf-8", "surrogatepass")
+    ).hexdigest()
+    assert attempt["prompt_excerpt"] == exact_prompt
+
+
+def test_failure_after_round_one_preserves_completed_decider_artifacts(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    def broken_substantiation(*args, **kwargs):
+        raise RuntimeError("resolution bridge failed")
+
+    monkeypatch.setattr(ah.arb, "substantiation", broken_substantiation)
+    report = run(repo, Agent(lambda engine, rnd: "opt-decimal"), tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "resolution bridge failed" in report
+    assert trailer_field(report, "ROUNDS") == "1"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert sorted(record["rounds"][0]) == ["claude", "codex"]
+    assert record["rounds"][0]["codex"]["reply"]
+    assert record["rounds"][0]["claude"]["prompt"]
+    assert sorted(record["label_maps"]) == ["claude", "codex"]
+
+
+def test_post_fanout_failure_preserves_completed_research_packet_and_digest(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(ah.eng, "require_evidence_profile", lambda engine: "test")
+    candidate = es.CandidateSource(
+        "https://docs.example.com/api", "API docs", "Example", "primary",
+        "Example defines the API", "supports_claim",
+    )
+    claim = ar.DiscoveryClaim("behavior", "The API retries twice.", candidate)
+    capture = es.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        "The API retries twice.",
+    )
+    bound = es.BoundSource(candidate, capture, "API", "The API retries twice.")
+
+    def researcher(**kwargs):
+        return ah.ResearchRun(
+            kwargs["engine"].name, kwargs["model"], (claim,), (bound,), (capture,),
+            "discovery", "binding", 2, ({}, {}), (1, 1),
+        )
+
+    def broken_substantiation(*args, **kwargs):
+        raise RuntimeError("post-research resolution failed")
+
+    monkeypatch.setattr(ah.arb, "substantiation", broken_substantiation)
+    args = {key: value for key, value in BASE.items() if key != "research"}
+    report = ah.arbitrate(
+        {**args, "repo_path": str(repo), "clean": False},
+        log_dir=tmp_path / "logs", engines=ENGINES,
+        run_agent=Agent(lambda engine, rnd: "opt-decimal"),
+        run_research=researcher, now=lambda: "20260727T120000",
+    )
+
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert trailer_field(report, "RESEARCH") == "complete 1 packets"
+    assert trailer_field(report, "RESEARCH-DIGEST") == record["research"]["digest"]
+    assert record["research"]["packets"]
+    assert record["research"]["packets"] == ar.render(
+        ar.packets([((claim,), (bound,))])
+    )
 
 
 def test_correction_execution_failure_preserves_the_rejected_reply(
@@ -328,7 +475,7 @@ def test_correction_execution_failure_preserves_the_rejected_reply(
     report = run(repo, failed_correction, tmp_path, clean=False)
 
     assert trailer_field(report, "ARBITRATION") == "FAILED"
-    assert "correction execution failed after a rejected reply" in report
+    assert "correction attempt failed after a rejected reply" in report
     assert claude_calls == 2
     record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
     failure = record["failed_round"]["deciders"]["claude"]
@@ -336,7 +483,12 @@ def test_correction_execution_failure_preserves_the_rejected_reply(
     assert "reply mentions AUTHORITY:" in failure["attempts"][0]["rejection"]
     assert "FORMAT CORRECTION" in failure["attempts"][1]["body"]
     assert failure["attempts"][1]["raw"] == ""
-    assert "execution failure" in failure["attempts"][1]["rejection"]
+
+
+    assert "provider unavailable" in failure["attempts"][1]["rejection"]
+    assert failure["attempts"][1]["status"] == "provider-failed"
+    assert failure["attempts"][1]["admitted"] is True
+    assert failure["attempts"][1]["invoked"] is True
     assert record["failed_round"]["deciders"]["codex"]["selected"] == "opt-decimal"
 
 
@@ -350,6 +502,60 @@ def test_whole_run_deadline_refuses_a_phase_that_cannot_fit(
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "insufficient time to start a 420s agent phase" in report
     assert not agent.calls
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["phase_attempts"][0]["status"] == "admission-refused"
+    assert record["phase_attempts"][0]["invoked"] is False
+
+
+def test_cleaner_execution_exception_keeps_pending_attempt_binding(
+    repo: Path, tmp_path: Path,
+):
+    def failed_cleaner(**kwargs):
+        raise RuntimeError("cleaner provider unavailable")
+
+    report = run(repo, failed_cleaner, tmp_path)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert record["phase_attempts"][0]["role"] == "cleaner"
+    assert record["phase_attempts"][0]["prompt_excerpt"]
+    assert len(record["phase_attempts"][0]["prompt_sha256"]) == 64
+    assert "cleaner provider unavailable" in record["phase_attempts"][0]["rejection"]
+
+
+def test_cleaner_execution_failure_keeps_distinct_engine_channels(
+    repo: Path, tmp_path: Path,
+):
+    channels = {
+        "engine": "codex", "returncode": 9,
+        "failure_detail": "structured cleaner failure", "text": "partial cleaner text",
+        "raw": "raw cleaner envelope", "stderr": "cleaner stderr",
+    }
+
+    def failed_cleaner(**kwargs):
+        raise ah.EngineCallError("cleaner failed", channels)
+
+    report = run(repo, failed_cleaner, tmp_path)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["phase_attempts"][0]["engine_failure"] == channels
+
+
+def test_attester_execution_exception_keeps_pending_attempt_binding(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+
+    def failed_attester(**kwargs):
+        if "TEXT AUDITOR" in kwargs["instructions"]:
+            raise RuntimeError("attester provider unavailable")
+        return scripted(**kwargs)
+
+    report = run(repo, failed_attester, tmp_path)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert [item["role"] for item in record["phase_attempts"]] == [
+        "cleaner", "attester",
+    ]
+    assert record["phase_attempts"][1]["prompt_excerpt"]
+    assert "attester provider unavailable" in record["phase_attempts"][1]["rejection"]
 
 
 def test_default_research_injects_one_shared_captured_packet_before_voting(
@@ -405,6 +611,457 @@ def test_default_research_injects_one_shared_captured_packet_before_voting(
     assert all(packet_id in call["body"] for call in decider_calls)
 
 
+def test_capture_failure_retains_completed_sibling_in_research_record(monkeypatch):
+    discovery = ar.DISCOVERY_MARKER + "\n" + json.dumps({
+        "claims": [{
+            "kind": "behavior",
+            "proposition": "The API retries twice.",
+            "candidate": {
+                "url": "https://docs.example.com/api", "title": "API docs",
+                "publisher": "Example", "source_kind": "primary",
+                "authority_basis": "Example defines the API",
+                "relation": "supports_claim",
+            },
+        }],
+    })
+    engine = ScriptedResearchEngine("codex", [
+        eng.Review(discovery, "discovery-session", "raw discovery"),
+    ])
+
+    def capture_all(candidates, **kwargs):
+        item = candidates[0]
+        completed = es.Capture(
+            item, item.url, 200, "text/html", "a" * 64, "b" * 64,
+            "The API retries twice.",
+        )
+        raise es.CaptureGroupError("RuntimeError: sibling exploded", (completed,))
+
+    monkeypatch.setattr(ah.external_sources, "capture_all", capture_all)
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+    assert caught.value.record["phase"] == "capture"
+    assert caught.value.record["captures"][0]["final_url"] == "https://docs.example.com/api"
+
+
+def test_binding_validation_failure_retains_both_rejected_replies(
+    monkeypatch,
+):
+    discovery = ar.DISCOVERY_MARKER + "\n" + json.dumps({
+        "claims": [{
+            "kind": "behavior",
+            "proposition": "The API retries twice.",
+            "candidate": {
+                "url": "https://docs.example.com/api",
+                "title": "API docs",
+                "publisher": "Example",
+                "source_kind": "primary",
+                "authority_basis": "Example defines the API",
+                "relation": "supports_claim",
+            },
+        }],
+    })
+    first = ar.BINDING_MARKER + "\n" + json.dumps({"bindings": []})
+    second = ar.BINDING_MARKER + "\n" + "not-json"
+    engine = ScriptedResearchEngine("claude", [
+        eng.Review(discovery, "discovery-session", "raw discovery"),
+        eng.Review(first, "binding-session", "raw first binding"),
+        eng.Review(second, "binding-session", "raw second binding"),
+    ])
+
+    def capture_all(candidates, **kwargs):
+        candidate = candidates[0]
+        return [es.Capture(
+            candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+            "The API retries twice.",
+        )]
+
+    monkeypatch.setattr(ah.external_sources, "capture_all", capture_all)
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+
+    record = caught.value.record
+    assert record["phase"] == "binding-validation-retry"
+    assert record["calls"] == 3
+    assert [item["phase"] for item in record["rejected_replies"]] == [
+        "binding", "binding-validation-retry",
+    ]
+    assert record["rejected_replies"][0]["extracted_excerpt"] == first
+    assert record["rejected_replies"][0]["raw_excerpt"] == "raw first binding"
+    assert record["rejected_replies"][1]["extracted_excerpt"] == second
+    assert record["accepted_claims"][0]["proposition"] == "The API retries twice."
+    assert record["captures"][0]["final_url"] == "https://docs.example.com/api"
+    assert [attempt["session_ref"] for attempt in record["attempts"]] == [
+        "discovery-session", "binding-session", "binding-session",
+    ]
+
+
+def test_research_execution_failure_surfaces_engine_detail():
+    engine = ScriptedResearchEngine("claude", [eng.Review(
+        "", None, "provider envelope", returncode=1, error=True,
+        failure_detail="Credit balance is too low to run this request.",
+    )])
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+
+    assert "Credit balance is too low" in str(caught.value)
+    assert caught.value.record["message"] == (
+        "Credit balance is too low to run this request."
+    )
+    assert caught.value.record["attempts"][-1]["raw_excerpt"] == "provider envelope"
+    assert caught.value.record["attempts"][-1]["failure_detail"] == (
+        "Credit balance is too low to run this request."
+    )
+    assert caught.value.record["attempts"][-1]["status"] == "provider-failed"
+
+
+@pytest.mark.parametrize("phase", [
+    "discovery", "discovery-validation-retry",
+    "binding", "binding-validation-retry",
+])
+def test_structured_research_provider_failure_has_failed_lifecycle_status(phase: str):
+    review = eng.Review(
+        "partial", "session", "raw", returncode=1, error=True,
+        failure_detail="provider failed",
+    )
+    record = ah._research_reply_record(phase, review, "provider failed")
+
+    assert record["phase"] == phase
+    assert record["status"] == "provider-failed"
+    assert record["invoked"] is True
+
+
+def test_research_invocation_exception_is_counted_with_prompt_binding():
+    engine = ScriptedResearchEngine("claude", [RuntimeError("provider offline")])
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+
+    record = caught.value.record
+    assert record["calls"] == 1
+    assert len(record["attempts"]) == 1
+    assert record["attempts"][0]["phase"] == "discovery"
+    assert record["attempts"][0]["prompt_excerpt"]
+    assert len(record["attempts"][0]["prompt_sha256"]) == 64
+    assert record["attempts"][0]["intended_session_ref"] is None
+    assert "provider offline" in record["attempts"][0]["failure_detail"]
+
+
+def test_validation_retry_exception_is_counted_with_session_and_prompt():
+    engine = ScriptedResearchEngine("claude", [
+        eng.Review("not discovery JSON", "discovery-session", "raw invalid"),
+        RuntimeError("retry provider offline"),
+    ])
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+
+    record = caught.value.record
+    assert record["calls"] == 2
+    assert [item["phase"] for item in record["attempts"]] == [
+        "discovery", "discovery-validation-retry",
+    ]
+    retry = record["attempts"][1]
+    assert retry["intended_session_ref"] == "discovery-session"
+    assert retry["prompt_excerpt"]
+    assert "retry provider offline" in retry["failure_detail"]
+    assert record["rejected_replies"][0]["raw_excerpt"] == "raw invalid"
+
+
+def test_research_deadline_admits_discovery_cap_before_invocation(monkeypatch):
+    engine = ScriptedResearchEngine("codex", [RuntimeError("must not run")])
+    monkeypatch.setattr(ah.time, "monotonic", lambda: 100.0)
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium", deadline=339.0,
+        )
+
+    assert caught.value.record["phase"] == "discovery"
+    assert "insufficient time" in caught.value.record["message"]
+    assert caught.value.record["calls"] == 0
+    assert caught.value.record["kind"] == "admission"
+    assert caught.value.record["attempts"][0]["status"] == "admission-refused"
+    assert caught.value.record["attempts"][0]["invoked"] is False
+    assert len(engine.reviews) == 1
+
+
+def test_research_deadline_admits_discovery_retry_cap_before_resume(monkeypatch):
+    engine = ScriptedResearchEngine("codex", [
+        eng.Review("not discovery JSON", "discovery-session", "raw invalid"),
+        RuntimeError("must not resume"),
+    ])
+    ticks = iter([0.0, 100.0])
+    monkeypatch.setattr(ah.time, "monotonic", lambda: next(ticks))
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium", deadline=339.0,
+        )
+
+    assert caught.value.record["phase"] == "discovery-validation-retry"
+    assert caught.value.record["calls"] == 1
+    assert caught.value.record["kind"] == "admission"
+    assert caught.value.record["attempts"][-1]["status"] == "admission-refused"
+    assert caught.value.record["attempts"][-1]["invoked"] is False
+    assert len(engine.reviews) == 1
+    assert caught.value.record["rejected_replies"][0]["raw_excerpt"] == "raw invalid"
+
+
+@pytest.mark.parametrize("retry", [False, True])
+def test_research_deadline_admits_each_binding_cap_before_resume(monkeypatch, retry):
+    discovery = ar.DISCOVERY_MARKER + "\n" + json.dumps({
+        "claims": [{
+            "kind": "behavior", "proposition": "The API retries twice.",
+            "candidate": {
+                "url": "https://docs.example.com/api", "title": "API docs",
+                "publisher": "Example", "source_kind": "primary",
+                "authority_basis": "Example defines the API",
+                "relation": "supports_claim",
+            },
+        }],
+    })
+    invalid_binding = eng.Review(
+        ar.BINDING_MARKER + "\n" + json.dumps({"bindings": []}),
+        "binding-session", "raw invalid binding",
+    )
+    reviews = [eng.Review(discovery, "discovery-session", "raw discovery")]
+    if retry:
+        reviews.append(invalid_binding)
+    reviews.append(RuntimeError("must not resume"))
+    engine = ScriptedResearchEngine("claude", reviews)
+    ticks = iter([0.0, 0.0, 100.0] if retry else [0.0, 100.0])
+    monkeypatch.setattr(ah.time, "monotonic", lambda: next(ticks))
+
+    def capture_all(candidates, **kwargs):
+        candidate = candidates[0]
+        return [es.Capture(
+            candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+            "The API retries twice.",
+        )]
+
+    monkeypatch.setattr(ah.external_sources, "capture_all", capture_all)
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium", deadline=459.0,
+        )
+
+    expected = "binding-validation-retry" if retry else "binding"
+    assert caught.value.record["phase"] == expected
+    assert caught.value.record["calls"] == (2 if retry else 1)
+    assert caught.value.record["kind"] == "admission"
+    assert caught.value.record["attempts"][-1]["status"] == "admission-refused"
+    assert caught.value.record["attempts"][-1]["invoked"] is False
+    assert len(engine.reviews) == 1
+    if retry:
+        assert caught.value.record["rejected_replies"][0]["raw_excerpt"] == (
+            "raw invalid binding"
+        )
+
+
+def test_successful_corrected_lane_keeps_the_initial_parser_error(monkeypatch):
+    valid_discovery = ar.DISCOVERY_MARKER + "\n" + json.dumps({
+        "claims": [{
+            "kind": "behavior",
+            "proposition": "The API retries twice.",
+            "candidate": {
+                "url": "https://docs.example.com/api", "title": "API docs",
+                "publisher": "Example", "source_kind": "primary",
+                "authority_basis": "Example defines the API",
+                "relation": "supports_claim",
+            },
+        }],
+    })
+    valid_binding = ar.BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "usable": True, "location": "API behavior",
+            "passage": "The API retries twice.",
+        }],
+    })
+    engine = ScriptedResearchEngine("codex", [
+        eng.Review("not discovery JSON", "s1", "raw rejected discovery"),
+        eng.Review(valid_discovery, "s1", "raw corrected discovery"),
+        eng.Review(valid_binding, "s1", "raw binding"),
+    ])
+
+    def capture_all(candidates, **kwargs):
+        candidate = candidates[0]
+        return [es.Capture(
+            candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+            "API behavior\nThe API retries twice.",
+        )]
+
+    monkeypatch.setattr(ah.external_sources, "capture_all", capture_all)
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+    run_record = ah._research_one(
+        engine=engine, model="m", packet=packet, options=("A", "B"),
+        forbidden=("a", "b"), effort="medium",
+    )
+
+    assert run_record.attempts[0]["phase"] == "discovery"
+    assert run_record.attempts[0]["error"]
+    assert run_record.attempts[0]["raw_excerpt"] == "raw rejected discovery"
+    assert run_record.attempts[1]["error"] == ""
+
+
+def test_valid_discovery_without_session_retains_the_accepted_claim():
+    discovery = ar.DISCOVERY_MARKER + "\n" + json.dumps({
+        "claims": [{
+            "kind": "behavior",
+            "proposition": "The API retries twice.",
+            "candidate": {
+                "url": "https://docs.example.com/api",
+                "title": "API docs",
+                "publisher": "Example",
+                "source_kind": "primary",
+                "authority_basis": "Example defines the API",
+                "relation": "supports_claim",
+            },
+        }],
+    })
+    engine = ScriptedResearchEngine(
+        "claude", [eng.Review(discovery, None, "raw valid discovery")],
+    )
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=engine, model="m", packet=packet, options=("A", "B"),
+            forbidden=("a", "b"), effort="medium",
+        )
+
+    assert caught.value.record["kind"] == "protocol"
+    assert caught.value.record["accepted_claims"][0]["proposition"] == (
+        "The API retries twice."
+    )
+    assert caught.value.record["attempts"][0]["raw_excerpt"] == "raw valid discovery"
+
+
+def test_terminal_research_failure_is_written_to_gate_audit(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(ah.eng, "require_evidence_profile", lambda engine: "test")
+
+    def researcher(**kwargs):
+        if kwargs["engine"].name == "claude":
+            raise ah.ResearchFailure(
+                "claude binding validation retry rejected: malformed JSON",
+                record={
+                    "engine": "claude",
+                    "model": kwargs["model"],
+                    "phase": "binding-validation-retry",
+                    "kind": "validation",
+                    "message": "malformed JSON",
+                    "calls": 3,
+                    "rejected_replies": [{"raw_excerpt": "the rejected body"}],
+                },
+            )
+        candidate = es.CandidateSource(
+            "https://docs.example.com/api", "API docs", "Example", "primary",
+            "Example defines the API", "supports_claim",
+        )
+        claim = ar.DiscoveryClaim("behavior", "The API retries twice.", candidate)
+        capture = es.Capture(
+            candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+            "The API retries twice.",
+        )
+        bound = es.BoundSource(candidate, capture, "API", "The API retries twice.")
+        return ah.ResearchRun(
+            kwargs["engine"].name, kwargs["model"], (claim,), (bound,), (capture,),
+            "discovery", "binding", 2, ({}, {}), (1, 1),
+            ({"phase": "discovery", "session_ref": "peer-session"},),
+        )
+
+    args = {key: value for key, value in BASE.items() if key != "research"}
+    report = ah.arbitrate(
+        {**args, "repo_path": str(repo), "clean": False},
+        log_dir=tmp_path / "logs", engines=ENGINES,
+        run_agent=Agent(lambda engine, rnd: "opt-decimal"),
+        run_research=researcher, now=lambda: "20260727T120000",
+    )
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert trailer_field(report, "CLEANING") == "skipped"
+    assert trailer_field(report, "RESEARCH") == "failed"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["snapshot"] == trailer_field(report, "SNAPSHOT")
+    assert record["cleaning"] == "skipped"
+    assert record["research"]["failures"][0]["phase"] == "binding-validation-retry"
+    assert record["research"]["failures"][0]["rejected_replies"][0][
+        "raw_excerpt"
+    ] == "the rejected body"
+    assert record["research"]["runs"][0]["engine"] == "codex"
+    assert record["research"]["runs"][0]["claims"][0]["proposition"] == (
+        "The API retries twice."
+    )
+    assert record["research"]["runs"][0]["bindings"][0]["passage"] == (
+        "The API retries twice."
+    )
+    assert record["research"]["runs"][0]["attempts"][0]["session_ref"] == (
+        "peer-session"
+    )
+    assert len(record["refs_before"]) == 64
+    assert len(record["refs_after"]) == 64
+
+
+def test_attester_execution_failure_keeps_distinct_engine_channels(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda engine, rnd: "opt-decimal")
+    channels = {
+        "engine": "claude", "returncode": 8,
+        "failure_detail": "structured attester failure", "text": "partial attester text",
+        "raw": "raw attester envelope", "stderr": "attester stderr",
+    }
+
+    def failed_attester(**kwargs):
+        if "TEXT AUDITOR" in kwargs["instructions"]:
+            raise ah.EngineCallError("attester failed", channels)
+        return scripted(**kwargs)
+
+    report = run(repo, failed_attester, tmp_path)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["phase_attempts"][1]["engine_failure"] == channels
+
+
 def test_research_false_is_the_explicit_repository_only_switch(
     repo: Path, tmp_path: Path,
 ):
@@ -420,6 +1077,29 @@ def test_research_false_is_the_explicit_repository_only_switch(
 
     assert trailer_field(report, "ARBITRATION") == "CONVERGED"
     assert trailer_field(report, "RESEARCH") == "repository-only"
+
+
+def test_repository_only_rejects_unsupported_decider_profile_before_snapshot_or_vote(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    checked: list[str] = []
+
+    def reject(engine):
+        checked.append(engine.name)
+        if engine.name == "claude":
+            raise RuntimeError("claude evidence mode supports a different CLI")
+
+    monkeypatch.setattr(ah.eng, "require_evidence_profile", reject)
+    monkeypatch.setattr(
+        ah, "_snapshot", lambda repo: pytest.fail("snapshot must not be created"),
+    )
+    agent = Agent(lambda engine, rnd: "opt-decimal")
+    report = run(repo, agent, tmp_path, clean=False)
+
+    assert checked == ["codex", "claude"]
+    assert not agent.calls
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "supports a different CLI" in report
 
 
 def test_research_packet_rejects_caller_id_in_captured_passage_before_voting(
@@ -452,6 +1132,16 @@ def test_research_packet_rejects_caller_id_in_captured_passage_before_voting(
 
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "reserved token 'opt-decimal' appears in 'research packet'" in report
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert trailer_field(report, "CLEANING") == "attested"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["research"]["failures"][0]["phase"] == "packet-validation"
+    assert record["research"]["packets"]
+    assert trailer_field(report, "RESEARCH-DIGEST") == record["research"]["digest"]
+    assert len(record["research"]["digest"]) == 64
+    assert record["snapshot"] == trailer_field(report, "SNAPSHOT")
+    assert len(record["refs_before"]) == 64
+    assert len(record["refs_after"]) == 64
     assert not [call for call in agent.calls if call["cwd"] is not None]
 
 
@@ -489,7 +1179,7 @@ def test_both_deciders_run_against_the_same_snapshot(repo: Path, tmp_path: Path)
     run(repo, agent, tmp_path)
     cwds = [c["cwd"] for c in agent.calls if c["cwd"] is not None]
     assert len(cwds) == 2
-    assert cwds[0] != cwds[1]  # separate worktrees
+    assert cwds[0] != cwds[1]  # separate inert materializations
     for wt in cwds:
         assert (Path(wt) / "app.py").exists() or True  # torn down after the call
 
@@ -569,6 +1259,59 @@ def test_labels_are_cleared_against_the_repository(repo: Path, tmp_path: Path, m
     report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path)
     assert trailer_field(report, "ARBITRATION") == "CONVERGED"
     assert planted["n"] >= 2  # it re-derived rather than proceeding
+
+
+def test_label_collision_history_survives_later_decider_failure(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    scans = 0
+    real_scan = evidence.scan_for_tokens
+
+    def scan(repo_, commit, tokens):
+        nonlocal scans
+        scans += 1
+        return [tokens[0]] if scans == 1 else real_scan(repo_, commit, tokens)
+
+    scripted = Agent(lambda e, r: "opt-float")
+
+    def failed_decider(**kwargs):
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            raise RuntimeError("decider unavailable after label recovery")
+        return scripted(**kwargs)
+
+    monkeypatch.setattr(ah.evidence, "scan_for_tokens", scan)
+    report = run(repo, failed_decider, tmp_path, clean=False)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert [item["status"] for item in record["label_attempt_records"]] == [
+        "collision", "selected",
+    ]
+    assert record["failed_round"]["deciders"]["claude"]["status"] == "failed"
+
+
+def test_later_label_scan_failure_keeps_completed_attempts(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    scans = 0
+
+    def scan(_repo, _commit, tokens):
+        nonlocal scans
+        scans += 1
+        if scans == 1:
+            return [tokens[0]]
+        raise RuntimeError("second label scan failed")
+
+    monkeypatch.setattr(ah.evidence, "scan_for_tokens", scan)
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "second label scan failed" in report
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    attempts = record["label_attempt_records"]
+    assert attempts[0]["status"] == "collision"
+    assert attempts[0]["repository_collisions"]
+    assert attempts[1]["status"] == "repository-scan-pending"
+    assert attempts[1]["repository_collisions"] is None
 
 
 def test_escaping_symlink_fails_before_spending(repo: Path, tmp_path: Path):
@@ -766,6 +1509,41 @@ def test_round_two_carries_bytes_and_no_model_prose(repo: Path, tmp_path: Path):
     assert round2[0].split("=== OPTIONS")[0] == round2[1].split("=== OPTIONS")[0]
 
 
+def test_later_carried_region_failure_keeps_earlier_bytes(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    (repo / "other.py").write_text("A = 1\nB = 2\nC = 3\nD = 4\nE = 5\n")
+    commit_all(repo, "other")
+    picks = {("codex", 1): "opt-float", ("claude", 1): "opt-decimal"}
+    agent = Agent(
+        lambda engine, rnd: picks.get((engine, rnd), "opt-float"),
+        extra={
+            ("codex", 1): {"decisive": "app.py:4"},
+            ("claude", 1): {"decisive": "other.py:3"},
+        },
+    )
+    real_read = ah.evidence.read_region
+    reads = 0
+
+    def read_region(repo_, region):
+        nonlocal reads
+        reads += 1
+        # Substantiation and union derivation resolve both anchors before the two
+        # round-two transport reads.
+        if reads == 6:
+            raise RuntimeError("second carried region failed")
+        return real_read(repo_, region)
+
+    monkeypatch.setattr(ah.evidence, "read_region", read_region)
+    report = run(repo, agent, tmp_path, clean=False)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert "second carried region failed" in report
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert len(record["carried_evidence"]) == 1
+    assert record["carried_evidence"][0]["body"]
+
+
 def test_round_two_carries_the_same_union_to_both(repo: Path, tmp_path: Path):
     """Round-3 FATAL: withholding a decider's own region stripped its decisive
     evidence from its own cold final vote."""
@@ -782,9 +1560,51 @@ def test_round_two_carries_the_same_union_to_both(repo: Path, tmp_path: Path):
         assert "app.py" in body and "other.py" in body
 
 
-def test_refs_moving_mid_run_fails(repo: Path, tmp_path: Path):
-    """A CONVERGED whose evidence base the recorded snapshot cannot describe is the
-    audit laundering this detection exists to prevent."""
+def test_dual_round_two_execution_failure_keeps_carried_and_phase_artifacts(
+    repo: Path, tmp_path: Path,
+):
+    (repo / "other.py").write_text("A = 1\nB = 2\nC = 3\nD = 4\nE = 5\n")
+    commit_all(repo, "other")
+    picks = {("codex", 1): "opt-float", ("claude", 1): "opt-decimal"}
+
+    class RoundTwoFails(Agent):
+        def __call__(self, **kwargs):
+            reply = super().__call__(**kwargs)
+            if kwargs["cwd"] is not None and "CODE REGIONS RELEVANT" in kwargs["body"]:
+                raise RuntimeError(f"{kwargs['engine_name']} unavailable in round two")
+            return reply
+
+    agent = RoundTwoFails(
+        lambda engine, rnd: picks.get((engine, rnd), "opt-decimal"),
+        extra={
+            ("codex", 1): {"decisive": "app.py:4"},
+            ("claude", 1): {"decisive": "other.py:3"},
+        },
+    )
+    report = run(repo, agent, tmp_path)
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "ROUNDS") == "1"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert sorted(record["failed_round"]["deciders"]) == ["claude", "codex"]
+    assert all(
+        item["attempts"][0]["body"]
+        and item["attempts"][0]["status"] == "provider-failed"
+        and item["attempts"][0]["invoked"] is True
+        for item in record["failed_round"]["deciders"].values()
+    )
+    assert {item["path"] for item in record["carried_evidence"]} == {
+        "app.py", "other.py",
+    }
+    assert [item["role"] for item in record["phase_attempts"]] == [
+        "cleaner", "attester",
+    ]
+
+
+def test_refs_moving_mid_run_is_reported_without_invalidating_snapshot(
+    repo: Path, tmp_path: Path,
+):
+    """The recorded snapshot still exactly describes both inert decider views."""
 
     class Moving(Agent):
         def __call__(self, **kw):
@@ -795,7 +1615,7 @@ def test_refs_moving_mid_run_fails(repo: Path, tmp_path: Path):
             return out
 
     report = run(repo, Moving(lambda e, r: "opt-float"), tmp_path)
-    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
     assert trailer_field(report, "REFS-MOVED") == "yes"
 
 
@@ -808,6 +1628,27 @@ def test_decider_failure_names_its_engine(repo: Path, tmp_path: Path):
 
     report = run(repo, Broken(lambda e, r: "opt-float"), tmp_path)
     assert "claude" in report and "cli exploded" in report
+
+
+def test_decider_workspace_setup_failure_opens_a_noninvoked_prompt_attempt(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    def fail_workspace(*args, **kwargs):
+        raise RuntimeError("materialization unavailable")
+
+    monkeypatch.setattr(ah.inert_tree, "evidence_workspace", fail_workspace)
+    agent = Agent(lambda e, r: "opt-float")
+    report = run(repo, agent, tmp_path)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert not [call for call in agent.calls if call["cwd"] is not None]
+    for failure in record["failed_round"]["deciders"].values():
+        [attempt] = failure["attempts"]
+        assert attempt["status"] == "setup-failed"
+        assert attempt["admitted"] is False
+        assert attempt["invoked"] is False
+        assert len(attempt["prompt_sha256"]) == 64
 
 
 def test_non_member_selected_fails_rather_than_mapping(repo: Path, tmp_path: Path):
@@ -829,6 +1670,9 @@ def test_cleaner_dropping_an_option_fails(repo: Path, tmp_path: Path):
                   cleaner=cleaner_reply({"opt-float": "Use a float."}))
     report = run(repo, agent, tmp_path)
     assert "changed the option id set" in report
+    assert trailer_field(report, "CLEANING") == "cleaner-rejected"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["cleaning"] == "cleaner-rejected"
 
 
 def test_cleaner_refusal_short_circuits(repo: Path, tmp_path: Path):
@@ -865,6 +1709,16 @@ def test_attestation_failure_retries_once_then_fails(repo: Path, tmp_path: Path)
     report = run(repo, agent, tmp_path)
     assert "failed attestation twice" in report
     assert len([c for c in agent.calls if "TEXT AUDITOR" in c["instructions"]]) == 2
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert trailer_field(report, "CLEANING") == "attestation-rejected"
+    assert trailer_field(report, "RESEARCH") == "not reached"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["snapshot"] == trailer_field(report, "SNAPSHOT")
+    assert record["cleaning"] == "attestation-rejected"
+    assert [attempt["role"] for attempt in record["phase_attempts"]] == [
+        "cleaner", "attester", "cleaner", "attester",
+    ]
+    assert record["phase_attempts"][-1]["rejection"]
 
 
 def test_stakes_advocacy_fails_to_the_caller(repo: Path, tmp_path: Path):
@@ -902,6 +1756,9 @@ def test_audit_failure_is_surfaced_not_swallowed(repo: Path, tmp_path: Path, mon
     report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path)
     assert trailer_field(report, "AUDIT").startswith("FAILED")
     assert trailer_field(report, "ARBITRATION") == "CONVERGED"  # verdict still returned
+    assert "## Audit fallback" in report
+    assert '"outcome":"CONVERGED"' in report
+    assert '"rounds"' in report
 
 
 def test_terminal_correction_audit_failure_is_surfaced(
@@ -922,6 +1779,171 @@ def test_terminal_correction_audit_failure_is_surfaced(
 
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert trailer_field(report, "AUDIT") == "FAILED could not write log"
+    assert "## Audit fallback" in report
+    assert '"failed_round"' in report
+    assert '"attempts"' in report
+
+
+def test_research_run_audit_bounds_and_hashes_raw_provider_envelopes():
+    oversized = "provider-envelope-" * 2_000
+    run_record = ah.ResearchRun(
+        "codex", "model", (), (), (), oversized, oversized, 2, (), (), (),
+    )
+    [record] = ah._research_run_records([run_record])
+    expected = hashlib.sha256(oversized.encode()).hexdigest()
+    assert record["discovery_raw_sha256"] == expected
+    assert record["binding_raw_sha256"] == expected
+    assert len(record["discovery_raw_excerpt"]) < len(oversized)
+    assert len(record["binding_raw_excerpt"]) < len(oversized)
+
+
+def test_run_agent_preserves_all_engine_failure_channels(monkeypatch, tmp_path: Path):
+    class FailedEngine:
+        def for_role(self, _role):
+            return self
+
+        def run(self, *args, **kwargs):
+            return eng.Review(
+                text="partial model text", session_ref="session", raw="raw envelope",
+                returncode=9, error=True, failure_detail="structured failure",
+                stderr="process stderr",
+            )
+
+    monkeypatch.setattr(ah.eng, "get_engine", lambda *a, **k: FailedEngine())
+    with pytest.raises(ah.EngineCallError) as caught:
+        ah._run_agent(
+            engine_name="codex", model="m", instructions="i", body="b",
+            cwd=tmp_path, effort="high", web_search=False, timeout=1,
+            text_only=False,
+        )
+    assert caught.value.record == {
+        "engine": "codex", "returncode": 9,
+        "failure_detail": "structured failure", "text": "partial model text",
+        "raw": "raw envelope", "stderr": "process stderr",
+    }
+
+
+def test_run_agent_marks_engine_setup_failure_before_provider_invocation(
+    monkeypatch, tmp_path: Path,
+):
+    lifecycle = {"status": "admitted", "admitted": True, "invoked": False}
+    monkeypatch.setattr(
+        ah.eng, "get_engine", lambda *a, **k: (_ for _ in ()).throw(
+            RuntimeError("engine setup unavailable")
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="engine setup unavailable"):
+        ah._run_agent(
+            engine_name="codex", model="m", instructions="i", body="b",
+            cwd=tmp_path, effort="high", web_search=False, timeout=1,
+            text_only=False, _attempt_lifecycle=lifecycle,
+        )
+
+    assert lifecycle == {
+        "status": "setup-failed", "admitted": True, "invoked": False,
+    }
+
+
+def test_research_role_setup_failure_is_prompt_bound_and_counts_zero_calls():
+    class SetupFails(FakeEngine):
+        def for_role(self, role: str):
+            raise RuntimeError("research role unavailable")
+
+    packet = ah.Packet("Choose.", "Local tool.", "", [], {"a": "A", "b": "B"},
+                       "skipped", "skipped")
+    with pytest.raises(ah.ResearchFailure) as caught:
+        ah._research_one(
+            engine=SetupFails("claude"), model="m", packet=packet,
+            options=("A", "B"), forbidden=("a", "b"), effort="medium",
+        )
+
+    record = caught.value.record
+    assert record["kind"] == "setup"
+    assert record["calls"] == 0
+    assert record["attempts"][0]["status"] == "setup-failed"
+    assert record["attempts"][0]["invoked"] is False
+    assert len(record["attempts"][0]["prompt_sha256"]) == 64
+
+
+def test_decider_audit_preserves_structured_engine_failure_channels(
+    repo: Path, tmp_path: Path,
+):
+    scripted = Agent(lambda e, r: "opt-float")
+    channels = {
+        "engine": "claude", "returncode": 9,
+        "failure_detail": "structured failure", "text": "partial text",
+        "raw": "raw envelope", "stderr": "process stderr",
+    }
+
+    def failed_agent(**kwargs):
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            raise ah.EngineCallError("claude failed", channels)
+        return scripted(**kwargs)
+
+    report = run(repo, failed_agent, tmp_path, clean=False)
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    attempt = record["failed_round"]["deciders"]["claude"]["attempts"][0]
+    assert attempt["failure"] == channels
+
+
+def test_aggregate_audit_fallback_is_bounded_and_schema_preserving(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(ah.logs, "write_log", lambda *a, **k: None)
+    huge = "reply-" * 20_000
+    failures = [
+        {"engine": f"lane-{index}", "attempts": [{"raw": huge}] * 40}
+        for index in range(40)
+    ]
+    record = {
+        "outcome": "FAILED",
+        "research": {
+            "failures": failures,
+            "runs": [{"engine": "completed-peer", "captures": [{"text": huge}]}],
+        },
+    }
+    audit, fallback = ah._write_bounded_audit(
+        tmp_path, record=record, timestamp="20260812T000000",
+    )
+    assert audit is None and fallback is not None
+    assert len(fallback) <= ah.MAX_AUDIT_FALLBACK_CHARS
+    parsed = json.loads(fallback)
+    assert parsed["research"]["runs"][0]["engine"] == "completed-peer"
+    assert parsed["research"]["failures"][-1]["_omitted_items"] > 0
+
+
+def test_audit_fallback_bounds_wide_nested_provider_mappings(
+    tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(ah.logs, "write_log", lambda *a, **k: None)
+    wide = {
+        f"field-{index}": {f"nested-{inner}": "x" * 10_000 for inner in range(100)}
+        for index in range(100)
+    }
+    audit, fallback = ah._write_bounded_audit(
+        tmp_path,
+        record={"outcome": "FAILED", "research": {"failures": [{"usage": wide}]}},
+        timestamp="20260812T000000",
+    )
+    assert audit is None and fallback is not None
+    assert len(fallback) <= ah.MAX_AUDIT_FALLBACK_CHARS
+    parsed = json.loads(fallback)
+    usage = parsed["research"]["failures"][0]["usage"]
+    assert usage["_omitted_fields"] > 0
+    assert len(usage["_omitted_fields_sha256"]) == 64
+
+
+def test_durable_audit_keeps_exact_large_packet_bytes(tmp_path: Path):
+    packet = "packet-byte-" * 2_000
+    audit, fallback = ah._write_bounded_audit(
+        tmp_path,
+        record={"outcome": "CONVERGED", "research": {"packets": packet}},
+        timestamp="20260812T000000",
+    )
+    assert audit is not None and fallback is None
+    record = json.loads(audit.read_text())
+    assert record["research"]["packets"] == packet
 
 
 def test_report_pairs_original_with_cleaned(repo: Path, tmp_path: Path):
@@ -996,6 +2018,12 @@ def test_cleaned_hint_reason_reaches_the_deciders_not_the_original(repo: Path):
             continue
         assert "the module under discussion" in call["body"]
         assert "APPROVED" not in call["body"]
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["cleaned"]["hints"] == [
+        {"path": "app.py", "reason": "the module under discussion"}
+    ]
+    assert len(record["cleaned"]["sha256"]) == 64
+    assert all(len(item["reply_sha256"]) == 64 for item in record["phase_attempts"])
 
 
 def test_attester_sees_the_real_original_hints(repo: Path, tmp_path: Path):
@@ -1067,16 +2095,20 @@ def test_engine_error_with_output_still_fails(monkeypatch):
 
         def run(self, *a, **k):
             return Review(
-                text="SELECTED: whatever\n", session_ref=None, raw="",
+                text="SELECTED: whatever\n", session_ref=None, raw="raw fallback",
                 returncode=1, error=True,
+                failure_detail="provider credit exhausted before completion",
             )
 
     monkeypatch.setattr(ah.eng, "get_engine", lambda name, text_only=False: Failing())
-    with pytest.raises(Exception, match="failed"):
+    with pytest.raises(Exception) as caught:
         ah._run_agent(
             engine_name="codex", model="m", instructions="i", body="b", cwd=None,
             effort="low", web_search=False, timeout=5, text_only=True,
         )
+    assert "provider credit exhausted before completion" in str(caught.value)
+    assert "SELECTED: whatever" not in str(caught.value)
+    assert "raw fallback" not in str(caught.value)
 
 
 def test_cleaner_model_override_is_honoured(repo: Path, tmp_path: Path):
@@ -1096,6 +2128,21 @@ def test_failure_still_returns_the_full_trailer(repo: Path, tmp_path: Path):
         assert trailer_field(report, field)
 
 
+def test_non_object_file_hint_fails_before_snapshot_with_complete_audit(
+    repo: Path, tmp_path: Path,
+):
+    report = run(
+        repo, Agent(lambda e, r: "opt-float"), tmp_path,
+        files=["app.py"],
+    )
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "SNAPSHOT") == "none"
+    assert "every file hint must be an object" in report
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["outcome"] == "FAILED"
+    assert record["raw_input"]["files"] == ["app.py"]
+
+
 def test_audit_holds_the_prompts_replies_and_carried_bytes(repo: Path, tmp_path: Path):
     """SNAPSHOT is provenance only, so if the log does not hold these the run is
     unauditable once gc reclaims the wrapper commit."""
@@ -1110,6 +2157,9 @@ def test_audit_holds_the_prompts_replies_and_carried_bytes(repo: Path, tmp_path:
     )
     report = run(repo, agent, tmp_path)
     record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert [item["role"] for item in record["phase_attempts"]] == [
+        "cleaner", "attester",
+    ]
     assert len(record["rounds"]) == 2
     for rnd in record["rounds"]:
         for engine, entry in rnd.items():
@@ -1183,7 +2233,127 @@ def test_a_commit_landing_during_the_snapshot_fails(repo: Path, tmp_path: Path, 
     report = run(repo, agent, tmp_path)
     assert trailer_field(report, "ARBITRATION") == "FAILED"
     assert "while the snapshot was being taken" in report
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert trailer_field(report, "CLEANING") == "not reached"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["snapshot"] == trailer_field(report, "SNAPSHOT")
+    assert len(record["refs_before"]) == 64
+    assert len(record["refs_after"]) == 64
     assert agent.calls == []  # nothing spent
+
+
+def test_second_setup_ref_failure_is_recorded_without_retry(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    real = evidence.refs_digest
+    calls = 0
+
+    def digest(repo_):
+        nonlocal calls
+        calls += 1
+        if calls == 2:
+            raise arb.ArbitrationError("setup boundary unavailable")
+        return real(repo_)
+
+    monkeypatch.setattr(ah.evidence, "refs_digest", digest)
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path, clean=False)
+    assert calls == 2
+    assert trailer_field(report, "REFS-MOVED") == "unavailable"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["refs_after"] is None
+    assert "setup boundary unavailable" in record["ref_provenance_error"]
+
+
+def test_unavailable_ref_provenance_during_setup_fails_before_snapshot(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    monkeypatch.setattr(
+        ah.evidence, "refs_digest",
+        lambda _repo: (_ for _ in ()).throw(arb.ArbitrationError("ref provenance unavailable")),
+    )
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path, clean=False)
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "SNAPSHOT") == "none"
+    assert trailer_field(report, "REFS-MOVED") == "unavailable"
+    assert "ref provenance unavailable" in report
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["refs_before"] is None
+    assert record["refs_after"] is None
+    assert record["refs_moved"] is None
+    assert "ref provenance unavailable" in record["ref_provenance_error"]
+
+
+def test_unavailable_final_ref_provenance_preserves_established_failure(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    real = evidence.refs_digest
+    calls = 0
+
+    def digest(repo_):
+        nonlocal calls
+        calls += 1
+        if calls >= 3:
+            raise arb.ArbitrationError("final ref provenance unavailable")
+        return real(repo_)
+
+    monkeypatch.setattr(ah.evidence, "refs_digest", digest)
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path, clean=False)
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "SNAPSHOT") != "none"
+    assert "final ref provenance unavailable" in report
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["refs_after"] is None
+    assert "final ref provenance unavailable" in record["ref_provenance_error"]
+    assert record["rounds"]
+
+
+def test_failed_final_ref_observation_is_not_retried(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    real = evidence.refs_digest
+    calls = 0
+
+    def digest(repo_):
+        nonlocal calls
+        calls += 1
+        if calls == 3:
+            raise arb.ArbitrationError("one-shot final provenance failure")
+        return real(repo_)
+
+    monkeypatch.setattr(ah.evidence, "refs_digest", digest)
+    report = run(repo, Agent(lambda e, r: "opt-float"), tmp_path, clean=False)
+    assert calls == 3
+    assert trailer_field(report, "REFS-MOVED") == "unavailable"
+    record = json.loads(Path(trailer_field(report, "AUDIT")).read_text())
+    assert record["refs_after"] is None
+    assert "one-shot final provenance failure" in record["ref_provenance_error"]
+
+
+def test_other_failure_plus_unavailable_final_refs_renders_unavailable(
+    repo: Path, tmp_path: Path, monkeypatch,
+):
+    real = evidence.refs_digest
+    calls = 0
+
+    def digest(repo_):
+        nonlocal calls
+        calls += 1
+        if calls >= 3:
+            raise arb.ArbitrationError("final refs unreadable")
+        return real(repo_)
+
+    def failed_decider(**kwargs):
+        if kwargs["cwd"] is not None and kwargs["engine_name"] == "claude":
+            raise RuntimeError("provider unavailable")
+        return scripted(**kwargs)
+
+    scripted = Agent(lambda e, r: "opt-float")
+    monkeypatch.setattr(ah.evidence, "refs_digest", digest)
+    report = run(repo, failed_decider, tmp_path, clean=False)
+    assert trailer_field(report, "ARBITRATION") == "FAILED"
+    assert trailer_field(report, "REFS-MOVED") == "unavailable"
+    assert "provider unavailable" in report
+    assert "final ref provenance unavailable" in report
 
 
 def test_retain_snapshot_ref_is_not_mistaken_for_operator_movement(repo: Path, tmp_path: Path):
@@ -1216,8 +2386,8 @@ def test_retain_ref_is_created_only_after_the_final_check(repo: Path, tmp_path: 
     assert "refs/paranoia/arbitrate/" in git(["for-each-ref", "--format=%(refname)"], repo)
 
 
-def test_retain_ref_is_not_created_when_refs_moved(repo: Path, tmp_path: Path):
-    """A failed run leaves no trace in the audited repo."""
+def test_refs_moving_after_snapshot_is_provenance_only(repo: Path, tmp_path: Path):
+    """Deciders see inert snapshot materializations, never the moving live refs."""
 
     class Moving(Agent):
         def __call__(self, **kw):
@@ -1228,8 +2398,11 @@ def test_retain_ref_is_not_created_when_refs_moved(repo: Path, tmp_path: Path):
             return out
 
     report = run(repo, Moving(lambda e, r: "opt-float"), tmp_path, retain_snapshot=True)
-    assert trailer_field(report, "ARBITRATION") == "FAILED"
-    assert "refs/paranoia" not in git(["for-each-ref", "--format=%(refname)"], repo)
+    assert trailer_field(report, "ARBITRATION") == "CONVERGED"
+    assert trailer_field(report, "REFS-MOVED") == "yes"
+    assert "refs/paranoia/arbitrate/" in git(
+        ["for-each-ref", "--format=%(refname)"], repo
+    )
 
 
 @pytest.mark.parametrize(

--- a/tests/test_arbitration.py
+++ b/tests/test_arbitration.py
@@ -679,9 +679,8 @@ def test_blocked_beats_unsubstantiated():
     assert got.outcome == arb.BLOCKED
 
 
-def test_refs_moved_and_failure_fail():
+def test_execution_failure_and_missing_votes_fail():
     votes = [vote("codex", "opt-a"), vote("claude", "opt-a")]
-    assert arb.compute_outcome(votes, substantiated=SUB, refs_moved=True).outcome == arb.FAILED
     assert arb.compute_outcome(votes, substantiated=SUB, failure="boom").outcome == arb.FAILED
     assert arb.compute_outcome([], substantiated={}).outcome == arb.FAILED
 

--- a/tests/test_arbitration_research.py
+++ b/tests/test_arbitration_research.py
@@ -67,6 +67,18 @@ def test_packet_union_is_deterministic_and_governing():
     assert ar.digest(packets) == ar.digest(tuple(reversed(packets)))
 
 
+def test_packet_digest_is_total_on_model_controlled_surrogates():
+    claims = ar.parse_discovery(discovery())
+    capture = captured(claims[0])
+    bound = es.BoundSource(
+        claims[0].candidate, capture, "section-\udcff",
+        "The API retries twice.",
+    )
+    packets = ar.packets([(claims, (bound,))])
+    assert "\udcff" in ar.render(packets)
+    assert len(ar.digest(packets)) == 64
+
+
 def test_discovery_prompt_contains_no_pipe_delimited_pseudo_enum():
     assert not re.search(
         r'"(?:kind|source_kind|relation)":"[^"]*\|[^"]*"',
@@ -102,3 +114,32 @@ def test_a_fenced_discovery_payload_parses_too():
     marker, body = bare.split("\n", 1)
     assert (ar.parse_discovery(f"{marker}\n```json\n{body}\n```")
             == ar.parse_discovery(bare))
+
+
+def test_binding_accepts_only_a_missing_outer_object_close():
+    claims = ar.parse_discovery(discovery())
+    captures = [captured(claims[0])]
+    body = json.dumps({"bindings": [{
+        "claim_index": 0, "usable": True, "location": "API behavior",
+        "passage": "The API retries twice.",
+    }]})
+    complete = ar.parse_binding(f"{ar.BINDING_MARKER}\n{body}", claims, captures)
+
+    assert ar.parse_binding(
+        f"{ar.BINDING_MARKER}\n{body[:-1]}", claims, captures,
+    ) == complete
+
+
+@pytest.mark.parametrize(
+    "broken",
+    [
+        '{"bindings":[{"claim_index":0 "usable":false}]}',
+        '{"bindings":[{"claim_index":0,"usable":false]',
+        '{"bindings":[{"claim_index":0,"usable":"unterminated}]}',
+    ],
+)
+def test_binding_does_not_guess_at_internal_or_multi_character_json_repairs(broken):
+    claims = ar.parse_discovery(discovery())
+    captures = [captured(claims[0])]
+    with pytest.raises(ar.ResearchError, match="invalid JSON"):
+        ar.parse_binding(f"{ar.BINDING_MARKER}\n{broken}", claims, captures)

--- a/tests/test_converge.py
+++ b/tests/test_converge.py
@@ -98,10 +98,19 @@ class TestConvergeBranch:
         class FailEngine(FakeEngine):
             def run(self, prompt, cwd, model, effort, web_search, **kw):
                 self.calls.append({"prompt": prompt, "cwd": Path(cwd)})
-                return Review(text="boom", session_ref=None, raw="", returncode=1, error=True)
+                return Review(
+                    text="boom", session_ref=None, raw="provider stdout",
+                    returncode=1, error=True, failure_detail="structured failure",
+                    stderr="process stderr",
+                )
 
         fe = FailEngine()
         out = handlers.critique_branch(_args(repo, converge=True), engine=fe, log_dir=tmp_path)
         assert "REVIEW FAILED" in out
         rec = json.loads(next(tmp_path.glob("*.json")).read_text())
         assert rec["error"] is True and rec["returncode"] == 1
+        assert rec["raw_excerpt"] == "provider stdout"
+        assert rec["failure_detail_excerpt"] == "structured failure"
+        assert rec["stderr_excerpt"] == "process stderr"
+        assert len({rec["raw_sha256"], rec["failure_detail_sha256"],
+                    rec["stderr_sha256"]}) == 3

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -254,6 +254,24 @@ class TestRunWithInjectedRunner:
         assert review.error is True
         assert review.text == "partial reviewer output"
         assert review.failure_detail == "terminal process diagnostic\n"
+        assert review.stderr == "terminal process diagnostic\n"
+
+    def test_structured_failure_detail_is_not_overwritten_by_stderr(self) -> None:
+        e = engines.get_engine("codex")
+        payload = (
+            '{"type":"turn.failed","error":{"message":"structured provider failure"}}\n'
+        )
+
+        def fake_runner(argv, stdin_text, cwd, timeout):
+            return RunResult(returncode=9, stdout=payload, stderr="process stderr\n")
+
+        review = e.run(
+            prompt="x", cwd=Path("/repo"), model="m", effort="high",
+            web_search=False, runner=fake_runner,
+        )
+        assert review.error is True
+        assert review.failure_detail == "structured provider failure"
+        assert review.stderr == "process stderr\n"
 
     def test_resume_uses_resume_argv(self) -> None:
         e = engines.get_engine("claude")

--- a/tests/test_evidence.py
+++ b/tests/test_evidence.py
@@ -3,6 +3,7 @@ clearance, and citation reads. Each case is a way the recorded snapshot could
 fail to describe what the deciders actually read."""
 
 from pathlib import Path
+import subprocess
 
 import pytest
 
@@ -114,6 +115,22 @@ def test_refs_digest_is_stable_across_a_file_edit(repo: Path):
     before = evidence.refs_digest(repo)
     (repo / "app.py").write_text("changed\n")
     assert evidence.refs_digest(repo) == before
+
+
+@pytest.mark.parametrize("failing_command", ["for-each-ref", "reflog"])
+def test_refs_digest_fails_closed_when_a_git_observation_fails(
+    repo: Path, monkeypatch, failing_command: str,
+):
+    real = evidence.inert_git.invoke
+
+    def invoke(cwd, args, **kwargs):
+        if args[0] == failing_command:
+            return subprocess.CompletedProcess(args, 1, b"", b"observation unavailable")
+        return real(cwd, args, **kwargs)
+
+    monkeypatch.setattr(evidence.inert_git, "invoke", invoke)
+    with pytest.raises(ArbitrationError, match="ref provenance unavailable"):
+        evidence.refs_digest(repo)
 
 
 def test_advance_and_restore_is_still_detected(repo: Path):

--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -1,10 +1,57 @@
 from email.message import Message
+import threading
+import time
+
+import pytest
 
 from paranoia_local import external_sources as es
 
 
 def candidate(url="https://docs.example.com/page", kind="primary"):
     return es.CandidateSource(url, "Docs", "Example", kind, "Example defines it", "supports_claim")
+
+
+def test_parallel_capture_failure_retains_completed_sibling():
+    first = candidate("https://docs.example.com/first")
+    second = candidate("https://docs.example.com/second")
+    completed = threading.Event()
+
+    def capture_one(item):
+        if item is second:
+            assert completed.wait(2)
+            raise RuntimeError("second capture exploded")
+        result = es.Capture(
+            item, item.url, 200, "text/html", "a" * 64, "b" * 64, "captured text",
+        )
+        completed.set()
+        return result
+
+    with pytest.raises(es.CaptureGroupError) as caught:
+        es.capture_all([first, second], capture_one=capture_one, workers=2)
+    assert [item.candidate.url for item in caught.value.completed] == [first.url]
+
+
+def test_parallel_capture_failure_waits_for_running_sibling_record():
+    first = candidate("https://docs.example.com/first")
+    second = candidate("https://docs.example.com/second")
+    sibling_started = threading.Event()
+    failed = threading.Event()
+
+    def capture_one(item):
+        if item is first:
+            assert sibling_started.wait(2)
+            failed.set()
+            raise RuntimeError("first capture exploded")
+        sibling_started.set()
+        assert failed.wait(2)
+        time.sleep(0.05)
+        return es.Capture(
+            item, item.url, 200, "text/html", "a" * 64, "b" * 64, "captured text",
+        )
+
+    with pytest.raises(es.CaptureGroupError) as caught:
+        es.capture_all([first, second], capture_one=capture_one, workers=2)
+    assert [item.candidate.url for item in caught.value.completed] == [second.url]
 
 
 def test_known_ugc_is_mechanically_demoted():

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -116,11 +116,13 @@ elif printf '%s' "$prompt" | grep -q 'You are a TEXT AUDITOR'; then
   body=$(printf 'FIDELITY: decision PRESERVED; opt-a PRESERVED; opt-b PRESERVED\nNEUTRALITY: PASS\nSTAKES-ADVOCACY: NONE')
 else
   label=$(printf '%s' "$prompt" | grep -o 'OPTION-[0-9a-f]\{16\}' | head -1)
-  body=$(printf 'Reasoning.\n\nSELECTED: %s\nSELECTED-RISK: NONE\nAUTHORITY: technical\nNEW-OPTION: NONE\nCONSTRAINT: A fact.\nDECISIVE-CITATION: app.py:4\nCITATIONS: NONE' "$label")
+  body=$(printf 'Reasoning.\n\nSELECTED: %s\nSELECTED-RISK: NONE\nAUTHORITY: technical\nNEW-OPTION: NONE\nCONSTRAINT: A fact.\nPUBLISHER-AUTHORITY: NO — repository citation\nPASSAGE-ENTAILMENT: NO — repository citation\nDECISION-RELEVANCE: YES — directly decides the option\nDECISIVE-CITATION: app.py:4\nCITATIONS: NONE' "$label")
 fi
 """
 
-FAKE_CODEX_ARB = "#!/bin/bash\n" + _ARB_SCRIPT + """
+FAKE_CODEX_ARB = """#!/bin/bash
+if [ "$1" = "--version" ]; then echo "codex-cli 0.144.6"; exit 0; fi
+""" + _ARB_SCRIPT + """
 python3 -c "
 import json,sys
 print(json.dumps({'type':'thread.started','thread_id':'t'}))
@@ -129,7 +131,9 @@ print(json.dumps({'type':'turn.completed','usage':{}}))
 " "$body"
 """
 
-FAKE_CLAUDE_ARB = "#!/bin/bash\n" + _ARB_SCRIPT + """
+FAKE_CLAUDE_ARB = """#!/bin/bash
+if [ "$1" = "--version" ]; then echo "claude 2.1.197"; exit 0; fi
+""" + _ARB_SCRIPT + """
 python3 -c "
 import json,sys
 print(json.dumps({'type':'result','subtype':'success','is_error':False,'result':sys.argv[1],'session_id':'s'}))

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -934,6 +934,35 @@ def _repo(tmp_path: Path) -> Path:
 
 
 class TestHandlerFlow:
+    @pytest.mark.parametrize(("returncode", "diagnostic"), [
+        (124, "timed out after 3600s"),
+        (127, "executable not found: codex"),
+    ])
+    def test_outer_claim_retry_persists_all_failure_channels(
+        self, tmp_path: Path, returncode: int, diagnostic: str,
+    ) -> None:
+        failed = Review(
+            text="partial", session_ref="session", raw="retry stdout",
+            returncode=returncode, error=True,
+            failure_detail="structured provider failure", stderr=diagnostic,
+        )
+        state, status = handlers._verify_plan_claims(
+            PLAN, pc.empty_state(), lineage_id="outer-retry", round_no=1,
+            stakes="trusted local tool",
+            engine=ScriptedEngine("not a claim audit", failed),
+            repo=_repo(tmp_path), model="m", effort="high", plan_repo_path=None,
+            on_progress=None,
+        )
+
+        assert status == "retry-failed"
+        debt = state["debt"]
+        assert debt["returncode"] == returncode
+        assert debt["rejected_excerpt"] == "retry stdout"
+        assert debt["failure_detail"] == "structured provider failure"
+        assert debt["stderr"] == diagnostic
+        assert len({debt["raw_sha256"], debt["failure_detail_sha256"],
+                    debt["stderr_sha256"]}) == 3
+
     def test_invalid_disposition_scalar_gets_one_correction_and_recovers(
         self, tmp_path: Path,
     ) -> None:
@@ -1555,6 +1584,118 @@ def test_indexed_plan_binding_rejects_an_omitted_source(tmp_path: Path) -> None:
             adapter._parse_indexed_binding(omitted, batch, captures)
     finally:
         adapter.close()
+
+
+@pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [
+    (False, 124, "timed out after 420s"),
+    (True, 127, "executable not found: codex"),
+])
+def test_binding_engine_failure_preserves_structured_diagnostics(
+    tmp_path: Path, correction: bool, returncode: int, diagnostic: str,
+) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    capture = external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        item["quote"],
+    )
+    failed = Review(
+        text="", session_ref="session" if correction else None, raw="",
+        returncode=returncode, error=True, failure_detail=diagnostic,
+        stderr=diagnostic,
+    )
+    replies = ([Review("invalid", "session", "provider stdout"), failed]
+               if correction else [failed])
+
+    class BindingEngine:
+        def resume(self, *args, **kwargs):
+            return replies.pop(0)
+
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = BindingEngine()
+    try:
+        with pytest.raises(pc.AuditError) as caught:
+            adapter._bind_indexed(
+                "session", audit, {(0, 0): capture}, "m", "high", {"timeout": 300},
+            )
+        debt = caught.value.debt(1)
+        assert debt["returncode"] == returncode
+        assert debt["rejected_excerpt"] == ""
+        assert debt["failure_detail"] == diagnostic
+        assert debt["stderr"] == diagnostic
+        assert debt["failure_detail_sha256"] != debt["raw_sha256"]
+        assert debt["stderr_sha256"] != debt["raw_sha256"]
+    finally:
+        adapter.close()
+
+
+@pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [
+    (False, 124, "timed out after 420s"),
+    (True, 127, "executable not found: codex"),
+])
+def test_outer_claim_verification_persists_binding_failure_channels(
+    tmp_path: Path, monkeypatch, correction: bool, returncode: int, diagnostic: str,
+) -> None:
+    source = _source()
+    candidate = external_sources.CandidateSource(
+        source["url"], source["title"], source["publisher"], source["source_kind"],
+        source["authority_basis"], source["relation"],
+    )
+    capture = external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        source["quote"],
+    )
+    monkeypatch.setattr(
+        handlers.external_sources, "capture_all", lambda candidates, **kwargs: [capture],
+    )
+    failed = Review(
+        text="", session_ref="binding-session" if correction else None, raw="",
+        returncode=returncode, error=True, failure_detail=diagnostic, stderr=diagnostic,
+    )
+    binding = ([Review("invalid", "binding-session", "invalid binding"), failed]
+               if correction else [failed])
+
+    class FailureEngine:
+        name = "codex"
+        default_model = "test"
+        native_web = True
+
+        def __init__(self, role="default"):
+            self.role = role
+
+        def for_role(self, role):
+            return FailureEngine(role)
+
+        def run(self, *args, **kwargs):
+            assert self.role == "evidence-discovery"
+            text = _audit(_claim())
+            return Review(text, "discovery-session", text)
+
+        def resume(self, *args, **kwargs):
+            assert self.role == "evidence-binding"
+            return binding.pop(0)
+
+    monkeypatch.setattr(handlers.eng, "CodexEngine", FailureEngine)
+    state, status = handlers._verify_plan_claims(
+        PLAN, pc.empty_state(), lineage_id="binding-failure", round_no=1,
+        stakes="trusted local tool", engine=FailureEngine(), repo=_repo(tmp_path),
+        model="m", effort="high", plan_repo_path=None, on_progress=None,
+    )
+
+    assert status == "failed"
+    debt = state["debt"]
+    assert debt["returncode"] == returncode
+    assert debt["rejected_excerpt"] == ""
+    assert debt["failure_detail"] == diagnostic
+    assert debt["stderr"] == diagnostic
+    assert debt["failure_detail_sha256"] != debt["raw_sha256"]
+    assert debt["stderr_sha256"] != debt["raw_sha256"]
 
 
 def test_plan_binding_demotes_a_redirect_to_ugc(tmp_path: Path) -> None:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -802,10 +802,12 @@ def test_staged_timeout_preserves_kind_message_state_and_trailer(tmp_path):
         closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
     )
     closure.release()
-    assert closure.lineage.review_state["staged_failure"] == {
+    failure = closure.lineage.review_state["staged_failure"]
+    assert {key: failure[key] for key in ("role", "kind", "message")} == {
         "role":"consolidation", "kind":"timeout",
         "message":"[paranoia-local error] timed out after 1800s",
     }
+    assert failure["engine_failure"]["returncode"] == 124
     assert "STRUCTURAL-FAILURE: role=consolidation kind=timeout" in trailer
     assert "CONVERGENCE: BLOCKED — staged timeout failure did not settle." in trailer
 
@@ -840,9 +842,11 @@ def test_staged_cancellation_preserves_exact_kind_and_message(tmp_path, returnco
         closure, stakes="s", snapshot="p", error=caught.value, mode=cc.PLAN_MODE,
     )
     closure.release()
-    assert closure.lineage.review_state["staged_failure"] == {
+    failure = closure.lineage.review_state["staged_failure"]
+    assert {key: failure[key] for key in ("role", "kind", "message")} == {
         "role":"coverage", "kind":"cancellation", "message":message,
     }
+    assert failure["engine_failure"]["returncode"] == returncode
     assert f"STRUCTURAL-ERROR: {message}" in trailer
     assert "CONVERGENCE: BLOCKED — staged cancellation failure did not settle." in trailer
 
@@ -1094,10 +1098,48 @@ def test_empty_or_whitespace_stderr_process_exit_reaches_staged_trailer(
         closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
     )
     closure.release()
-    assert closure.lineage.review_state["staged_failure"] == {
+    failure = closure.lineage.review_state["staged_failure"]
+    assert {key: failure[key] for key in ("role", "kind", "message")} == {
         "role":"consolidation", "kind":"execution", "message":expected_detail,
     }
+    projection = failure["engine_failure"]
+    assert projection["returncode"] == 9
+    assert projection["raw_excerpt"] == stdout
+    assert projection["failure_detail_excerpt"] == expected_detail
+    assert projection["stderr_excerpt"] == stderr
     assert f"STRUCTURAL-ERROR: {expected_detail}" in trailer
+
+
+@pytest.mark.parametrize(("returncode", "detail", "stderr", "kind"), [
+    (124, "provider timed out", "timed out after 420s", "timeout"),
+    (127, "provider unavailable", "executable not found: codex", "unavailable"),
+])
+def test_staged_failure_persists_all_engine_channels(
+    tmp_path, returncode, detail, stderr, kind,
+):
+    review = Review(
+        text="partial", session_ref=None, raw="provider stdout", returncode=returncode,
+        error=True, failure_detail=detail, stderr=stderr,
+    )
+    error = handlers._engine_failure_error(review, role="consolidation")
+    closure = handlers._PlanClassClosure(
+        f"engine-channels-{returncode}", round_no=1, state_root=tmp_path, stamp="T",
+    )
+    closure.prepare()
+    handlers._settle_staged_failure(
+        closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
+    )
+    closure.release()
+
+    failure = closure.lineage.review_state["staged_failure"]
+    assert failure["kind"] == kind
+    projection = failure["engine_failure"]
+    assert projection["returncode"] == returncode
+    assert projection["raw_excerpt"] == "provider stdout"
+    assert projection["failure_detail_excerpt"] == detail
+    assert projection["stderr_excerpt"] == stderr
+    assert len({projection["raw_sha256"], projection["failure_detail_sha256"],
+                projection["stderr_sha256"]}) == 3
 
 
 def test_oversized_class_preflight_persists_exact_validation_identity(tmp_path):


### PR DESCRIPTION
## Summary
- retain unanimous arbitration verdicts when refs move after immutable snapshot setup
- bound and diagnose research JSON correction paths, including narrow terminal-brace recovery
- preserve exact attempt lifecycle and structured provider diagnostics through durable consumers
- add executable reconciliation for the signed-in arbitration acceptance artifact
- retain correction-settlement diagnostics for all three payload types already present on current main

## Verification
- signed-in Codex + Claude end-to-end arbitration: CONVERGED, 7 captured packets, 10 provider calls
- full suite: 872 passed
- focused acceptance validator and failure-projection tests
- paranoia CODE convergence: NOT-BLOCKED, 0 open classes, 0 structural debt