### PR TITLE
Grant Claude WebSearch to evidence discovery

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,6 +116,10 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   attestation. Claude `WebFetch` must not be enabled in plan verification or arbitration
   research. No placeholder endpoint, optional plugin, or caller adapter may stand in for this
   primary path.
+  Claude discovery must both expose and allow only `WebSearch`; repository evidence may expose
+  and allow only `Read,Grep,Glob`; binding and text evidence roles must remain tool-less. A
+  permission denial of a tool required by the active evidence role is an execution failure, not
+  an unverified-claim result.
   Treat the final redirect URL as governing UGC/self-source eligibility and persist capture
   digests plus cold authority/entailment decisions before support may freeze.
   Validate retained inventory before capture; attest replacement wording as its own exact

--- a/README.md
+++ b/README.md
@@ -662,7 +662,11 @@ What it does, in order:
 
 `research: true` requires `web_search: true`; the incompatible combination is rejected before
 any model call. `web_search` authorizes only the isolated discovery roles. Binding and every
-decider call run with web disabled, and only server-captured packets can affect substantiation.
+decider call run with web disabled, and other evidence roles retain their narrower tool surface.
+Claude evidence roles use matching
+availability and permission allowlists on fresh and resumed calls; denial of a tool required by
+the active role is a visible provider-capability failure, never an empty-search success. Binding
+and text roles use explicit empty allowlists. Only server-captured packets can affect substantiation.
 The signed-in end-to-end record, including exact versions, packet digest, source references,
 plan-claim closure, repository-only closure, and defects found by the first real runs, is
 [`docs/evidence_capture_acceptance_2026-08-10.json`](docs/evidence_capture_acceptance_2026-08-10.json).

--- a/docs/claude_websearch_grant_acceptance_2026-08-13.md
+++ b/docs/claude_websearch_grant_acceptance_2026-08-13.md
@@ -1,0 +1,30 @@
+# Claude evidence-role permission acceptance — 2026-08-13
+
+Frozen operating model: one trusted local operator and trusted OS; repository,
+plan, fetched pages, and model output are untrusted data; Claude discovery may
+use only native `WebSearch`, repository evidence only `Read,Grep,Glob`, and
+binding/text roles no tools. Hostile local races, compromised OS, multitenancy,
+and custom transport hardening are excluded. Silent search denial or false
+verification is high impact; an explicit recoverable block is acceptable.
+
+Environment: Claude Code 2.1.197, `claude-haiku-4-5-20251001`.
+
+- Discovery used matching `--tools WebSearch --allowedTools WebSearch` under
+  `--safe-mode --setting-sources "" --strict-mcp-config`. It completed one real
+  WebSearch (`modelUsage.webSearchRequests: 1`) with no permission denials in
+  16.019 seconds, costing $0.0376802.
+- The tool-less profile used matching empty availability and permission lists.
+  An explicit WebSearch request executed zero searches; the unavailable tool
+  could only appear as model text. It completed in 2.157 seconds, costing
+  $0.004629.
+- Provider calls: 2. Combined provider duration: 18.176 seconds. Combined cost:
+  $0.0423092.
+- Tests: 34 focused engine/instrumentation tests passed; the full suite passed
+  950 tests in 92.62 seconds.
+- Production diff: one file, `src/paranoia_local/engines.py`, +18/-3. It is the
+  only touched production module and contains 544 lines after the change.
+
+The discovery result proves the required permission grant works on the pinned
+CLI. The tool-less result proves the empty role surface remains unavailable; it
+does not rely on a permission-denial event because an unavailable tool is never
+offered to Claude Code.

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -388,10 +388,14 @@ class ClaudeEngine(Engine):
         return ""
 
     def _evidence_argv(self, model: str, effort: str) -> list[str]:
+        tools = self._evidence_tools()
         return [
             "--output-format", "json", "--model", model, "--effort", effort,
             "--safe-mode", "--setting-sources", "", "--strict-mcp-config",
-            "--tools", self._evidence_tools(),
+            # `--tools` narrows availability; it does not grant permission in
+            # headless `-p` mode. Keep both boundaries identical so discovery can
+            # actually use WebSearch while binding/text remain genuinely tool-less.
+            "--tools", tools, "--allowedTools", tools,
         ]
 
     def _allowed(self, web_search: bool) -> str:
@@ -456,14 +460,25 @@ class ClaudeEngine(Engine):
             usage = {"tokens": tokens, "cost_usd": cost}
         text = str(data.get("result", ""))
         is_error = bool(data.get("is_error", False))
+        denied = {
+            item.get("tool_name")
+            for item in data.get("permission_denials", [])
+            if isinstance(item, dict) and isinstance(item.get("tool_name"), str)
+        } if isinstance(data.get("permission_denials", []), list) else set()
+        required = set(filter(None, self._evidence_tools().split(",")))
+        denied_required = sorted(required & denied)
+        permission_failure = (
+            "required evidence tool permission denied: " + ", ".join(denied_required)
+            if self.role in EVIDENCE_ROLES and denied_required else None
+        )
         return Review(
             text=text,
             session_ref=data.get("session_id"),
             raw=stdout,
-            error=is_error,
+            error=is_error or permission_failure is not None,
             usage=usage,
             duration_ms=data.get("duration_ms"),
-            failure_detail=text if is_error else None,
+            failure_detail=text if is_error else permission_failure,
         )
 
 

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 import pytest
@@ -177,16 +178,54 @@ class TestClaudeArgv:
         assert "sess-xyz" in argv
 
     def test_evidence_role_tool_sets_repeat_on_resume(self) -> None:
+        expected = {
+            engines.ROLE_DISCOVERY: "WebSearch",
+            engines.ROLE_REPOSITORY: "Read,Grep,Glob",
+            engines.ROLE_BINDING: "",
+            engines.ROLE_TEXT: "",
+        }
+        for role, tools in expected.items():
+            engine = engines.get_engine("claude").for_role(role)
+            calls = (
+                engine.build_argv(Path("/launch"), "m", "high", role == engines.ROLE_DISCOVERY),
+                engine.build_resume_argv(
+                    "s", Path("/launch"), "m", "high", role == engines.ROLE_DISCOVERY,
+                ),
+            )
+            for argv in calls:
+                assert argv[argv.index("--tools") + 1] == tools
+                assert argv[argv.index("--allowedTools") + 1] == tools
+                assert "--safe-mode" in argv and "--strict-mcp-config" in argv
+        discovery_tools = expected[engines.ROLE_DISCOVERY]
+        assert "WebFetch" not in discovery_tools
+        assert "Read" not in discovery_tools
+
+    def test_required_evidence_tool_denial_is_a_capability_failure(self) -> None:
         discovery = engines.get_engine("claude").for_role(engines.ROLE_DISCOVERY)
-        fresh = discovery.build_argv(Path("/launch"), "m", "high", True)
-        assert fresh[fresh.index("--tools") + 1] == "WebSearch"
-        assert "--safe-mode" in fresh and "--strict-mcp-config" in fresh
+        payload = json.dumps({
+            "type": "result", "subtype": "success", "is_error": False,
+            "result": "fallback claims", "session_id": "s",
+            "permission_denials": [{"tool_name": "WebSearch"}],
+        })
+
+        review = discovery.parse_output(payload)
+
+        assert review.error is True
+        assert review.text == "fallback claims"
+        assert review.failure_detail == "required evidence tool permission denied: WebSearch"
+
+    def test_tool_less_role_denial_remains_expected_enforcement(self) -> None:
         binding = engines.get_engine("claude").for_role(engines.ROLE_BINDING)
-        resumed = binding.build_resume_argv("s", Path("/launch"), "m", "high", False)
-        assert resumed[resumed.index("--tools") + 1] == ""
-        repository = engines.get_engine("claude").for_role(engines.ROLE_REPOSITORY)
-        argv = repository.build_argv(Path("/launch"), "m", "high", False)
-        assert argv[argv.index("--tools") + 1] == "Read,Grep,Glob"
+        payload = json.dumps({
+            "type": "result", "subtype": "success", "is_error": False,
+            "result": "bound without tools", "session_id": "s",
+            "permission_denials": [{"tool_name": "WebSearch"}],
+        })
+
+        review = binding.parse_output(payload)
+
+        assert review.error is False
+        assert review.failure_detail is None
 
     def test_parse_output_extracts_result_and_session(self) -> None:
         e = engines.get_engine("claude")


### PR DESCRIPTION
## Summary
- grant Claude evidence discovery both advertised and allowed WebSearch capability
- keep repository-evidence roles restricted to Read/Grep/Glob and binding/text roles tool-less
- surface required evidence-tool permission denials as explicit execution failures
- document and test the exact fresh/resume role matrix

## Verification
- 950 tests passed in 92.62s
- focused engine/instrumentation suite: 34 passed
- live Claude discovery probe made one WebSearch request with no permission denial
- tool-less control made zero WebSearch requests
- tightly staked Codex CODE review: CONVERGENCE: NOT-BLOCKED; zero structural debt/classes