### PR TITLE
Rekey cold finding ID collisions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -78,7 +78,11 @@ derive mirror debt, disposition, binding, and lifecycle rows deterministically, 
 canonical class engine before the single atomic state transition. Preserve every current legal
 semantic outcome, including carried-debt identity, independent new-class severity, and standalone
 class actions. Preserve stored debt IDs; allocate new IDs canonically and compare historical fresh
-V1 labels through an explicit semantic bijection. Define rejection atomicity over substantive
+V1 labels through an explicit semantic bijection. Treat fresh governing-finding labels as
+response-local: after validating response-local uniqueness and bindings, deterministically rekey
+collisions with durable historical finding IDs and rewrite every in-response reference. Historical
+updates remain debt-ID keyed; unknown, duplicate, and misbound references still reject. Define
+rejection atomicity over substantive
 review/class state while retaining required failure diagnostics. Prove historical V1/V2
 materialization equivalence, and do not ship a permissive alias normalizer, partial settlement,
 durable dual protocol, extra model call, or new persistence mechanism. A structured-output

--- a/README.md
+++ b/README.md
@@ -220,7 +220,12 @@ that survives the round.
 Tracked staged plan and branch reviews return provider-constrained semantic JSON. The model emits
 each source mapping, classification, debt outcome, class outcome, and independent class action once;
 the server validates the graph, allocates new debt IDs, derives the internal mirror rows, and applies
-class operations through the same durable class engine used by the legacy terminal register. Every
+class operations through the same durable class engine used by the legacy terminal register.
+Decision-level finding IDs are response-local references: if a cold response reuses a historical
+finding ID it was not shown, the server deterministically rekeys that fresh finding and all of its
+coverage/class references before materialization, retaining the rename in the audit settlement.
+Durable history updates remain keyed only by supplied debt IDs. Duplicate response-local IDs and
+unknown or misbound references still reject the decision. Every
 governing finding must explicitly declare whether it is a genuine one-off, a new reusable class,
 or an occurrence of an active class. Every embedded new-class definition is bound to exactly one
 finding; omission or an unbound definition rejects the settlement instead of silently treating its

--- a/docs/staged_review_protocol_v2_plan.md
+++ b/docs/staged_review_protocol_v2_plan.md
@@ -325,6 +325,13 @@ Replace the mixed `parse_settlement` path with three pure phases:
    derive source/class bindings and permitted lifecycle operations, enrich durable debt from
    governing findings, and dry-run the canonical class engine against a copied lineage.
 
+Governing-finding IDs are response-local labels, not authority over durable history. After the
+response graph has established that those labels are unique and internally bound, materialization
+rekeys any label that collides with a retained historical finding ID to the lowest unused `F<n>`
+and rewrites its coverage and `new_finding` basis references. The rename is retained in the audit
+settlement. Historical updates still name durable `debt_id` values, so rekeying cannot overwrite or
+impersonate an earlier finding. Unknown, duplicate, and misbound response references still reject.
+
 V2 owns one fresh-ID allocator: visit newly debt-bearing governing findings in their
 validated response order and assign the lowest unused `D<n>` against every retained open or
 closed durable ID. One finding receives exactly one new debt. Existing V1 debt IDs are never

--- a/src/paranoia_local/staged_protocol.py
+++ b/src/paranoia_local/staged_protocol.py
@@ -591,6 +591,16 @@ def materialize_decision_value(
     by_finding = _unique(findings, "id", "governing_findings", issues)
     if role == "final":
         _validate_coverage(value["coverage"], by_finding, issues)
+    for outcome_index, outcome in enumerate(value["class_outcomes"]):
+        basis = outcome.get("basis")
+        if (
+            basis and basis["kind"] == "new_finding"
+            and basis["finding_id"] not in by_finding
+        ):
+            issues.append(
+                f"/class_outcomes/{outcome_index}/basis/finding_id: "
+                "must name a governing finding"
+            )
     classes = {row["class_id"]: row for row in active_classes}
     if len(classes) != len(active_classes):
         issues.append("/active_classes: duplicate class_id")

--- a/src/paranoia_local/staged_protocol.py
+++ b/src/paranoia_local/staged_protocol.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import json
 import re
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Iterable, Sequence
 
@@ -492,6 +493,43 @@ def _fresh_debt_ids(count: int, reserved: set[str]) -> list[str]:
     return result
 
 
+def _rekey_finding_collisions(
+    value: dict[str, Any], historic_ids: set[str],
+) -> tuple[dict[str, Any], dict[str, str]]:
+    """Make response-local finding labels safe for durable materialization."""
+    finding_ids = [row["id"] for row in value["governing_findings"]]
+    reserved = set(finding_ids) | historic_ids
+    renamed: dict[str, str] = {}
+    candidate = 1
+    for finding_id in finding_ids:
+        if finding_id not in historic_ids:
+            continue
+        while f"F{candidate}" in reserved:
+            candidate += 1
+        replacement = f"F{candidate}"
+        candidate += 1
+        reserved.add(replacement)
+        renamed[finding_id] = replacement
+    if not renamed:
+        return value, {}
+
+    rewritten = deepcopy(value)
+    for finding in rewritten["governing_findings"]:
+        finding["id"] = renamed.get(finding["id"], finding["id"])
+    for outcome in rewritten["class_outcomes"]:
+        basis = outcome.get("basis")
+        if basis and basis["kind"] == "new_finding":
+            basis["finding_id"] = renamed.get(
+                basis["finding_id"], basis["finding_id"],
+            )
+    for coverage in rewritten.get("coverage", []):
+        coverage["finding_ids"] = [
+            renamed.get(finding_id, finding_id)
+            for finding_id in coverage["finding_ids"]
+        ]
+    return rewritten, renamed
+
+
 def class_records_from_actions(
     actions: Sequence[dict[str, Any]],
 ) -> list[dict[str, Any]]:
@@ -565,11 +603,11 @@ def materialize_decision_value(
         row.get("finding_id") for row in debt_by_id.values()
         if isinstance(row.get("finding_id"), str)
     }
-    reused = sorted(set(by_finding) & historic_finding_ids)
-    if reused:
-        issues.append(
-            f"/governing_findings: new findings reuse durable identities {reused}"
-        )
+    value, finding_id_renames = _rekey_finding_collisions(
+        value, historic_finding_ids,
+    )
+    findings = value["governing_findings"]
+    by_finding = _unique(findings, "id", "governing_findings", issues)
 
     source_rows: list[dict[str, Any]] = []
     governing_by_source: dict[str, list[str]] = {}
@@ -884,6 +922,8 @@ def materialize_decision_value(
     }
     if role == "final":
         result["coverage"] = value["coverage"]
+    if finding_id_renames:
+        result["_finding_id_renames"] = finding_id_renames
     return result
 
 

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1435,6 +1435,80 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     assert third_audit["staged_settlement"]["findings"][0]["id"] == "F1"
 
 
+def test_final_collision_audit_preserves_class_and_debt_lifecycle(
+    repo, tmp_path, monkeypatch,
+):
+    stakes = "trusted local tool"
+    state = rc.normalize_state({}, stakes=stakes, snapshot="prior")
+    state["phase"] = "final"
+    state["debt"] = [{
+        "id":"D7", "finding_id":"G1", "status":"closed", "severity":"MAJOR",
+        "summary":"historic occurrence", "evidence":["plan:1"],
+        "remedy":"historic remedy", "source_ids":[], "class_ids":["class-a"],
+        "first_round":1, "last_round":2,
+    }]
+    tracked = cc.TrackedClass(
+        class_id="class-a", invariant="the recurring invariant", severity="MAJOR",
+        first_round=1, status=cc.CLOSED, procedure="inspect the recurring path",
+    )
+    cc.save_lineage(
+        cc.default_state_root(),
+        cc.Lineage(
+            "final-collision-audit", mode=cc.PLAN_MODE,
+            classes={"class-a":tracked}, next_seq=2, rounds=2, review_state=state,
+        ),
+    )
+
+    final_finding = {
+        "id":"G1", "severity":"MAJOR", "summary":"fresh recurrence",
+        "evidence":["plan:1"], "remedy":"repair the recurrence",
+        "classification":{"kind":"existing_class", "class_id":"class-a"},
+    }
+    response = wire({
+        "role":"final", "governing_findings":[final_finding], "debt_outcomes":[],
+        "class_outcomes":[{
+            "class_id":"class-a", "verdict":"violated", "evidence":["plan:1"],
+            "basis":{"kind":"new_finding", "finding_id":"G1"},
+        }],
+        "class_actions":[{"kind":"reopen", "class_id":"class-a"}],
+        "coverage":payload(lane(findings=[final_finding]))["coverage"],
+    })
+
+    def run(self, prompt, *args, **kwargs):
+        assert '"role": "final"' in prompt
+        return Review(text=response, session_ref="final-collision", raw=response)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    result = handlers.critique_plan({
+        "plan_text":"# Plan\n\nDo it.", "repo_path":str(repo),
+        "lineage":"final-collision-audit", "round":3,
+        "claim_verification":False, "stakes":stakes,
+    }, engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs", now=lambda:"FC1")
+
+    assert "REOPEN class-a" in result
+    assert "STRUCTURAL-PHASE: correction" in result
+    audit = json.loads(next((tmp_path / "logs").glob("FC1-critique_plan-*.json")).read_text())
+    settlement = audit["staged_settlement"]
+    assert settlement["_finding_id_renames"] == {"G1":"F1"}
+    assert settlement["class_records"] == [{"op":"reopen", "class_id":"class-a"}]
+    assert settlement["findings"][0]["id"] == "F1"
+    assert settlement["debt"][0]["finding_id"] == "F1"
+
+    persisted = cc.load_lineage(
+        cc.default_state_root(), "final-collision-audit", stamp="FC2",
+        mode=cc.PLAN_MODE,
+    )
+    assert persisted.classes["class-a"].status == cc.OPEN
+    historic = next(row for row in persisted.review_state["debt"] if row["id"] == "D7")
+    fresh = next(row for row in persisted.review_state["debt"] if row["id"] != "D7")
+    assert (historic["finding_id"], historic["status"], historic["class_ids"]) == (
+        "G1", "closed", ["class-a"],
+    )
+    assert (fresh["finding_id"], fresh["status"], fresh["class_ids"]) == (
+        "F1", "open", ["class-a"],
+    )
+
+
 def test_branch_reuses_complete_census_after_settlement_rejection(
     repo_with_branch, tmp_path, monkeypatch,
 ):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1368,10 +1368,16 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
             })
         else:
             assert '"role": "final"' in prompt
+            final_finding = {
+                "id":"G1", "severity":"OUT-OF-SCOPE",
+                "summary":"advisory final observation", "evidence":["plan:1"],
+                "remedy":"retain as context",
+                "classification":{"kind":"one_off", "reason":"final-only context"},
+            }
             text = wire({
-                "role":"final", "governing_findings":[], "debt_outcomes":[],
-                "class_outcomes":[], "class_actions":[],
-                "coverage": payload(lane())["coverage"],
+                "role":"final", "governing_findings":[final_finding],
+                "debt_outcomes":[], "class_outcomes":[], "class_actions":[],
+                "coverage": payload(lane(findings=[final_finding]))["coverage"],
             })
         return Review(text=text, session_ref=f"s{len(calls)}", raw=text)
 
@@ -1425,6 +1431,8 @@ def test_plan_handler_runs_census_correction_and_cold_final(repo, tmp_path, monk
     third_audit = json.loads(next((tmp_path / "logs").glob("T3-critique_plan-*.json")).read_text())
     assert [row["role"] for row in second_audit["attempt_ledger"]] == ["correction"]
     assert [row["role"] for row in third_audit["attempt_ledger"]] == ["final"]
+    assert third_audit["staged_settlement"]["_finding_id_renames"] == {"G1":"F1"}
+    assert third_audit["staged_settlement"]["findings"][0]["id"] == "F1"
 
 
 def test_branch_reuses_complete_census_after_settlement_rejection(

--- a/tests/test_staged_protocol.py
+++ b/tests/test_staged_protocol.py
@@ -822,6 +822,53 @@ def test_finding_collision_rekeys_new_finding_class_basis():
     assert parsed["class_assessments"][0]["finding_id"] == "F1"
     assert parsed["debt"][0]["finding_id"] == "F1"
 
+    lineage = lineage_with_active(cls)
+    register = rc.register_from_records(parsed["class_records"], mechanized=False)
+    cc.apply_register(lineage, register, round_no=2)
+    assert lineage.classes["class-a"].status == cc.OPEN
+
+    state = rc.normalize_state({}, stakes="s", snapshot="before")
+    state["phase"] = "final"
+    state["debt"] = [durable_debt(status="closed")]
+    settled = rc.settle_state(
+        state, parsed, phase="final", snapshot="after", round_no=2,
+    )
+    historic = next(row for row in settled["debt"] if row["id"] == "D7")
+    fresh = next(row for row in settled["debt"] if row["id"] != "D7")
+    assert historic["finding_id"] == "old-finding"
+    assert historic["status"] == "closed"
+    assert fresh["finding_id"] == "F1"
+    assert fresh["class_ids"] == ["class-a"]
+    assert settled["phase"] == "correction"
+    assert parsed["_finding_id_renames"] == {"old-finding": "F1"}
+
+
+def test_rekey_cannot_legalize_an_originally_unknown_class_basis():
+    cls = active_class(status=cc.CLOSED)
+    value = decision(
+        "final",
+        governing_findings=[finding(
+            "old-finding",
+            classification={"kind": "existing_class", "class_id": "class-a"},
+        )],
+        coverage=coverage("old-finding"),
+        class_outcomes=[{
+            "class_id": "class-a", "verdict": "violated", "evidence": ["plan:1"],
+            "basis": {"kind": "new_finding", "finding_id": "F1"},
+        }],
+        class_actions=[{"kind": "reopen", "class_id": "class-a"}],
+    )
+
+    with pytest.raises(
+        sp.ProtocolError,
+        match=r"/class_outcomes/0/basis/finding_id: must name a governing finding",
+    ):
+        materialize(
+            value,
+            active_classes=[cls],
+            durable_debt=[durable_debt(status="closed")],
+        )
+
 
 def test_finding_collision_allocator_skips_response_and_durable_identities():
     value = decision(

--- a/tests/test_staged_protocol.py
+++ b/tests/test_staged_protocol.py
@@ -762,10 +762,82 @@ def test_final_coverage_binds_every_new_finding():
         materialize(value)
 
 
-def test_new_finding_cannot_reuse_durable_finding_identity():
-    value = decision("correction", governing_findings=[finding("old-finding")])
-    with pytest.raises(sp.ProtocolError, match="reuse durable identities"):
-        materialize(value, durable_debt=[durable_debt()])
+def test_new_finding_collision_is_rekeyed_without_changing_durable_history():
+    value = decision(
+        "correction",
+        governing_findings=[finding("old-finding")],
+        debt_outcomes=[{
+            "debt_id": "D7", "status": "closed", "evidence": ["plan:1"],
+        }],
+    )
+
+    parsed = materialize(value, durable_debt=[durable_debt()])
+
+    assert parsed["findings"][0]["id"] == "F1"
+    assert parsed["debt_updates"] == [{
+        "id": "D7", "status": "closed", "evidence": ["plan:1"],
+    }]
+    assert parsed["_finding_id_renames"] == {"old-finding": "F1"}
+
+
+def test_finding_collision_rekeys_every_response_local_reference():
+    value = decision(
+        "final",
+        governing_findings=[finding("old-finding")],
+        coverage=coverage("old-finding"),
+    )
+
+    parsed = materialize(
+        value,
+        active_classes=[],
+        durable_debt=[durable_debt(status="closed")],
+    )
+
+    assert parsed["findings"][0]["id"] == "F1"
+    assert parsed["coverage"][0]["finding_ids"] == ["F1"]
+
+
+def test_finding_collision_rekeys_new_finding_class_basis():
+    cls = active_class(status=cc.CLOSED)
+    value = decision(
+        "final",
+        governing_findings=[finding(
+            "old-finding",
+            classification={"kind": "existing_class", "class_id": "class-a"},
+        )],
+        coverage=coverage("old-finding"),
+        class_outcomes=[{
+            "class_id": "class-a", "verdict": "violated", "evidence": ["plan:1"],
+            "basis": {"kind": "new_finding", "finding_id": "old-finding"},
+        }],
+        class_actions=[{"kind": "reopen", "class_id": "class-a"}],
+    )
+
+    parsed = materialize(
+        value,
+        active_classes=[cls],
+        durable_debt=[durable_debt(status="closed")],
+    )
+
+    assert parsed["class_assessments"][0]["finding_id"] == "F1"
+    assert parsed["debt"][0]["finding_id"] == "F1"
+
+
+def test_finding_collision_allocator_skips_response_and_durable_identities():
+    value = decision(
+        "correction",
+        governing_findings=[finding("old-finding"), finding("F1")],
+    )
+
+    parsed = materialize(
+        value,
+        durable_debt=[
+            durable_debt("D7", status="closed"),
+            durable_debt("D8", cid=None, status="closed", finding_id="F2"),
+        ],
+    )
+
+    assert [row["id"] for row in parsed["findings"]] == ["F3", "F1"]
 
 
 def test_census_schema_represents_full_three_lane_aggregate_and_fanout():


### PR DESCRIPTION
Fixes the staged cold-final contradiction where a fresh response-local finding label could collide with durable history the reviewer was deliberately not shown.

The server now validates the original response graph first, deterministically rekeys only historical collisions, rewrites coverage and new-finding basis references, and retains the rename map in the staged audit. Historical updates remain exclusively debt-ID keyed; duplicate, unknown, and misbound references still reject.

Acceptance:
- 1,036 tests passed in 57.09s with isolated Git/temp configuration
- Signed-in same-vendor Codex CODE review converged in 4 rounds: 3 census lanes + consolidation, 2 corrections, 1 cold final; 7 model calls total
- Final review: 0 open classes, 0 blocking debt, CONVERGENCE: NOT-BLOCKED
- Combined handler acceptance proves audit mapping, canonical REOPEN, historical D7/G1 preservation, and fresh F1/class binding
- Production diff: +55/-5 in staged_protocol.py; largest touched production module is 956 lines (handlers.py remains 2,820 lines and is unchanged)
- Observable review-driver wall time was approximately 11.6 minutes; audit token totals: 6,778,358 input (5,925,888 cached), 39,008 output, 21,351 reasoning

Frozen stakes: trusted single operator/OS and pinned Codex/class engine; untrusted static repository/model bytes; no repository code execution or hostile local race; false clearance/history overwrite/wrong binding high impact; recoverable visible blocking acceptable.