### PR TITLE
Preserve partial indexed claim bindings

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,6 +156,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   Treat an omitted expected indexed binding row as unusable for that exact source and demote only
   the affected claim when it has no other qualifying evidence. Preserve omission as a distinct
   conservative outcome from an explicit `usable:false` row so durable provenance remains truthful.
+  For an explicit unusable row, retain a server-owned capture failure reason when capture failed;
+  use model-rejection provenance only when the server capture was actually available.
   Non-integer, unknown, or duplicate identities, malformed rows, unavailable captures claimed as
   usable, and passage mismatches still reject through the bounded correction path.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   use model-rejection provenance only when the server capture was actually available.
   Non-integer, unknown, or duplicate identities, malformed rows, unavailable captures claimed as
   usable, and passage mismatches still reject through the bounded correction path.
+  Apply the same exact-integer identity rule before constructing cold-attestation keys; no JSON
+  scalar or container alias may bind authority or entailment to another claim or evidence row.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.
   Captured binding failure debt must retain raw provider stdout, structured failure detail, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -153,6 +153,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   Validate retained inventory before capture; attest replacement wording as its own exact
   proposition; and enforce aggregate capture/binding budgets so multiplicative per-claim maxima
   become visible debt rather than an hours-long run.
+  Treat an omitted expected indexed binding row as unusable for that exact source and demote only
+  the affected claim when it has no other qualifying evidence. Unknown or duplicate identities,
+  malformed rows, unavailable captures claimed as usable, and passage mismatches still reject.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.
   Captured binding failure debt must retain raw provider stdout, structured failure detail, and

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   proposition; and enforce aggregate capture/binding budgets so multiplicative per-claim maxima
   become visible debt rather than an hours-long run.
   Treat an omitted expected indexed binding row as unusable for that exact source and demote only
-  the affected claim when it has no other qualifying evidence. Record neutral omission provenance;
-  non-integer, unknown, or duplicate identities, malformed rows, unavailable captures claimed as
+  the affected claim when it has no other qualifying evidence. Preserve omission as a distinct
+  conservative outcome from an explicit `usable:false` row so durable provenance remains truthful.
+  Non-integer, unknown, or duplicate identities, malformed rows, unavailable captures claimed as
   usable, and passage mismatches still reject through the bounded correction path.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,8 +154,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   proposition; and enforce aggregate capture/binding budgets so multiplicative per-claim maxima
   become visible debt rather than an hours-long run.
   Treat an omitted expected indexed binding row as unusable for that exact source and demote only
-  the affected claim when it has no other qualifying evidence. Unknown or duplicate identities,
-  malformed rows, unavailable captures claimed as usable, and passage mismatches still reject.
+  the affected claim when it has no other qualifying evidence. Record neutral omission provenance;
+  non-integer, unknown, or duplicate identities, malformed rows, unavailable captures claimed as
+  usable, and passage mismatches still reject through the bounded correction path.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.
   Captured binding failure debt must retain raw provider stdout, structured failure detail, and

--- a/README.md
+++ b/README.md
@@ -380,9 +380,10 @@ does not invalidate the rest of the audit.
 Other valid claims in the same response are still registered.
 If an indexed captured-text binding response omits an expected source key, the server materializes
 that key as unusable: its source becomes context and any claim left without qualifying evidence is
-forced to blocking `unverified`. Valid rows in the same batch survive. Unknown or duplicate keys,
-malformed rows, unavailable captures claimed as usable, and passages absent from the capture still
-reject the batch and receive the bounded same-session correction.
+forced to blocking `unverified`, with neutral provenance that no accepted captured-text binding was
+returned. Valid rows in the same batch survive. Non-integer, unknown, or duplicate keys, malformed
+rows, unavailable captures claimed as usable, and passages absent from the capture still reject the
+batch and receive the bounded same-session correction.
 If the bounded correction retry still contains an unbindable anchor, that item is
 recorded as explicit blocking audit debt while the retry's valid claims and valid
 removal dispositions are persisted. The next round therefore repairs one item

--- a/README.md
+++ b/README.md
@@ -378,6 +378,11 @@ Likewise, evidence that does not entail the model's `supported`/`refuted` verdic
 only as context and that individual claim is forced to blocking `unverified`. One bad packet
 does not invalidate the rest of the audit.
 Other valid claims in the same response are still registered.
+If an indexed captured-text binding response omits an expected source key, the server materializes
+that key as unusable: its source becomes context and any claim left without qualifying evidence is
+forced to blocking `unverified`. Valid rows in the same batch survive. Unknown or duplicate keys,
+malformed rows, unavailable captures claimed as usable, and passages absent from the capture still
+reject the batch and receive the bounded same-session correction.
 If the bounded correction retry still contains an unbindable anchor, that item is
 recorded as explicit blocking audit debt while the retry's valid claims and valid
 removal dispositions are persisted. The next round therefore repairs one item

--- a/README.md
+++ b/README.md
@@ -379,11 +379,12 @@ only as context and that individual claim is forced to blocking `unverified`. On
 does not invalidate the rest of the audit.
 Other valid claims in the same response are still registered.
 If an indexed captured-text binding response omits an expected source key, the server materializes
-that key as unusable: its source becomes context and any claim left without qualifying evidence is
-forced to blocking `unverified`, with neutral provenance that no accepted captured-text binding was
-returned. Valid rows in the same batch survive. Non-integer, unknown, or duplicate keys, malformed
-rows, unavailable captures claimed as usable, and passages absent from the capture still reject the
-batch and receive the bounded same-session correction.
+that omission as a distinct conservative outcome: its source becomes context and any claim left
+without qualifying evidence is forced to blocking `unverified`, with provenance that the binding
+row was omitted. A returned `usable:false` row instead records that the model explicitly marked the
+captured source unusable. Valid rows in the same batch survive. Non-integer, unknown, or duplicate
+keys, malformed rows, unavailable captures claimed as usable, and passages absent from the capture
+still reject the batch and receive the bounded same-session correction.
 If the bounded correction retry still contains an unbindable anchor, that item is
 recorded as explicit blocking audit debt while the retry's valid claims and valid
 removal dispositions are persisted. The next round therefore repairs one item

--- a/README.md
+++ b/README.md
@@ -382,9 +382,11 @@ If an indexed captured-text binding response omits an expected source key, the s
 that omission as a distinct conservative outcome: its source becomes context and any claim left
 without qualifying evidence is forced to blocking `unverified`, with provenance that the binding
 row was omitted. A returned `usable:false` row instead records that the model explicitly marked the
-captured source unusable. Valid rows in the same batch survive. Non-integer, unknown, or duplicate
-keys, malformed rows, unavailable captures claimed as usable, and passages absent from the capture
-still reject the batch and receive the bounded same-session correction.
+captured source unusable when a capture exists; if the server capture itself failed, the durable
+context records that server-owned failure reason instead. Valid rows in the same batch survive.
+Non-integer, unknown, or duplicate keys, malformed rows, unavailable captures claimed as usable,
+and passages absent from the capture still reject the batch and receive the bounded same-session
+correction.
 If the bounded correction retry still contains an unbindable anchor, that item is
 recorded as explicit blocking audit debt while the retry's valid claims and valid
 removal dispositions are persisted. The next round therefore repairs one item

--- a/README.md
+++ b/README.md
@@ -387,6 +387,8 @@ context records that server-owned failure reason instead. Valid rows in the same
 Non-integer, unknown, or duplicate keys, malformed rows, unavailable captures claimed as usable,
 and passages absent from the capture still reject the batch and receive the bounded same-session
 correction.
+Cold-attestation rows apply the same exact-integer identity rule before key construction; Boolean,
+float, string, null, array, and object aliases cannot bind authority or entailment to another claim.
 If the bounded correction retry still contains an unbindable anchor, that item is
 recorded as explicit blocking audit debt while the retry's valid claims and valid
 removal dispositions are persisted. The next round therefore repairs one item

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -88,9 +88,71 @@
     "tool_returncode": 0,
     "tool_error": false
   },
+  "controlled_omission": {
+    "recorded_at": "2026-08-14T05:32:27+01:00",
+    "implementation_commit": "8e24587536ebf624bed93b3095bcaa967198ebae",
+    "kind": "production-backed controlled model boundary",
+    "control": "After signed-in Codex discovery and real server capture, the harness returned the production binding parser one valid captured-text row and deliberately omitted expected key [1,0]. Signed-in Codex cold attestation and canonical reconciliation then ran unchanged.",
+    "duration_ms": 38016,
+    "omitted_keys": [[1, 0]],
+    "binding_response_sha256": "2a4161895b8158001d35ce847e3667104861b2cd394ff9a9e4df1d71f475d0f9",
+    "attempts": [
+      {
+        "role": "claim-discovery",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffe8a-16f8-7733-9f24-21d304c4f5d3",
+        "response_sha256": "eb3b64042f6933f27a62dd267abcc6ebbc38d978fabb5acb703125386a9e8fa5"
+      },
+      {
+        "role": "claim-binding",
+        "kind": "controlled-omission",
+        "session_ref": "019ffe8a-16f8-7733-9f24-21d304c4f5d3",
+        "response_sha256": "2a4161895b8158001d35ce847e3667104861b2cd394ff9a9e4df1d71f475d0f9"
+      },
+      {
+        "role": "claim-attestation",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffe8a-92be-7130-ad4e-d517919b8fa8",
+        "response_sha256": "6e143a646ac0eba6b7d809c9a554e3b4bf34b7d4b18ce45e8faf4f8bdb8a6fad"
+      }
+    ],
+    "durable_state": {
+      "state_sha256": "065fc063af5f9085e317172d1471894e7105137e5bac58862e7c93f766dd1581",
+      "blocked": true,
+      "debt": null,
+      "supported_claim": {
+        "claim_id": "C-875be98074",
+        "verdict": "supported",
+        "captured_text_sha256": "a229306f4b004059a6e046f6d62cc112b4ad327011c2448b52b596c454a28f3a",
+        "publisher_authority": true,
+        "passage_entailment": true
+      },
+      "omitted_claim": {
+        "claim_id": "C-01c0486e7a",
+        "verdict": "unverified",
+        "relation": "context",
+        "location": "No binding row returned for captured source",
+        "quote": "The model omitted this captured-source binding.",
+        "capture_attestations": []
+      }
+    }
+  },
+  "measurements": {
+    "production_diff": {
+      "files": ["src/paranoia_local/handlers.py"],
+      "added_lines": 35,
+      "deleted_lines": 9,
+      "net_lines": 26
+    },
+    "largest_production_modules": [
+      {"path": "src/paranoia_local/handlers.py", "lines": 2809},
+      {"path": "src/paranoia_local/arbitrate_handler.py", "lines": 2768},
+      {"path": "src/paranoia_local/plan_claims.py", "lines": 1417}
+    ]
+  },
   "scope": {
     "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, cold attestation, stable-ID reconciliation, and durable claim-state persistence.",
-    "omission_path": "The live provider returned its sole requested row. Omission degradation is established by the executable full-lifecycle regression, not claimed from this live sample.",
+    "omission_path": "The ordinary live provider returned its sole requested row. A separate controlled production-backed run on commit 8e24587 used signed-in discovery and cold attestation plus real server captures, deliberately omitted expected key [1,0] at the model boundary, and durably retained one supported sibling while blocking the omitted claim as unverified.",
     "structural_review": "The disposable fixture plan opened unrelated structural debt after claim settlement; this artifact is claim-path acceptance, not whole-plan convergence."
   }
 }

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -138,12 +138,12 @@
     }
   },
   "final_revision_acceptance": {
-    "recorded_at": "2026-08-14T05:50:32+01:00",
-    "implementation_commit": "31149deb8570863f874ef363119064e487212cd2",
+    "recorded_at": "2026-08-14T06:05:06+01:00",
+    "implementation_commit": "ac50c479dd536ba6d3e3e2253e9af321ba62fbdb",
     "kind": "production-backed controlled three-outcome binding run",
     "control": "Signed-in Codex discovered three claims and the server captured all three official pages. The controlled model boundary returned one valid binding, omitted key [1,0], and returned usable:false for key [2,0] after deterministically replacing that real capture with a failed Capture. Signed-in Codex cold attestation, canonical reconciliation, and atomic lineage persistence then ran unchanged.",
     "model_calls": 3,
-    "duration_ms": 48010,
+    "duration_ms": 42151,
     "omitted_keys": [[1, 0]],
     "capture_failed_keys": [[2, 0]],
     "binding_response_sha256": "84ad675552ecbf66b79410d177a37255f3c13fe96e360044fe19acabeeae6202",
@@ -151,32 +151,32 @@
       {
         "role": "claim-discovery",
         "kind": "signed-in-provider",
-        "session_ref": "019ffe9a-ad1d-73c2-8b38-0529db530901",
-        "response_sha256": "a1e77fd72062101634e67c03dd2edc8c3c91819e7e1b9d57efb4de6dfd12a987",
-        "input_tokens": 65408,
-        "cached_input_tokens": 32256,
-        "output_tokens": 1730,
-        "reasoning_output_tokens": 860
+        "session_ref": "019ffea8-183a-7ca2-9b28-90832fe26586",
+        "response_sha256": "626db8fe724cf4c20a5546a2cdaf3acbea94a58f4efe44114fa75bcfd971223b",
+        "input_tokens": 65706,
+        "cached_input_tokens": 38144,
+        "output_tokens": 1427,
+        "reasoning_output_tokens": 565
       },
       {
         "role": "claim-binding",
         "kind": "controlled-partial-binding",
-        "session_ref": "019ffe9a-ad1d-73c2-8b38-0529db530901",
+        "session_ref": "019ffea8-183a-7ca2-9b28-90832fe26586",
         "response_sha256": "84ad675552ecbf66b79410d177a37255f3c13fe96e360044fe19acabeeae6202"
       },
       {
         "role": "claim-attestation",
         "kind": "signed-in-provider",
-        "session_ref": "019ffe9b-4f87-7482-9132-a58dc7565198",
-        "response_sha256": "a0df9f8f08f59d97e9888aaa7644896cf48ba94442938c12b2f3377faf721cdc",
-        "input_tokens": 8975,
+        "session_ref": "019ffea8-a1aa-7460-bf9c-824765b9e06f",
+        "response_sha256": "82df9eb7fcd26832ed2055caf948bb804288f969fcc610b808bab0989f7cc069",
+        "input_tokens": 8990,
         "cached_input_tokens": 2816,
-        "output_tokens": 113,
+        "output_tokens": 121,
         "reasoning_output_tokens": 0
       }
     ],
     "durable_state": {
-      "state_sha256": "e75a2a24ed6ea2cd7f881a59e88bef97aa5036e9ea5ce5186d98eac8a1b2f2c0",
+      "state_sha256": "22147a080652dbcdd7269f3db6a9ef8d5848609d178618281b36f4f87e1482b9",
       "blocked": true,
       "debt": null,
       "claims": [
@@ -224,7 +224,7 @@
     ]
   },
   "scope": {
-    "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, cold attestation, stable-ID reconciliation, and durable claim-state persistence. The final controlled run on commit 31149de exercised valid, omitted, and capture-failed explicit-unusable outcomes together.",
+    "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, exact-identity cold attestation, stable-ID reconciliation, and durable claim-state persistence. The final controlled run on commit ac50c47 exercised valid, omitted, and capture-failed explicit-unusable outcomes together.",
     "omission_path": "The ordinary live provider returned its sole requested row. A separate controlled production-backed run on commit 8e24587 used signed-in discovery and cold attestation plus real server captures, deliberately omitted expected key [1,0] at the model boundary, and durably retained one supported sibling while blocking the omitted claim as unverified.",
     "structural_review": "The disposable fixture plan opened unrelated structural debt after claim settlement; this artifact is claim-path acceptance, not whole-plan convergence."
   }

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -207,6 +207,61 @@
       ]
     }
   },
+  "invalid_attestation_acceptance": {
+    "recorded_at": "2026-08-14T06:11:47+01:00",
+    "implementation_commit": "ac50c479dd536ba6d3e3e2253e9af321ba62fbdb",
+    "kind": "production-backed controlled invalid-attestation run",
+    "control": "Signed-in Codex discovered and bound two official claims from real server captures. The controlled cold-attestation boundary returned one exact row and one Boolean claim_index alias. The production parser and outer claim lifecycle then ran unchanged.",
+    "model_calls": 3,
+    "signed_in_model_calls": 2,
+    "duration_ms": 38555,
+    "controlled_attestation_response_sha256": "9a68aba2dff53f0ae3a5e289d7ee42a1dff00c4b4caede500579f8b86eb6f452",
+    "expected_parser_error": "attestation row indices must be integers",
+    "attempts": [
+      {
+        "role": "claim-discovery",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffeae-3b5a-7252-967d-a656fbbce275",
+        "response_sha256": "56327bad95733163d4d23438fd01c1cabf3726c4630e539458d495ac3863946c",
+        "input_tokens": 33496,
+        "cached_input_tokens": 2816,
+        "output_tokens": 906,
+        "reasoning_output_tokens": 358
+      },
+      {
+        "role": "claim-binding",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffeae-3b5a-7252-967d-a656fbbce275",
+        "response_sha256": "be9b385445e7c2120ab8d38757af94954198ec66559caf76583f5e062c15997a",
+        "input_tokens": 55787,
+        "cached_input_tokens": 5632,
+        "output_tokens": 1076,
+        "reasoning_output_tokens": 402
+      },
+      {
+        "role": "claim-attestation",
+        "kind": "controlled-boolean-identity",
+        "session_ref": "controlled-invalid-attestation",
+        "response_sha256": "9a68aba2dff53f0ae3a5e289d7ee42a1dff00c4b4caede500579f8b86eb6f452"
+      }
+    ],
+    "durable_state": {
+      "state_sha256": "446c518435713007689bef7f5eb2b47fed9e5656578eb44a3a7b672b333d18bb",
+      "status": "failed",
+      "blocked": true,
+      "claim_count": 0,
+      "debt": {
+        "reason": "claim-audit reviewer failed (exit 0)",
+        "round": 1,
+        "returncode": 0,
+        "raw_sha256": "9a68aba2dff53f0ae3a5e289d7ee42a1dff00c4b4caede500579f8b86eb6f452",
+        "rejected_identity": {
+          "claim_index": true,
+          "evidence_index": 0
+        }
+      }
+    }
+  },
   "measurements": {
     "production_diff": {
       "files": [

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -209,13 +209,16 @@
   },
   "measurements": {
     "production_diff": {
-      "files": ["src/paranoia_local/handlers.py"],
-      "added_lines": 42,
-      "deleted_lines": 9,
-      "net_lines": 33
+      "files": [
+        "src/paranoia_local/handlers.py",
+        "src/paranoia_local/plan_claims.py"
+      ],
+      "added_lines": 48,
+      "deleted_lines": 11,
+      "net_lines": 37
     },
     "largest_production_modules": [
-      {"path": "src/paranoia_local/handlers.py", "lines": 2816},
+      {"path": "src/paranoia_local/handlers.py", "lines": 2820},
       {"path": "src/paranoia_local/arbitrate_handler.py", "lines": 2768},
       {"path": "src/paranoia_local/plan_claims.py", "lines": 1417}
     ]

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -1,0 +1,96 @@
+{
+  "acceptance_kind": "indexed-claim-binding-current-revision",
+  "recorded_at": "2026-08-14T05:19:22+01:00",
+  "implementation_commit": "0479336c647b026f023c8ee0a1a514f1148c229a",
+  "provider": {
+    "engine": "codex",
+    "cli_version": "0.144.6",
+    "model": "gpt-5.6-sol",
+    "effort": "high",
+    "web_discovery": true,
+    "binding_web_access": false,
+    "attestation_web_access": false
+  },
+  "fixture": {
+    "repository_head": "fa3c9e6320e7069f7b70c3f9143780a9bfe3bcf8",
+    "plan_digest": "76ce6d80bbe0eb86",
+    "lineage": "claim-binding-live-acceptance-20260814",
+    "round": 1
+  },
+  "claim_phase": {
+    "status": "parsed 1 new + 0 targeted retained + 0 frozen",
+    "model_calls": 3,
+    "duration_ms": 39877,
+    "counts": {
+      "supported": 1,
+      "refuted": 0,
+      "unverified": 0
+    },
+    "debt": null,
+    "claim": {
+      "claim_id": "C-203733f1cc",
+      "anchor": "Python 3.11.0 was released on October 24, 2022.",
+      "proposition": "Python 3.11.0 was released on October 24, 2022.",
+      "verdict": "supported",
+      "evidence": {
+        "url": "https://www.python.org/downloads/release/python-3110/",
+        "publisher": "Python Software Foundation",
+        "source_kind": "primary",
+        "location": "Lines 1–2, release-date field and stable-release heading",
+        "passage": "Release date: Oct. 24, 2022 This is the stable release of Python 3.11.0",
+        "relation": "supports_claim",
+        "captured_text_sha256": "a229306f4b004059a6e046f6d62cc112b4ad327011c2448b52b596c454a28f3a"
+      },
+      "cold_attestation": {
+        "publisher_authority": true,
+        "authority_reason": "The Python Software Foundation operates Python's official website and governs the official release record for Python 3.11.0.",
+        "passage_entailment": true,
+        "entailment_reason": "The passage explicitly identifies Python 3.11.0 as the stable release and gives its release date as Oct. 24, 2022, directly supporting the proposition."
+      },
+      "verified_round": 1
+    }
+  },
+  "attempts": [
+    {
+      "role": "claim-discovery",
+      "session_ref": "019ffe7b-9c3a-7661-ad30-c619e011df8c",
+      "outcome": "completed",
+      "response_sha256": "bc8be9f082dda5cd824784d18dcf326d0c4c1471680e7f2052a88895029a52ae",
+      "input_tokens": 50524,
+      "cached_input_tokens": 30976,
+      "output_tokens": 958,
+      "reasoning_output_tokens": 545
+    },
+    {
+      "role": "claim-binding",
+      "session_ref": "019ffe7b-9c3a-7661-ad30-c619e011df8c",
+      "outcome": "completed",
+      "response_sha256": "bdd0959dbb4976c52f4be1e9716aa653b0245131dc96f5488c5237496f89b669",
+      "input_tokens": 71523,
+      "cached_input_tokens": 33792,
+      "output_tokens": 1124,
+      "reasoning_output_tokens": 629
+    },
+    {
+      "role": "claim-attestation",
+      "session_ref": "019ffe7c-1f73-72c1-99c5-459ab137ba99",
+      "outcome": "completed",
+      "response_sha256": "d6fc8d22e885038c374f298e16b251e4418024ed1a3b56883ff4d5cf4e257d15",
+      "input_tokens": 8989,
+      "cached_input_tokens": 0,
+      "output_tokens": 114,
+      "reasoning_output_tokens": 0
+    }
+  ],
+  "durable_artifacts": {
+    "lineage_state_sha256": "89aed308aa56b0335bf993f6ec9b2e0e19966774da14f674d15dca508402c1b5",
+    "audit_log_sha256": "2f6d49076200c99b9f81c8b99ca7ffd4b533f16d8952601b993a3e2c36145f9f",
+    "tool_returncode": 0,
+    "tool_error": false
+  },
+  "scope": {
+    "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, cold attestation, stable-ID reconciliation, and durable claim-state persistence.",
+    "omission_path": "The live provider returned its sole requested row. Omission degradation is established by the executable full-lifecycle regression, not claimed from this live sample.",
+    "structural_review": "The disposable fixture plan opened unrelated structural debt after claim settlement; this artifact is claim-path acceptance, not whole-plan convergence."
+  }
+}

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -137,6 +137,76 @@
       }
     }
   },
+  "final_revision_acceptance": {
+    "recorded_at": "2026-08-14T05:50:32+01:00",
+    "implementation_commit": "31149deb8570863f874ef363119064e487212cd2",
+    "kind": "production-backed controlled three-outcome binding run",
+    "control": "Signed-in Codex discovered three claims and the server captured all three official pages. The controlled model boundary returned one valid binding, omitted key [1,0], and returned usable:false for key [2,0] after deterministically replacing that real capture with a failed Capture. Signed-in Codex cold attestation, canonical reconciliation, and atomic lineage persistence then ran unchanged.",
+    "model_calls": 3,
+    "duration_ms": 48010,
+    "omitted_keys": [[1, 0]],
+    "capture_failed_keys": [[2, 0]],
+    "binding_response_sha256": "84ad675552ecbf66b79410d177a37255f3c13fe96e360044fe19acabeeae6202",
+    "attempts": [
+      {
+        "role": "claim-discovery",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffe9a-ad1d-73c2-8b38-0529db530901",
+        "response_sha256": "a1e77fd72062101634e67c03dd2edc8c3c91819e7e1b9d57efb4de6dfd12a987",
+        "input_tokens": 65408,
+        "cached_input_tokens": 32256,
+        "output_tokens": 1730,
+        "reasoning_output_tokens": 860
+      },
+      {
+        "role": "claim-binding",
+        "kind": "controlled-partial-binding",
+        "session_ref": "019ffe9a-ad1d-73c2-8b38-0529db530901",
+        "response_sha256": "84ad675552ecbf66b79410d177a37255f3c13fe96e360044fe19acabeeae6202"
+      },
+      {
+        "role": "claim-attestation",
+        "kind": "signed-in-provider",
+        "session_ref": "019ffe9b-4f87-7482-9132-a58dc7565198",
+        "response_sha256": "a0df9f8f08f59d97e9888aaa7644896cf48ba94442938c12b2f3377faf721cdc",
+        "input_tokens": 8975,
+        "cached_input_tokens": 2816,
+        "output_tokens": 113,
+        "reasoning_output_tokens": 0
+      }
+    ],
+    "durable_state": {
+      "state_sha256": "e75a2a24ed6ea2cd7f881a59e88bef97aa5036e9ea5ce5186d98eac8a1b2f2c0",
+      "blocked": true,
+      "debt": null,
+      "claims": [
+        {
+          "claim_id": "C-76a83a1cd5",
+          "verdict": "supported",
+          "relation": "supports_claim",
+          "captured_text_sha256": "6de6e0bddabfb7a291003b98b69fdcd1c131a7edf2320355ffeca8aa88289a39",
+          "publisher_authority": true,
+          "passage_entailment": true
+        },
+        {
+          "claim_id": "C-370b619781",
+          "verdict": "unverified",
+          "relation": "context",
+          "location": "No binding row returned for captured source",
+          "quote": "The model omitted this captured-source binding.",
+          "capture_attestations": []
+        },
+        {
+          "claim_id": "C-43a88af1f4",
+          "verdict": "unverified",
+          "relation": "context",
+          "location": "Server capture unavailable",
+          "quote": "Server capture unavailable: controlled capture failure after real server capture",
+          "capture_attestations": []
+        }
+      ]
+    }
+  },
   "measurements": {
     "production_diff": {
       "files": ["src/paranoia_local/handlers.py"],
@@ -151,7 +221,7 @@
     ]
   },
   "scope": {
-    "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, cold attestation, stable-ID reconciliation, and durable claim-state persistence.",
+    "proved": "The committed production path completed signed-in discovery, server capture, indexed binding with browsing disabled, cold attestation, stable-ID reconciliation, and durable claim-state persistence. The final controlled run on commit 31149de exercised valid, omitted, and capture-failed explicit-unusable outcomes together.",
     "omission_path": "The ordinary live provider returned its sole requested row. A separate controlled production-backed run on commit 8e24587 used signed-in discovery and cold attestation plus real server captures, deliberately omitted expected key [1,0] at the model boundary, and durably retained one supported sibling while blocking the omitted claim as unverified.",
     "structural_review": "The disposable fixture plan opened unrelated structural debt after claim settlement; this artifact is claim-path acceptance, not whole-plan convergence."
   }

--- a/docs/claim_binding_acceptance_2026-08-14.json
+++ b/docs/claim_binding_acceptance_2026-08-14.json
@@ -140,12 +140,12 @@
   "measurements": {
     "production_diff": {
       "files": ["src/paranoia_local/handlers.py"],
-      "added_lines": 35,
+      "added_lines": 42,
       "deleted_lines": 9,
-      "net_lines": 26
+      "net_lines": 33
     },
     "largest_production_modules": [
-      {"path": "src/paranoia_local/handlers.py", "lines": 2809},
+      {"path": "src/paranoia_local/handlers.py", "lines": 2816},
       {"path": "src/paranoia_local/arbitrate_handler.py", "lines": 2768},
       {"path": "src/paranoia_local/plan_claims.py", "lines": 1417}
     ]

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -194,6 +194,17 @@ failure does not restart research.
 
 ## Recorded real acceptance
 
+The indexed binding correction is recorded in
+[`claim_binding_acceptance_2026-08-14.json`](claim_binding_acceptance_2026-08-14.json).
+On implementation commit `0479336`, a fresh signed-in `critique_plan` run completed discovery,
+server capture, tool-less indexed binding, independent cold attestation, stable-ID reconciliation,
+and durable persistence for one official Python Software Foundation claim in 39.877 seconds and
+three claim-model calls. The persisted claim count is one supported, zero refuted, zero unverified,
+with no claim debt. The live provider returned the requested row; the separate executable
+full-lifecycle regression proves that an omitted row becomes neutral context and blocks only its
+affected claim as `unverified`. The disposable plan later opened unrelated structural findings, so
+the artifact claims current-revision claim-path acceptance, not whole-plan convergence.
+
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).
 It covers a known false internet-only claim, an external fact, an RFC design principle, an

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -205,7 +205,7 @@ Codex discovery and cold attestation plus real server captures, deliberately omi
 `(1,0)` at the model boundary, and durably produced one supported claim plus one context-only
 `unverified` claim. Explicit `usable:false` and omission also have separate durable provenance.
 An explicit unusable row retains server capture-failure provenance when capture itself failed.
-The artifact records the +42/-9 production diff and the three largest production modules. The
+The artifact records the +48/-11 production diff and the three largest production modules. The
 disposable plan later opened unrelated structural findings, so the artifact claims current-revision
 claim-path acceptance, not whole-plan convergence.
 

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -218,6 +218,13 @@ cold attestation and canonical atomic persistence then produced one supported cl
 three model calls and 42.151 seconds; its sessions, response hashes, state hash, and exact durable
 outcomes are retained in the artifact.
 
+A second controlled failure run on the same `ac50c47` behavior commit used signed-in discovery,
+real server capture, and signed-in binding for two claims, then supplied a Boolean-alias identity at
+the cold-attestation boundary. Exact identity validation rejected the response before settlement.
+Canonical durable state remained blocked with zero applied claims and retained debt bound to the
+exact rejected-response hash, so the valid sibling row could not be misbound or partially applied.
+The run used two signed-in calls plus the controlled attestation boundary and 38.555 seconds.
+
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).
 It covers a known false internet-only claim, an external fact, an RFC design principle, an

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -200,10 +200,13 @@ On implementation commit `0479336`, a fresh signed-in `critique_plan` run comple
 server capture, tool-less indexed binding, independent cold attestation, stable-ID reconciliation,
 and durable persistence for one official Python Software Foundation claim in 39.877 seconds and
 three claim-model calls. The persisted claim count is one supported, zero refuted, zero unverified,
-with no claim debt. The live provider returned the requested row; the separate executable
-full-lifecycle regression proves that an omitted row becomes neutral context and blocks only its
-affected claim as `unverified`. The disposable plan later opened unrelated structural findings, so
-the artifact claims current-revision claim-path acceptance, not whole-plan convergence.
+with no claim debt. A second production-backed controlled run on commit `8e24587` used signed-in
+Codex discovery and cold attestation plus real server captures, deliberately omitted expected key
+`(1,0)` at the model boundary, and durably produced one supported claim plus one context-only
+`unverified` claim. Explicit `usable:false` and omission also have separate durable provenance.
+The artifact records the +35/-9 production diff and the three largest production modules. The
+disposable plan later opened unrelated structural findings, so the artifact claims current-revision
+claim-path acceptance, not whole-plan convergence.
 
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -209,13 +209,13 @@ The artifact records the +48/-11 production diff and the three largest productio
 disposable plan later opened unrelated structural findings, so the artifact claims current-revision
 claim-path acceptance, not whole-plan convergence.
 
-The final acceptance run is bound to behavior commit `31149de`. Signed-in Codex discovered three
+The final acceptance run is bound to behavior commit `ac50c47`. Signed-in Codex discovered three
 official Python release claims and the server captured all three pages. A controlled production
 model boundary preserved one valid binding, omitted key `(1,0)`, and returned `usable:false` for
 key `(2,0)` after replacing that real capture with a deterministic failed-capture record. Signed-in
 cold attestation and canonical atomic persistence then produced one supported claim, one omitted
 `unverified` claim, and one capture-failed `unverified` claim with distinct provenance. The run used
-three model calls and 48.010 seconds; its sessions, response hashes, state hash, and exact durable
+three model calls and 42.151 seconds; its sessions, response hashes, state hash, and exact durable
 outcomes are retained in the artifact.
 
 The current Codex acceptance record is

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -209,6 +209,15 @@ The artifact records the +42/-9 production diff and the three largest production
 disposable plan later opened unrelated structural findings, so the artifact claims current-revision
 claim-path acceptance, not whole-plan convergence.
 
+The final acceptance run is bound to behavior commit `31149de`. Signed-in Codex discovered three
+official Python release claims and the server captured all three pages. A controlled production
+model boundary preserved one valid binding, omitted key `(1,0)`, and returned `usable:false` for
+key `(2,0)` after replacing that real capture with a deterministic failed-capture record. Signed-in
+cold attestation and canonical atomic persistence then produced one supported claim, one omitted
+`unverified` claim, and one capture-failed `unverified` claim with distinct provenance. The run used
+three model calls and 48.010 seconds; its sessions, response hashes, state hash, and exact durable
+outcomes are retained in the artifact.
+
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).
 It covers a known false internet-only claim, an external fact, an RFC design principle, an

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -204,7 +204,8 @@ with no claim debt. A second production-backed controlled run on commit `8e24587
 Codex discovery and cold attestation plus real server captures, deliberately omitted expected key
 `(1,0)` at the model boundary, and durably produced one supported claim plus one context-only
 `unverified` claim. Explicit `usable:false` and omission also have separate durable provenance.
-The artifact records the +35/-9 production diff and the three largest production modules. The
+An explicit unusable row retains server capture-failure provenance when capture itself failed.
+The artifact records the +42/-9 production diff and the three largest production modules. The
 disposable plan later opened unrelated structural findings, so the artifact claims current-revision
 claim-path acceptance, not whole-plan convergence.
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2331,6 +2331,10 @@ class _CapturedClaimEngine:
                     "authority_reason", "passage_entailment", "entailment_reason",
                 }:
                     raise ValueError("invalid attestation row")
+                if type(row["claim_index"]) is not int or type(
+                    row["evidence_index"]
+                ) is not int:
+                    raise ValueError("attestation row indices must be integers")
                 key = (row["claim_index"], row["evidence_index"])
                 if key not in expected or key in decisions:
                     raise ValueError("unknown or duplicate attestation row")

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -53,6 +53,15 @@ PLAN_BINDING_MARKER = "=== PLAN EVIDENCE BINDING JSON ==="
 MAX_PLAN_BINDING_BATCH_CHARS = 400_000
 MAX_PLAN_CAPTURE_SOURCES = 200
 MAX_PLAN_BINDING_BATCHES = 5
+
+
+class _OmittedBinding:
+    __slots__ = ()
+
+
+_OMITTED_BINDING = _OmittedBinding()
+
+
 def _attempt(
     role: str, engine: Engine, review: Review, *, sequence: int | None = None,
 ) -> rc.Attempt:
@@ -2070,7 +2079,9 @@ class _CapturedClaimEngine:
         model: str, effort: str, binding_kwargs: dict[str, Any],
     ) -> tuple[pc.Audit, list[Review]]:
         assert self.binding_engine is not None
-        decisions: dict[tuple[int, int], tuple[str, str] | None] = {}
+        decisions: dict[
+            tuple[int, int], tuple[str, str] | None | _OmittedBinding
+        ] = {}
         reviews: list[Review] = []
         current_session = session_ref
         for batch in self._binding_batches(discovery, captures):
@@ -2129,11 +2140,15 @@ class _CapturedClaimEngine:
             for evidence_index, item in enumerate(claim["evidence"]):
                 capture = captures[(claim_index, evidence_index)]
                 item["url"] = capture.final_url or item["url"]
-                binding = decisions.get((claim_index, evidence_index))
-                if binding is None:
+                binding = decisions[(claim_index, evidence_index)]
+                if binding is _OMITTED_BINDING:
                     item["relation"] = "context"
-                    item["location"] = "No accepted captured-text binding"
-                    item["quote"] = "No accepted captured-text passage was returned."
+                    item["location"] = "No binding row returned for captured source"
+                    item["quote"] = "The model omitted this captured-source binding."
+                elif binding is None:
+                    item["relation"] = "context"
+                    item["location"] = "Captured source explicitly marked unusable"
+                    item["quote"] = "No usable captured-text passage was returned."
                 else:
                     item["location"], item["quote"] = binding
         combined = pc.Audit(
@@ -2149,7 +2164,7 @@ class _CapturedClaimEngine:
     def _parse_indexed_binding(
         self, text: str, batch: list[dict[str, Any]],
         captures: dict[tuple[int, int], external_sources.Capture],
-    ) -> dict[tuple[int, int], tuple[str, str] | None]:
+    ) -> dict[tuple[int, int], tuple[str, str] | None | _OmittedBinding]:
         if text.count(PLAN_BINDING_MARKER) != 1:
             raise pc.AuditError(f"expected exactly one {PLAN_BINDING_MARKER} marker", text)
         tail = text.split(PLAN_BINDING_MARKER, 1)[1].strip()
@@ -2163,7 +2178,9 @@ class _CapturedClaimEngine:
         expected = {(row["claim_index"], row["evidence_index"]) for row in batch}
         if not isinstance(raw, list):
             raise pc.AuditError("indexed binding rows must be an array", text)
-        result: dict[tuple[int, int], tuple[str, str] | None] = {}
+        result: dict[
+            tuple[int, int], tuple[str, str] | None | _OmittedBinding
+        ] = {}
         for row in raw:
             if not isinstance(row, dict) or set(row) != {
                 "claim_index", "evidence_index", "usable", "location", "passage",
@@ -2192,10 +2209,11 @@ class _CapturedClaimEngine:
             result[key] = (location, passage)
         # Exhaustive identity remains server-owned. A model omission cannot support a
         # claim, but it also need not discard independently valid rows from this batch.
-        # Materialize each missing expected key as the existing unusable-binding value;
-        # unknown and duplicate keys have already failed above.
+        # Materialize each missing expected key as a distinct conservative outcome;
+        # unknown and duplicate keys have already failed above. Keeping omission
+        # separate from an explicit unusable judgement preserves truthful provenance.
         for key in sorted(expected - result.keys()):
-            result[key] = None
+            result[key] = _OMITTED_BINDING
         return result
 
     def _parse_bound(

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2132,8 +2132,8 @@ class _CapturedClaimEngine:
                 binding = decisions.get((claim_index, evidence_index))
                 if binding is None:
                     item["relation"] = "context"
-                    item["location"] = "Server capture unavailable"
-                    item["quote"] = "No server-captured passage was available."
+                    item["location"] = "No accepted captured-text binding"
+                    item["quote"] = "No accepted captured-text passage was returned."
                 else:
                     item["location"], item["quote"] = binding
         combined = pc.Audit(
@@ -2169,6 +2169,8 @@ class _CapturedClaimEngine:
                 "claim_index", "evidence_index", "usable", "location", "passage",
             }:
                 raise pc.AuditError("indexed binding row fields are invalid", text)
+            if type(row["claim_index"]) is not int or type(row["evidence_index"]) is not int:
+                raise pc.AuditError("indexed binding row indices must be integers", text)
             key = (row["claim_index"], row["evidence_index"])
             if key not in expected or key in result or type(row["usable"]) is not bool:
                 raise pc.AuditError("indexed binding row identity is invalid or duplicated", text)

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2147,8 +2147,15 @@ class _CapturedClaimEngine:
                     item["quote"] = "The model omitted this captured-source binding."
                 elif binding is None:
                     item["relation"] = "context"
-                    item["location"] = "Captured source explicitly marked unusable"
-                    item["quote"] = "No usable captured-text passage was returned."
+                    if not capture.usable:
+                        detail = " ".join(
+                            (capture.error or "capture contained no extracted text").split()
+                        )
+                        item["location"] = "Server capture unavailable"
+                        item["quote"] = f"Server capture unavailable: {detail}"
+                    else:
+                        item["location"] = "Captured source explicitly marked unusable"
+                        item["quote"] = "No usable captured-text passage was returned."
                 else:
                     item["location"], item["quote"] = binding
         combined = pc.Audit(

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2161,8 +2161,8 @@ class _CapturedClaimEngine:
             raise pc.AuditError("invalid indexed binding envelope", text)
         raw = value["bindings"]
         expected = {(row["claim_index"], row["evidence_index"]) for row in batch}
-        if not isinstance(raw, list) or len(raw) != len(expected):
-            raise pc.AuditError("indexed binding inventory differs from its batch", text)
+        if not isinstance(raw, list):
+            raise pc.AuditError("indexed binding rows must be an array", text)
         result: dict[tuple[int, int], tuple[str, str] | None] = {}
         for row in raw:
             if not isinstance(row, dict) or set(row) != {
@@ -2188,6 +2188,12 @@ class _CapturedClaimEngine:
             if not external_sources.passage_matches(passage, capture.text):
                 raise pc.AuditError("indexed binding passage is not in captured text", text)
             result[key] = (location, passage)
+        # Exhaustive identity remains server-owned. A model omission cannot support a
+        # claim, but it also need not discard independently valid rows from this batch.
+        # Materialize each missing expected key as the existing unusable-binding value;
+        # unknown and duplicate keys have already failed above.
+        for key in sorted(expected - result.keys()):
+            result[key] = None
         return result
 
     def _parse_bound(

--- a/src/paranoia_local/plan_claims.py
+++ b/src/paranoia_local/plan_claims.py
@@ -250,7 +250,7 @@ def _captured_support(record: dict[str, Any]) -> bool:
         if not isinstance(row, dict):
             continue
         index = row.get("evidence_index")
-        if not isinstance(index, int) or not 0 <= index < len(evidence):
+        if type(index) is not int or not 0 <= index < len(evidence):
             continue
         item = evidence[index]
         if (
@@ -505,7 +505,7 @@ def _validate_capture_attestations(
         if not isinstance(row, dict) or set(row) != required:
             raise ValueError("capture_attestation fields are invalid")
         index = row["evidence_index"]
-        if not isinstance(index, int) or not 0 <= index < len(evidence) or index in seen:
+        if type(index) is not int or not 0 <= index < len(evidence) or index in seen:
             raise ValueError("capture_attestation evidence_index is invalid or duplicated")
         seen.add(index)
         final_url = _one_line(row["final_url"], "capture_attestation.final_url")

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1993,7 +1993,7 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
     }
     final = artifact["final_revision_acceptance"]
     assert final["implementation_commit"] == (
-        "31149deb8570863f874ef363119064e487212cd2"
+        "ac50c479dd536ba6d3e3e2253e9af321ba62fbdb"
     )
     assert final["model_calls"] == 3
     assert final["omitted_keys"] == [[1, 0]]

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -2011,6 +2011,24 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
         "Server capture unavailable"
     )
     assert final["durable_state"]["blocked"] is True
+    invalid = artifact["invalid_attestation_acceptance"]
+    assert invalid["implementation_commit"] == (
+        "ac50c479dd536ba6d3e3e2253e9af321ba62fbdb"
+    )
+    assert invalid["expected_parser_error"] == (
+        "attestation row indices must be integers"
+    )
+    assert [row["kind"] for row in invalid["attempts"]] == [
+        "signed-in-provider", "signed-in-provider", "controlled-boolean-identity",
+    ]
+    assert invalid["durable_state"]["blocked"] is True
+    assert invalid["durable_state"]["claim_count"] == 0
+    assert invalid["durable_state"]["debt"]["raw_sha256"] == invalid[
+        "controlled_attestation_response_sha256"
+    ]
+    assert invalid["durable_state"]["debt"]["rejected_identity"] == {
+        "claim_index": True, "evidence_index": 0,
+    }
 
 
 @pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1720,6 +1720,43 @@ def test_binding_omission_survives_capture_attestation_and_reconciliation(
         adapter.close()
 
 
+def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
+    artifact = json.loads(
+        (Path(__file__).parents[1] / "docs" / "claim_binding_acceptance_2026-08-14.json")
+        .read_text(encoding="utf-8")
+    )
+    assert artifact["implementation_commit"] == (
+        "0479336c647b026f023c8ee0a1a514f1148c229a"
+    )
+    assert artifact["provider"] == {
+        "engine": "codex",
+        "cli_version": "0.144.6",
+        "model": "gpt-5.6-sol",
+        "effort": "high",
+        "web_discovery": True,
+        "binding_web_access": False,
+        "attestation_web_access": False,
+    }
+    assert artifact["claim_phase"]["counts"] == {
+        "supported": 1, "refuted": 0, "unverified": 0,
+    }
+    assert artifact["claim_phase"]["debt"] is None
+    assert artifact["claim_phase"]["claim"]["verdict"] == "supported"
+    assert len(artifact["claim_phase"]["claim"]["evidence"][
+        "captured_text_sha256"
+    ]) == 64
+    assert [row["role"] for row in artifact["attempts"]] == [
+        "claim-discovery", "claim-binding", "claim-attestation",
+    ]
+    assert all(row["outcome"] == "completed" for row in artifact["attempts"])
+    assert artifact["attempts"][0]["session_ref"] == artifact["attempts"][1][
+        "session_ref"
+    ]
+    assert artifact["durable_artifacts"]["tool_returncode"] == 0
+    assert artifact["durable_artifacts"]["tool_error"] is False
+    assert "not claimed from this live sample" in artifact["scope"]["omission_path"]
+
+
 @pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [
     (False, 124, "timed out after 420s"),
     (True, 127, "executable not found: codex"),

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1868,6 +1868,26 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
         "deleted_lines": 9,
         "net_lines": 33,
     }
+    final = artifact["final_revision_acceptance"]
+    assert final["implementation_commit"] == (
+        "31149deb8570863f874ef363119064e487212cd2"
+    )
+    assert final["model_calls"] == 3
+    assert final["omitted_keys"] == [[1, 0]]
+    assert final["capture_failed_keys"] == [[2, 0]]
+    assert [row["kind"] for row in final["attempts"]] == [
+        "signed-in-provider", "controlled-partial-binding", "signed-in-provider",
+    ]
+    assert [row["verdict"] for row in final["durable_state"]["claims"]] == [
+        "supported", "unverified", "unverified",
+    ]
+    assert final["durable_state"]["claims"][1]["location"] == (
+        "No binding row returned for captured source"
+    )
+    assert final["durable_state"]["claims"][2]["location"] == (
+        "Server capture unavailable"
+    )
+    assert final["durable_state"]["blocked"] is True
 
 
 @pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1212,6 +1212,40 @@ def test_only_server_attested_supported_packets_freeze() -> None:
     )) == 1
 
 
+def test_capture_attestation_boolean_index_cannot_parse_or_freeze() -> None:
+    evidence = [
+        _source(url="https://docs.python.org/3/whatsnew/3.11.html"),
+        _source(),
+    ]
+    attestation = {
+        "evidence_index": 1,
+        "final_url": evidence[1]["url"],
+        "text_sha256": "a" * 64,
+        "relation": "supports_claim",
+        "publisher_authority": True,
+        "authority_reason": "The publisher owns the release record.",
+        "passage_entailment": True,
+        "entailment_reason": "The passage states the release date.",
+    }
+    audit = pc.parse_audit(_audit(_claim(
+        evidence=evidence, capture_attestations=[attestation],
+    )), PLAN)
+    state = pc.reconcile(
+        {}, audit, lineage_id="capture-index", round_no=1, plan_text=PLAN,
+    )
+    record = next(iter(state["claims"].values()))
+    record["capture_attestations"][0]["evidence_index"] = True
+    assert not pc.frozen_supported_ids(
+        state, PLAN, require_capture_attestation=True,
+    )
+
+    forged = dict(attestation, evidence_index=True)
+    with pytest.raises(pc.AuditError, match="evidence_index is invalid or duplicated"):
+        pc.parse_audit(_audit(_claim(
+            evidence=evidence, capture_attestations=[forged],
+        )), PLAN)
+
+
 def test_negative_attestation_removes_exact_replacement_but_keeps_refutation(
     tmp_path: Path,
 ) -> None:
@@ -1260,6 +1294,92 @@ def test_negative_attestation_removes_exact_replacement_but_keeps_refutation(
         assert f'"proposition":"{replacement}"' in attester_prompt
     finally:
         adapter.close()
+
+
+def _run_indexed_attestation_rows(
+    tmp_path: Path, rows: list[dict[str, object]],
+) -> pc.Audit | Review:
+    second_anchor = "Python documentation also records the release date."
+    plan = PLAN + "\n" + second_anchor + "\n"
+    evidence = [
+        _source(),
+        _source(url="https://docs.python.org/3/whatsnew/3.11.html"),
+    ]
+    audit = pc.parse_audit(_audit(
+        _claim(evidence=evidence),
+        _claim(anchor=second_anchor, proposition=second_anchor, evidence=evidence),
+    ), plan)
+    response = (
+        "=== EVIDENCE ATTESTATION JSON ===\n"
+        + json.dumps({"attestations": rows})
+    )
+    engine = _RoleScript({"evidence-text": [response]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    for claim_index, claim in enumerate(audit.claims):
+        for evidence_index, item in enumerate(claim["evidence"]):
+            candidate = external_sources.CandidateSource(
+                item["url"], item["title"], item["publisher"], item["source_kind"],
+                item["authority_basis"], item["relation"],
+            )
+            adapter.captures[(claim_index, evidence_index)] = (
+                external_sources.Capture(
+                    candidate, candidate.url, 200, "text/html", "a" * 64,
+                    f"{claim_index * 2 + evidence_index + 1:064x}", item["quote"],
+                )
+            )
+    try:
+        return adapter._attest(audit, "m", "high")
+    finally:
+        adapter.close()
+
+
+def _valid_attestation_rows() -> list[dict[str, object]]:
+    return [{
+        "claim_index": claim_index,
+        "evidence_index": evidence_index,
+        "publisher_authority": True,
+        "authority_reason": "official owner",
+        "passage_entailment": True,
+        "entailment_reason": "direct statement",
+    } for claim_index in range(2) for evidence_index in range(2)]
+
+
+@pytest.mark.parametrize("field", ["claim_index", "evidence_index"])
+@pytest.mark.parametrize("invalid_index", [True, 1.0, "1", None, [], {}])
+def test_attestation_index_types_fail_before_identity_binding(
+    tmp_path: Path, field: str, invalid_index: object,
+) -> None:
+    rows = _valid_attestation_rows()
+    rows[-1][field] = invalid_index
+    result = _run_indexed_attestation_rows(tmp_path, rows)
+    assert isinstance(result, Review)
+    assert result.error
+    assert result.session_ref == "session"
+    assert "attestation row indices must be integers" in result.text
+
+
+@pytest.mark.parametrize(("case", "message"), [
+    ("unknown", "unknown or duplicate attestation row"),
+    ("duplicate", "unknown or duplicate attestation row"),
+    ("omitted", "attestation inventory differs"),
+])
+def test_attestation_identity_inventory_fails_recoverably(
+    tmp_path: Path, case: str, message: str,
+) -> None:
+    rows = _valid_attestation_rows()
+    if case == "unknown":
+        rows[-1]["claim_index"] = 9
+    elif case == "duplicate":
+        rows[-1] = dict(rows[0])
+    else:
+        rows.pop()
+    result = _run_indexed_attestation_rows(tmp_path, rows)
+    assert isinstance(result, Review)
+    assert result.error
+    assert result.session_ref == "session"
+    assert message in result.text
 
 
 def test_retained_inventory_is_corrected_before_capture(
@@ -1863,10 +1983,13 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
     }
     assert controlled["durable_state"]["blocked"] is True
     assert artifact["measurements"]["production_diff"] == {
-        "files": ["src/paranoia_local/handlers.py"],
-        "added_lines": 42,
-        "deleted_lines": 9,
-        "net_lines": 33,
+        "files": [
+            "src/paranoia_local/handlers.py",
+            "src/paranoia_local/plan_claims.py",
+        ],
+        "added_lines": 48,
+        "deleted_lines": 11,
+        "net_lines": 37,
     }
     final = artifact["final_revision_acceptance"]
     assert final["implementation_commit"] == (

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1585,7 +1585,7 @@ def test_indexed_plan_binding_defaults_omission_but_rejects_unknown_key(
         })
         assert adapter._parse_indexed_binding(omitted, batch, captures) == {
             (0, 0): ("release record", passage),
-            (0, 1): None,
+            (0, 1): handlers._OMITTED_BINDING,
         }
 
         unknown = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
@@ -1713,8 +1713,54 @@ def test_binding_omission_survives_capture_attestation_and_reconciliation(
         assert records[second_anchor]["verdict"] == "unverified"
         omitted = records[second_anchor]["evidence"][0]
         assert omitted["relation"] == "context"
-        assert omitted["location"] == "No accepted captured-text binding"
-        assert omitted["quote"] == "No accepted captured-text passage was returned."
+        assert omitted["location"] == "No binding row returned for captured source"
+        assert omitted["quote"] == "The model omitted this captured-source binding."
+        assert pc.is_blocked(state)
+    finally:
+        adapter.close()
+
+
+def test_explicit_unusable_binding_has_distinct_durable_provenance(
+    tmp_path: Path,
+) -> None:
+    discovery = pc.parse_audit(_audit(_claim()), PLAN)
+    item = discovery.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        item["quote"],
+    )}
+    binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "evidence_index": 0, "usable": False,
+            "location": None, "passage": None,
+        }],
+    })
+    engine = _RoleScript({"evidence-binding": [binding]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        audit, reviews = adapter._bind_indexed(
+            "session", discovery, captures, "m", "high", {},
+        )
+        assert len(reviews) == 1
+        state = pc.reconcile(
+            {}, audit, lineage_id="explicit-unusable", round_no=1, plan_text=PLAN,
+        )
+        record = next(iter(state["claims"].values()))
+        assert record["verdict"] == "unverified"
+        assert record["evidence"][0]["relation"] == "context"
+        assert record["evidence"][0]["location"] == (
+            "Captured source explicitly marked unusable"
+        )
+        assert record["evidence"][0]["quote"] == (
+            "No usable captured-text passage was returned."
+        )
         assert pc.is_blocked(state)
     finally:
         adapter.close()

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1800,7 +1800,30 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
     ]
     assert artifact["durable_artifacts"]["tool_returncode"] == 0
     assert artifact["durable_artifacts"]["tool_error"] is False
-    assert "not claimed from this live sample" in artifact["scope"]["omission_path"]
+    controlled = artifact["controlled_omission"]
+    assert controlled["implementation_commit"] == (
+        "8e24587536ebf624bed93b3095bcaa967198ebae"
+    )
+    assert controlled["omitted_keys"] == [[1, 0]]
+    assert [row["kind"] for row in controlled["attempts"]] == [
+        "signed-in-provider", "controlled-omission", "signed-in-provider",
+    ]
+    assert controlled["durable_state"]["supported_claim"]["verdict"] == "supported"
+    assert controlled["durable_state"]["omitted_claim"] == {
+        "claim_id": "C-01c0486e7a",
+        "verdict": "unverified",
+        "relation": "context",
+        "location": "No binding row returned for captured source",
+        "quote": "The model omitted this captured-source binding.",
+        "capture_attestations": [],
+    }
+    assert controlled["durable_state"]["blocked"] is True
+    assert artifact["measurements"]["production_diff"] == {
+        "files": ["src/paranoia_local/handlers.py"],
+        "added_lines": 35,
+        "deleted_lines": 9,
+        "net_lines": 26,
+    }
 
 
 @pytest.mark.parametrize(("correction", "returncode", "diagnostic"), [

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1766,6 +1766,50 @@ def test_explicit_unusable_binding_has_distinct_durable_provenance(
         adapter.close()
 
 
+def test_explicit_unusable_binding_preserves_capture_failure_provenance(
+    tmp_path: Path,
+) -> None:
+    discovery = pc.parse_audit(_audit(_claim()), PLAN)
+    item = discovery.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, None, None, None, None, None, None,
+        error="capture timed out\nwhile reading response",
+    )}
+    binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "evidence_index": 0, "usable": False,
+            "location": None, "passage": None,
+        }],
+    })
+    engine = _RoleScript({"evidence-binding": [binding]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        audit, reviews = adapter._bind_indexed(
+            "session", discovery, captures, "m", "high", {},
+        )
+        assert len(reviews) == 1
+        state = pc.reconcile(
+            {}, audit, lineage_id="capture-failed", round_no=1, plan_text=PLAN,
+        )
+        record = next(iter(state["claims"].values()))
+        assert record["verdict"] == "unverified"
+        assert record["evidence"][0]["relation"] == "context"
+        assert record["evidence"][0]["location"] == "Server capture unavailable"
+        assert record["evidence"][0]["quote"] == (
+            "Server capture unavailable: capture timed out while reading response"
+        )
+        assert pc.is_blocked(state)
+    finally:
+        adapter.close()
+
+
 def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
     artifact = json.loads(
         (Path(__file__).parents[1] / "docs" / "claim_binding_acceptance_2026-08-14.json")
@@ -1820,9 +1864,9 @@ def test_recorded_claim_binding_acceptance_is_narrow_and_complete() -> None:
     assert controlled["durable_state"]["blocked"] is True
     assert artifact["measurements"]["production_diff"] == {
         "files": ["src/paranoia_local/handlers.py"],
-        "added_lines": 35,
+        "added_lines": 42,
         "deleted_lines": 9,
-        "net_lines": 26,
+        "net_lines": 33,
     }
 
 

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1600,30 +1600,67 @@ def test_indexed_plan_binding_defaults_omission_but_rejects_unknown_key(
         adapter.close()
 
 
-def test_indexed_binding_omission_preserves_valid_claim_and_demotes_affected_claim(
-    tmp_path: Path,
+@pytest.mark.parametrize("field", ["claim_index", "evidence_index"])
+@pytest.mark.parametrize("invalid_index", [True, 0.0, "0", None, [], {}])
+def test_invalid_binding_index_type_uses_bounded_correction(
+    tmp_path: Path, field: str, invalid_index: object,
+) -> None:
+    discovery = pc.parse_audit(_audit(_claim()), PLAN)
+    item = discovery.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        item["quote"],
+    )}
+    invalid_row = {
+        "claim_index": 0, "evidence_index": 0, "usable": False,
+        "location": None, "passage": None,
+    }
+    invalid_row[field] = invalid_index
+    invalid = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [invalid_row],
+    })
+    corrected = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "evidence_index": 0, "usable": False,
+            "location": None, "passage": None,
+        }],
+    })
+    engine = _RoleScript({"evidence-binding": [invalid, corrected]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        audit, reviews = adapter._bind_indexed(
+            "session", discovery, captures, "m", "high", {},
+        )
+        assert len(reviews) == 2
+        assert [role for role, _ in engine.calls] == [
+            "evidence-binding", "evidence-binding",
+        ]
+        assert audit.claims[0]["verdict"] == "unverified"
+    finally:
+        adapter.close()
+
+
+def test_binding_omission_survives_capture_attestation_and_reconciliation(
+    tmp_path: Path, monkeypatch,
 ) -> None:
     second_anchor = "Python documentation also records the release date."
     plan = PLAN + "\n" + second_anchor + "\n"
-    discovery = pc.parse_audit(_audit(
+    discovery_payload = _audit(
         _claim(),
         _claim(
             anchor=second_anchor,
             proposition=second_anchor,
             evidence=[_source(url="https://docs.python.org/3/whatsnew/3.11.html")],
         ),
-    ), plan)
-    captures = {}
-    for claim_index, claim in enumerate(discovery.claims):
-        item = claim["evidence"][0]
-        candidate = external_sources.CandidateSource(
-            item["url"], item["title"], item["publisher"], item["source_kind"],
-            item["authority_basis"], item["relation"],
-        )
-        captures[(claim_index, 0)] = external_sources.Capture(
-            candidate, candidate.url, 200, "text/html", "a" * 64,
-            f"{claim_index + 1:064x}", item["quote"],
-        )
+    )
+    discovery = pc.parse_audit(discovery_payload, plan)
     passage = discovery.claims[0]["evidence"][0]["quote"]
     binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
         "bindings": [{
@@ -1631,25 +1668,54 @@ def test_indexed_binding_omission_preserves_valid_claim_and_demotes_affected_cla
             "location": "release record", "passage": passage,
         }],
     })
-    engine = _RoleScript({"evidence-binding": [binding]})
+    attestation = (
+        '=== EVIDENCE ATTESTATION JSON ===\n'
+        '{"attestations":[{"claim_index":0,"evidence_index":0,'
+        '"publisher_authority":true,"authority_reason":"official release owner",'
+        '"passage_entailment":true,"entailment_reason":"states the release date"}]}'
+    )
+    engine = _RoleScript({
+        "evidence-discovery": [discovery_payload],
+        "evidence-binding": [binding],
+        "evidence-text": [attestation],
+    })
+
+    def capture_all(candidates, **kwargs):
+        return [
+            external_sources.Capture(
+                candidate, candidate.url, 200, "text/html", "a" * 64,
+                f"{index + 1:064x}", passage,
+            )
+            for index, candidate in enumerate(candidates)
+        ]
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    ledger: list[dict] = []
     adapter = handlers._CapturedClaimEngine(
         engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+        attempt_ledger=ledger,
     )
-    adapter.binding_engine = engine.for_role("evidence-binding")
     try:
-        audit, reviews = adapter._bind_indexed(
-            "session", discovery, captures, "m", "high", {},
+        review = adapter.run("audit", tmp_path, "m", "high", True)
+        assert not review.error
+        audit = pc.parse_audit(review.text, plan)
+        state = pc.reconcile(
+            {}, audit, lineage_id="omitted-binding", round_no=1, plan_text=plan,
         )
-        assert len(reviews) == 1
-        assert [role for role, _ in engine.calls] == ["evidence-binding"]
-        assert [claim["verdict"] for claim in audit.claims] == [
-            "supported", "unverified",
+        assert [role for role, _ in engine.calls] == [
+            "evidence-discovery", "evidence-binding", "evidence-text",
         ]
-        assert audit.claims[0]["evidence"][0]["relation"] == "supports_claim"
-        assert audit.claims[1]["evidence"][0]["relation"] == "context"
-        assert audit.claims[1]["evidence"][0]["location"] == (
-            "Server capture unavailable"
-        )
+        assert [row["role"] for row in ledger] == [
+            "claim-discovery", "claim-binding", "claim-attestation",
+        ]
+        records = {row["anchor"]: row for row in state["claims"].values()}
+        assert records[PLAN.splitlines()[-1]]["verdict"] == "supported"
+        assert records[second_anchor]["verdict"] == "unverified"
+        omitted = records[second_anchor]["evidence"][0]
+        assert omitted["relation"] == "context"
+        assert omitted["location"] == "No accepted captured-text binding"
+        assert omitted["quote"] == "No accepted captured-text passage was returned."
+        assert pc.is_blocked(state)
     finally:
         adapter.close()
 

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1556,7 +1556,9 @@ def test_evidence_deadline_debt_is_persisted_before_structural_review(
     assert "CLAIM-AUDIT-DEBT" in result
 
 
-def test_indexed_plan_binding_rejects_an_omitted_source(tmp_path: Path) -> None:
+def test_indexed_plan_binding_defaults_omission_but_rejects_unknown_key(
+    tmp_path: Path,
+) -> None:
     claim = _claim(evidence=[_source(), _source(url="https://docs.python.org/3/whatsnew/3.11.html")])
     audit = pc.parse_audit(_audit(claim), PLAN)
     adapter = handlers._CapturedClaimEngine(
@@ -1574,13 +1576,80 @@ def test_indexed_plan_binding_rejects_an_omitted_source(tmp_path: Path) -> None:
                 item["quote"],
             )
         batch = adapter._binding_batches(audit, captures)[0]
-        omitted = (
-            handlers.PLAN_BINDING_MARKER
-            + '\n{"bindings":[{"claim_index":0,"evidence_index":0,'
-            '"usable":false,"location":null,"passage":null}]}'
+        passage = audit.claims[0]["evidence"][0]["quote"]
+        omitted = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+            "bindings": [{
+                "claim_index": 0, "evidence_index": 0, "usable": True,
+                "location": "release record", "passage": passage,
+            }],
+        })
+        assert adapter._parse_indexed_binding(omitted, batch, captures) == {
+            (0, 0): ("release record", passage),
+            (0, 1): None,
+        }
+
+        unknown = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+            "bindings": [{
+                "claim_index": 9, "evidence_index": 0, "usable": False,
+                "location": None, "passage": None,
+            }],
+        })
+        with pytest.raises(pc.AuditError, match="identity is invalid or duplicated"):
+            adapter._parse_indexed_binding(unknown, batch, captures)
+    finally:
+        adapter.close()
+
+
+def test_indexed_binding_omission_preserves_valid_claim_and_demotes_affected_claim(
+    tmp_path: Path,
+) -> None:
+    second_anchor = "Python documentation also records the release date."
+    plan = PLAN + "\n" + second_anchor + "\n"
+    discovery = pc.parse_audit(_audit(
+        _claim(),
+        _claim(
+            anchor=second_anchor,
+            proposition=second_anchor,
+            evidence=[_source(url="https://docs.python.org/3/whatsnew/3.11.html")],
+        ),
+    ), plan)
+    captures = {}
+    for claim_index, claim in enumerate(discovery.claims):
+        item = claim["evidence"][0]
+        candidate = external_sources.CandidateSource(
+            item["url"], item["title"], item["publisher"], item["source_kind"],
+            item["authority_basis"], item["relation"],
         )
-        with pytest.raises(pc.AuditError, match="inventory differs"):
-            adapter._parse_indexed_binding(omitted, batch, captures)
+        captures[(claim_index, 0)] = external_sources.Capture(
+            candidate, candidate.url, 200, "text/html", "a" * 64,
+            f"{claim_index + 1:064x}", item["quote"],
+        )
+    passage = discovery.claims[0]["evidence"][0]["quote"]
+    binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "evidence_index": 0, "usable": True,
+            "location": "release record", "passage": passage,
+        }],
+    })
+    engine = _RoleScript({"evidence-binding": [binding]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        audit, reviews = adapter._bind_indexed(
+            "session", discovery, captures, "m", "high", {},
+        )
+        assert len(reviews) == 1
+        assert [role for role, _ in engine.calls] == ["evidence-binding"]
+        assert [claim["verdict"] for claim in audit.claims] == [
+            "supported", "unverified",
+        ]
+        assert audit.claims[0]["evidence"][0]["relation"] == "supports_claim"
+        assert audit.claims[1]["evidence"][0]["relation"] == "context"
+        assert audit.claims[1]["evidence"][0]["location"] == (
+            "Server capture unavailable"
+        )
     finally:
         adapter.close()
 


### PR DESCRIPTION
## Summary
- treat omitted expected binding rows as distinct conservative outcomes instead of rejecting the whole batch
- preserve valid sibling bindings while demoting only claims left without qualifying evidence to unverified
- require exact integer identities across binding, cold attestation, persisted attestation validation, and freeze checks
- preserve distinct omission, explicit unusable, and server capture-failure provenance

## Validation
- complete suite: 1031 passed
- claim-verification module: 126 passed
- signed-in production acceptance covered ordinary discovery, server capture, binding, cold attestation, durable reconciliation, controlled omission, controlled capture failure, and controlled invalid attestation
- same-vendor Codex CODE round 10: 0 open classes, 3 closed, CONVERGENCE NOT-BLOCKED

Production changes are limited to +48/-11 lines across handlers.py and plan_claims.py; the larger remainder is focused regression and retained acceptance evidence.