### PR TITLE
Guide duplicate class outcome retries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,6 +41,10 @@ its source disposition to fan out to one distinct governing finding per affected
 force the reviewer to split or paraphrase the source finding merely to satisfy settlement shape.
 Every target of a repeated source must be an existing-class finding backed by its own distinct
 violated assessment citing that source; repetition must not manufacture one-off or new-class debt.
+During census consolidation, class outcomes are an exact one-row projection of the integrity lane.
+A finding from another lane may bind an existing class only when the violated integrity assessment
+cites a source consolidated into that finding; never append a second outcome or override a satisfied
+integrity assessment merely because another lane found a conceptually related defect.
 Derive the deterministic close transition when an open, unmechanized class is assessed satisfied;
 do not discard a healthy census because the model omitted that redundant lifecycle record.
 After consolidation-only failure, reuse a complete validated lane census only under exact bindings

--- a/README.md
+++ b/README.md
@@ -143,8 +143,10 @@ three-lane census, targeted correction rounds over durable debt and changed code
 broad, cold final regression before clearance. Every staged branch role retains the established
 code-review investigation, packet-use, proportionality, and warranted-web-search profile; only its
 structured output contract changes. The staged roles use closed, role-specific provider schemas,
-then the server validates the complete bounded schema and semantic graph independently. The pinned
-Codex schema subset lacks `uniqueItems`, and Claude must not receive the draft-identifying
+then the server validates the complete bounded schema and semantic graph independently. The
+consolidator projects each integrity-lane class assessment exactly once; cross-lane findings cannot
+append a second outcome or override an integrity-lane satisfaction judgement. The pinned Codex
+schema subset lacks `uniqueItems`, and Claude must not receive the draft-identifying
 `$schema` metadata. Those two non-semantic keywords are removed only from the provider projection;
 uniqueness remains mandatory in local validation, so duplicates can trigger the existing
 same-session correction but can never settle. There is no prose/marker fallback. One-shot reviews

--- a/docs/duplicate_class_outcome_acceptance_2026-08-15.json
+++ b/docs/duplicate_class_outcome_acceptance_2026-08-15.json
@@ -1,0 +1,57 @@
+{
+  "kind": "bounded-real-provider-acceptance-projection",
+  "date": "2026-08-15",
+  "engine": "codex",
+  "model": "gpt-5.6-sol",
+  "effort": "high",
+  "web_search": false,
+  "implementation_commit": "6bdae17770f31c56e62be3f9f5fb3d687e47e309",
+  "lineage": "duplicate-class-outcome-acceptance-20260815",
+  "active_class_id": "89308d49",
+  "audit": {
+    "filename": "20260815T193925-critique_branch-1f341fa7.json",
+    "sha256": "54e6dfb1b75d1e15c62f285ab1c26a82fc8389b34a42f7d3a9ef298d76221169"
+  },
+  "attempts": [
+    {"role": "census-behaviour", "outcome": "completed", "response_sha256": "0eac0a10e95a07338fddef7779ef4692b3773942e9fca8a9ebaa76149866b25c"},
+    {"role": "census-execution", "outcome": "validation-invalid", "response_sha256": "b7abb2055bcac7b030b490c58d8af753ca994ae881f48a2f282be226452c8e48"},
+    {"role": "census-integrity", "outcome": "completed", "response_sha256": "80b890cf4c8579832220d7ae71a4bb1eb2b3f3a33169ec55aaa2c1b3c602bbe6"},
+    {"role": "census-execution-validation-retry", "outcome": "completed", "response_sha256": "08ba3f33ad6acc514fbb97278477eda9e2a5eb5682105365ed91e411cbaec691"},
+    {"role": "consolidation", "outcome": "completed", "response_sha256": "90b95f63feb27c703a769952af8e0db8c915b89abdd47f91ac93fbaf6c1551f0"}
+  ],
+  "accepted_class_assessment": {
+    "class_id": "89308d49",
+    "verdict": "satisfied",
+    "evidence": [
+      "repository/src/paranoia_local/prompts.py:360-365",
+      "repository/src/paranoia_local/handlers.py:721-755",
+      "repository/src/paranoia_local/staged_protocol.py:719-766"
+    ],
+    "finding_id": null
+  },
+  "durable_result": {
+    "seeded_class_status": "closed",
+    "lineage_state_sha256": "2f5ab42b179ccdf6cc09fdf07d95461e04e045993a5b44879135103f859b170d",
+    "phase": "correction",
+    "phase_reason": "the acceptance review independently opened a test-coverage class"
+  },
+  "usage": {
+    "attempt_count": 5,
+    "input_tokens": 4837709,
+    "cached_input_tokens": 4177408,
+    "output_tokens": 26480,
+    "reasoning_output_tokens": 13107,
+    "observable_elapsed_seconds_approx": 202
+  },
+  "production_diff": {
+    "additions": 50,
+    "deletions": 2,
+    "largest_diff_module": {"path": "src/paranoia_local/staged_protocol.py", "added_lines": 37},
+    "largest_changed_module": {"path": "src/paranoia_local/handlers.py", "lines": 2827}
+  },
+  "limitations": [
+    "The real provider emitted a valid one-row consolidation; it did not exercise consolidation validation retry.",
+    "The full provider audit is represented by its hash and bounded semantic projection, not committed verbatim.",
+    "The separately retained cross-layer test owns duplicate rejection, same-session correction, audit projection, and durable settlement."
+  ]
+}

--- a/docs/staged_review_protocol_v2_acceptance.md
+++ b/docs/staged_review_protocol_v2_acceptance.md
@@ -90,6 +90,31 @@ The final durable state is phase `clear`, three historical debts all `closed`, a
 `closed`. The rejected delimiter round did not increment durable rounds or apply either attempted
 payload.
 
+### Duplicate class-outcome correction acceptance (2026-08-15)
+
+A controlled signed-in Codex branch census reviewed implementation commit `6bdae17770f31c56e62be3f9f5fb3d687e47e309`
+with active class `89308d49` seeded through the canonical class engine. The integrity lane assessed
+that class `satisfied` with three repository evidence anchors. Consolidation emitted exactly one
+outcome for the class with the identical verdict and ordered evidence, and durable settlement closed
+the seeded class. This establishes the real provider's one-row behavior at this commit; it does not
+claim that every future provider response will follow the prompt.
+
+The bounded retained projection is
+[`duplicate_class_outcome_acceptance_2026-08-15.json`](duplicate_class_outcome_acceptance_2026-08-15.json).
+The full local audit SHA-256 was `54e6dfb1b75d1e15c62f285ab1c26a82fc8389b34a42f7d3a9ef298d76221169`;
+the consolidation response SHA-256 was `90b95f63feb27c703a769952af8e0db8c915b89abdd47f91ac93fbaf6c1551f0`.
+The run made five model attempts—three lanes, one execution-lane validation retry, and
+consolidation—and used 4,837,709 input tokens (4,177,408 cached), 26,480 output tokens, and 13,107
+reasoning tokens. Observable provider wall time across the command yields was approximately 202
+seconds.
+
+At the reviewed implementation commit the production diff was 50 additions and 2 deletions across
+`handlers.py`, `prompts.py`, and `staged_protocol.py`. The largest production diff was 37 added lines
+in `staged_protocol.py`; the largest changed production module was `handlers.py` at 2,827 lines.
+The real run did not force a consolidation retry. A production-handler test now supplies a seeded
+active class and valid branch anchors, sends a duplicate/overriding consolidation response, repairs
+it on the actual same-session retry, and asserts the exact audited and durable class assessment.
+
 ## Real Claude primary lifecycle
 
 The same disposable repository and contradictory/corrected plan pair then exercised the complete

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -561,6 +561,7 @@ def _staged_structural_review(
         source_severities: dict[str, str] | None = None,
         assessment_verdicts: dict[str, str] | None = None,
         assessment_findings: dict[str, str | None] | None = None,
+        assessment_evidence: dict[str, list[str]] | None = None,
         known_debt: list[str] | None = None, role: str,
     ) -> dict[str, Any]:
         del assessment_ids, known_debt
@@ -576,6 +577,7 @@ def _staged_structural_review(
                 source_ids=source_ids, source_severities=source_severities,
                 assessment_verdicts=assessment_verdicts,
                 assessment_findings=assessment_findings,
+                assessment_evidence=assessment_evidence,
                 active_classes=active_classes,
                 durable_debt=state.get("debt", []),
             )
@@ -722,6 +724,10 @@ def _staged_structural_review(
         assessment_findings = {
             a["class_id"]: a["finding_id"] for m in manifests for a in m["class_assessments"]
         }
+        assessment_evidence = {
+            a["class_id"]: list(a["evidence"])
+            for m in manifests for a in m["class_assessments"]
+        }
         consolidation_body = json.dumps({
             "role": "census", "stakes": stakes, "manifests": manifests,
             "active_classes": active_classes,
@@ -746,6 +752,7 @@ def _staged_structural_review(
                     assessment_ids=assessment_ids,
                     assessment_verdicts=assessment_verdicts,
                     assessment_findings=assessment_findings,
+                    assessment_evidence=assessment_evidence,
                     known_debt=[
                         d["id"] for d in state.get("debt", []) if d.get("status") == "open"
                     ],

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -357,8 +357,12 @@ complete reusable definition and explicit class severity; or existing_class nami
 class. One source may fan out only to distinct existing-class findings for distinct violated
 assessments that cited it. Consolidate all occurrences of one existing class into one finding.
 
-Preserve every integrity verdict in class_outcomes. A violation uses new_finding and names the
-governing finding following its cited lane source; satisfaction has no basis. Return one
+Treat class_outcomes as an exact projection of the integrity manifest: emit exactly one row per
+active class with the same verdict and evidence. A violation uses new_finding and names the one
+governing finding that includes its cited integrity source; satisfaction has no basis and must not
+gain a second outcome from another lane. A cross-lane finding may classify as existing_class only
+when that class's integrity assessment is violated and its cited source is included; otherwise
+classify the finding as one_off or new_class. Return one
 debt_outcome for every supplied open debt: open needs current evidence and a concrete remaining
 condition; closed needs current evidence. Do not invent debt or IDs. Use class_actions only for an
 independent lifecycle/severity decision. Closed mechanized violation requires replace with a

--- a/src/paranoia_local/staged_protocol.py
+++ b/src/paranoia_local/staged_protocol.py
@@ -669,6 +669,21 @@ def materialize_decision_value(
                 )
                 finding_class[finding["id"]] = None
                 continue
+            if role == "census":
+                expected_verdict = (assessment_verdicts or {}).get(cid)
+                cited_source = (assessment_findings or {}).get(cid)
+                if expected_verdict != "violated":
+                    issues.append(
+                        f"/governing_findings/{finding_index}/classification/class_id: "
+                        f"cannot target active class {cid!r}; its integrity assessment "
+                        f"verdict is {expected_verdict!r}, so reclassify this finding"
+                    )
+                elif cited_source not in finding.get("source_ids", []):
+                    issues.append(
+                        f"/governing_findings/{finding_index}/source_ids: existing class "
+                        f"{cid!r} requires its cited violated integrity source "
+                        f"{cited_source!r}"
+                    )
             if cid in existing_findings:
                 issues.append(
                     f"/governing_findings: multiple findings classify to active class {cid!r}"
@@ -700,6 +715,17 @@ def materialize_decision_value(
         row["class_id"]: f"/class_outcomes/{index}"
         for index, row in reversed(list(enumerate(value["class_outcomes"])))
     }
+    seen_outcomes: set[str] = set()
+    for outcome_index, outcome in enumerate(value["class_outcomes"]):
+        cid = outcome["class_id"]
+        if cid in seen_outcomes and role == "census":
+            expected_verdict = (assessment_verdicts or {}).get(cid)
+            issues.append(
+                f"/class_outcomes/{outcome_index}: duplicate class outcome for {cid!r}; "
+                "emit exactly one census projection preserving integrity verdict "
+                f"{expected_verdict!r}"
+            )
+        seen_outcomes.add(cid)
     outcomes = _unique(
         value["class_outcomes"], "class_id", "class_outcomes", issues,
     )

--- a/src/paranoia_local/staged_protocol.py
+++ b/src/paranoia_local/staged_protocol.py
@@ -582,6 +582,7 @@ def materialize_decision_value(
     source_ids: Sequence[str] = (), source_severities: dict[str, str] | None = None,
     assessment_verdicts: dict[str, str] | None = None,
     assessment_findings: dict[str, str | None] | None = None,
+    assessment_evidence: dict[str, Sequence[str]] | None = None,
     active_classes: Sequence[dict[str, Any]] = (),
     durable_debt: Sequence[dict[str, Any]] = (),
 ) -> dict[str, Any]:
@@ -755,6 +756,14 @@ def materialize_decision_value(
         ):
             issues.append(
                 f"{outcome_pointer}/verdict: must preserve integrity-lane verdict"
+            )
+        expected_evidence = (assessment_evidence or {}).get(cid)
+        if role == "census" and expected_evidence is not None and (
+            outcome["evidence"] != list(expected_evidence)
+        ):
+            issues.append(
+                f"{outcome_pointer}/evidence: must exactly preserve "
+                "integrity-lane evidence"
             )
         target: str | None = None
         if outcome["verdict"] == "violated":
@@ -968,6 +977,7 @@ def materialize_decision(
     source_ids: Sequence[str] = (), source_severities: dict[str, str] | None = None,
     assessment_verdicts: dict[str, str] | None = None,
     assessment_findings: dict[str, str | None] | None = None,
+    assessment_evidence: dict[str, Sequence[str]] | None = None,
     active_classes: Sequence[dict[str, Any]] = (),
     durable_debt: Sequence[dict[str, Any]] = (),
 ) -> dict[str, Any]:
@@ -978,5 +988,6 @@ def materialize_decision(
         source_severities=source_severities,
         assessment_verdicts=assessment_verdicts,
         assessment_findings=assessment_findings,
+        assessment_evidence=assessment_evidence,
         active_classes=active_classes, durable_debt=durable_debt,
     )

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -548,7 +548,7 @@ def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_p
         "class_outcomes": [
             {
                 "class_id": "class-a", "verdict": "satisfied",
-                "evidence": ["plan:1"],
+                "evidence": ["plan:2"],
             },
             {
                 "class_id": "class-a", "verdict": "violated",
@@ -562,6 +562,7 @@ def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_p
         "kind": "one_off", "reason": "not the satisfied active class",
     }
     corrected["class_outcomes"] = corrected["class_outcomes"][:1]
+    corrected["class_outcomes"][0]["evidence"] = ["plan:1"]
     retry_prompts = []
 
     def parser(text):
@@ -573,6 +574,7 @@ def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_p
                 source_severities={"execution:F1": "MAJOR"},
                 assessment_verdicts={"class-a": "satisfied"},
                 assessment_findings={"class-a": None},
+                assessment_evidence={"class-a": ["plan:1"]},
                 active_classes=active,
             )
         except sp.ProtocolError as exc:
@@ -606,6 +608,7 @@ def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_p
     guidance = retry_prompts[0]
     assert "emit exactly one census projection preserving integrity verdict 'satisfied'" in guidance
     assert "its integrity assessment verdict is 'satisfied', so reclassify this finding" in guidance
+    assert "/class_outcomes/0/evidence: must exactly preserve integrity-lane evidence" in guidance
 
 
 def test_terminal_correction_validation_retains_extracted_replies(tmp_path):

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -530,6 +530,84 @@ def test_staged_validation_retry_timeout_is_not_validation_debt(tmp_path):
     assert not handlers._cacheable_consolidation_error(caught.value)
 
 
+def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_path):
+    active = [{
+        "class_id": "class-a", "invariant": "class invariant", "severity": "MAJOR",
+        "status": "open", "mechanized": False, "pattern": None,
+        "pathspec": None, "procedure": "inspect the class",
+    }]
+    finding_row = {
+        "id": "execution:F1", "severity": "MAJOR", "summary": "cross-lane defect",
+        "evidence": ["plan:1"], "remedy": "repair the defect",
+        "source_ids": ["execution:F1"],
+        "classification": {"kind": "existing_class", "class_id": "class-a"},
+    }
+    invalid = {
+        "role": "census", "governing_findings": [finding_row],
+        "debt_outcomes": [], "class_actions": [],
+        "class_outcomes": [
+            {
+                "class_id": "class-a", "verdict": "satisfied",
+                "evidence": ["plan:1"],
+            },
+            {
+                "class_id": "class-a", "verdict": "violated",
+                "evidence": ["plan:1"],
+                "basis": {"kind": "new_finding", "finding_id": "execution:F1"},
+            },
+        ],
+    }
+    corrected = json.loads(json.dumps(invalid))
+    corrected["governing_findings"][0]["classification"] = {
+        "kind": "one_off", "reason": "not the satisfied active class",
+    }
+    corrected["class_outcomes"] = corrected["class_outcomes"][:1]
+    retry_prompts = []
+
+    def parser(text):
+        value = sp.decode_decision(text, mode=cc.BRANCH_MODE, role="census")
+        try:
+            return sp.materialize_decision_value(
+                value, mode=cc.BRANCH_MODE, role="census",
+                source_ids=["execution:F1"],
+                source_severities={"execution:F1": "MAJOR"},
+                assessment_verdicts={"class-a": "satisfied"},
+                assessment_findings={"class-a": None},
+                active_classes=active,
+            )
+        except sp.ProtocolError as exc:
+            raise rc.CensusError(str(exc)) from exc
+
+    class Engine:
+        name = "fake"
+
+        def run(self, *args, **kwargs):
+            text = wire(invalid)
+            return Review(text=text, session_ref="session", raw=text)
+
+        def resume(self, session_ref, prompt, *args, **kwargs):
+            assert session_ref == "session"
+            retry_prompts.append(prompt)
+            text = wire(corrected)
+            return Review(text=text, session_ref="session", raw=text)
+
+    _, parsed, attempts = handlers._staged_call(
+        role="consolidation", engine=Engine(), prompt="consolidate", cwd=tmp_path,
+        model="m", effort="high", timeout=1200, on_progress=None, parser=parser,
+    )
+
+    assert parsed["class_assessments"] == [{
+        "class_id": "class-a", "verdict": "satisfied",
+        "evidence": ["plan:1"], "finding_id": None,
+    }]
+    assert [attempt.outcome for attempt in attempts] == [
+        "validation-invalid", "completed",
+    ]
+    guidance = retry_prompts[0]
+    assert "emit exactly one census projection preserving integrity verdict 'satisfied'" in guidance
+    assert "its integrity assessment verdict is 'satisfied', so reclassify this finding" in guidance
+
+
 def test_terminal_correction_validation_retains_extracted_replies(tmp_path):
     invalid = payload(settlement())
     invalid.update(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -611,6 +611,109 @@ def test_duplicate_class_outcome_retry_receives_actionable_semantic_repair(tmp_p
     assert "/class_outcomes/0/evidence: must exactly preserve integrity-lane evidence" in guidance
 
 
+def test_branch_census_retry_preserves_seeded_integrity_outcome_durably(
+    repo_with_branch, tmp_path, monkeypatch,
+):
+    lineage_id = "active-class-census-retry"
+    lineage = cc.Lineage(lineage_id, mode=cc.BRANCH_MODE)
+    class_id = cc.apply_register(
+        lineage,
+        cc.Register(new_classes=(cc.NewClass(
+            "class outcomes preserve integrity evidence", "MAJOR",
+            procedure="inspect consolidation",
+        ),)),
+        round_no=0,
+    )[0]
+    cc.save_lineage(cc.default_state_root(), lineage)
+    anchor = "repository/README.md:1"
+    invalid = {
+        "role": "census",
+        "governing_findings": [{
+            "id": "behaviour:F1", "severity": "OUT-OF-SCOPE",
+            "summary": "separate advisory", "evidence": [anchor],
+            "remedy": "retain as context", "source_ids": ["behaviour:F1"],
+            "classification": {"kind": "existing_class", "class_id": class_id},
+        }],
+        "debt_outcomes": [], "class_actions": [],
+        "class_outcomes": [
+            {"class_id": class_id, "verdict": "satisfied", "evidence": [anchor]},
+            {
+                "class_id": class_id, "verdict": "violated", "evidence": [anchor],
+                "basis": {"kind": "new_finding", "finding_id": "behaviour:F1"},
+            },
+        ],
+    }
+    corrected = json.loads(json.dumps(invalid))
+    corrected["governing_findings"][0]["classification"] = {
+        "kind": "one_off", "reason": "separate from the satisfied class",
+    }
+    corrected["class_outcomes"] = corrected["class_outcomes"][:1]
+    retry_prompts = []
+
+    def run(self, prompt, *args, **kwargs):
+        if prompts.STAGED_CENSUS_INSTRUCTIONS.splitlines()[0] in prompt:
+            lane_name = next(
+                row.split()[-1] for row in prompt.splitlines()
+                if row.startswith("ROLE: census lane")
+            )
+            findings = []
+            assessments = []
+            if lane_name == "behaviour":
+                findings = [{
+                    "id": "F1", "severity": "OUT-OF-SCOPE",
+                    "summary": "separate advisory", "evidence": [anchor],
+                    "remedy": "retain as context",
+                }]
+            if lane_name == "integrity":
+                assessments = [{
+                    "class_id": class_id, "verdict": "satisfied",
+                    "evidence": [anchor], "finding_id": None,
+                }]
+            value = payload(lane(lane_name, findings=findings, assessments=assessments))
+            for coverage_row in value["coverage"]:
+                coverage_row["evidence"] = [anchor]
+            text = wire(value)
+        else:
+            text = wire(invalid)
+        return Review(text=text, session_ref="active-session", raw=text)
+
+    def resume(self, session_ref, prompt, *args, **kwargs):
+        assert session_ref == "active-session"
+        retry_prompts.append(prompt)
+        text = wire(corrected)
+        return Review(text=text, session_ref=session_ref, raw=text)
+
+    monkeypatch.setattr(handlers.eng.CodexEngine, "run", run)
+    monkeypatch.setattr(handlers.eng.CodexEngine, "resume", resume)
+    result = handlers.critique_branch(
+        {
+            "repo_path": str(repo_with_branch), "base_ref": "main",
+            "head_ref": "feature", "lineage": lineage_id, "round": 1,
+            "stakes": "trusted local tool",
+        },
+        engine=handlers.eng.CodexEngine(), log_dir=tmp_path / "logs",
+        now=lambda: "ACTIVE",
+    )
+
+    assert "CONVERGENCE: NOT-BLOCKED" in result
+    assert "emit exactly one census projection" in retry_prompts[0]
+    audit = json.loads(
+        next((tmp_path / "logs").glob("ACTIVE-critique_branch-*.json")).read_text()
+    )
+    assert [row["role"] for row in audit["attempt_ledger"]][-2:] == [
+        "consolidation", "consolidation-validation-retry",
+    ]
+    assert audit["staged_settlement"]["class_assessments"] == [{
+        "class_id": class_id, "verdict": "satisfied",
+        "evidence": [anchor], "finding_id": None,
+    }]
+    settled = cc.load_lineage(
+        cc.default_state_root(), lineage_id, stamp="after", mode=cc.BRANCH_MODE,
+    )
+    assert settled.classes[class_id].status == cc.CLOSED
+    assert settled.review_state["phase"] == "clear"
+
+
 def test_terminal_correction_validation_retains_extracted_replies(tmp_path):
     invalid = payload(settlement())
     invalid.update(

--- a/tests/test_staged_protocol.py
+++ b/tests/test_staged_protocol.py
@@ -8,6 +8,7 @@ import pytest
 from jsonschema import Draft202012Validator
 
 from paranoia_local import class_closure as cc
+from paranoia_local import prompts
 from paranoia_local import review_census as rc
 from paranoia_local import staged_protocol as sp
 
@@ -754,6 +755,54 @@ def test_source_fanout_requires_distinct_cited_existing_classes():
         active_classes=classes,
     )
     assert len(parsed["debt"]) == 2
+
+
+def test_census_duplicate_outcome_names_integrity_projection_repair():
+    value = decision(
+        "census",
+        governing_findings=[finding(
+            fid="execution:F1", source_ids=["execution:F1"],
+            classification={"kind": "existing_class", "class_id": "class-a"},
+        )],
+        class_outcomes=[
+            {
+                "class_id": "class-a", "verdict": "satisfied",
+                "evidence": ["plan:1"],
+            },
+            {
+                "class_id": "class-a", "verdict": "violated",
+                "evidence": ["plan:2"],
+                "basis": {"kind": "new_finding", "finding_id": "execution:F1"},
+            },
+        ],
+    )
+
+    with pytest.raises(sp.ProtocolError) as caught:
+        materialize(
+            value,
+            source_ids=["execution:F1"],
+            source_severities={"execution:F1": "MAJOR"},
+            assessment_verdicts={"class-a": "satisfied"},
+            assessment_findings={"class-a": None},
+            active_classes=[active_class()],
+        )
+
+    message = str(caught.value)
+    assert (
+        "/governing_findings/0/classification/class_id: cannot target active class "
+        "'class-a'; its integrity assessment verdict is 'satisfied', so reclassify "
+        "this finding"
+    ) in message
+    assert (
+        "/class_outcomes/1: duplicate class outcome for 'class-a'; emit exactly one "
+        "census projection preserving integrity verdict 'satisfied'"
+    ) in message
+
+
+def test_consolidation_prompt_forbids_cross_lane_duplicate_class_outcomes():
+    contract = " ".join(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS.split())
+    assert "exact projection of the integrity manifest" in contract
+    assert "must not gain a second outcome from another lane" in contract
 
 
 def test_final_coverage_binds_every_new_finding():

--- a/tests/test_staged_protocol.py
+++ b/tests/test_staged_protocol.py
@@ -799,6 +799,24 @@ def test_census_duplicate_outcome_names_integrity_projection_repair():
     ) in message
 
 
+def test_census_outcome_must_preserve_integrity_evidence_exactly():
+    value = decision("census", class_outcomes=[{
+        "class_id": "class-a", "verdict": "satisfied", "evidence": ["plan:2"],
+    }])
+
+    with pytest.raises(
+        sp.ProtocolError,
+        match=r"/class_outcomes/0/evidence: must exactly preserve integrity-lane evidence",
+    ):
+        materialize(
+            value,
+            assessment_verdicts={"class-a": "satisfied"},
+            assessment_findings={"class-a": None},
+            assessment_evidence={"class-a": ["plan:1"]},
+            active_classes=[active_class()],
+        )
+
+
 def test_consolidation_prompt_forbids_cross_lane_duplicate_class_outcomes():
     contract = " ".join(prompts.STAGED_CONSOLIDATION_INSTRUCTIONS.split())
     assert "exact projection of the integrity manifest" in contract


### PR DESCRIPTION
Fixes the staged census failure where consolidation repeats a satisfied integrity outcome with a second violated outcome for the same class.\n\nThe fix preserves fail-closed semantics: class outcomes are an exact one-row projection of the integrity manifest, and a cross-lane finding cannot override a satisfied class. Pointer-addressed diagnostics tell the existing same-session retry to remove the duplicate and reclassify the unrelated finding. Census verdict and evidence are both bound exactly.\n\nValidation:\n- focused staged protocol and handler suites: 127 passed\n- full suite: 1041 passed in 61.45s\n- signed-in Codex active-class census retained in the bounded acceptance artifact\n- same-vendor Codex CODE convergence: NOT-BLOCKED after broad final\n\nThis intentionally does not merge contradictory outcomes or partially settle a malformed round.