### PR TITLE
Accept provider CLIs at or above supported minimums

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -156,7 +156,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   Claude discovery must both expose and allow only `WebSearch`; repository evidence may expose
   and allow only `Read,Grep,Glob`; binding and text evidence roles must remain tool-less. A
   permission denial of a tool required by the active evidence role is an execution failure, not
-  an unverified-claim result.
+  an unverified-claim result. Treat the accepted Codex and Claude CLI versions as minimums, not
+  exact pins: permit later versions and let unsupported flags/tools, missing structured output, or
+  other real capability failures block visibly.
   Treat the final redirect URL as governing UGC/self-source eligibility and persist capture
   digests plus cold authority/entailment decisions before support may freeze.
   Validate retained inventory before capture; attest replacement wording as its own exact

--- a/README.md
+++ b/README.md
@@ -713,7 +713,8 @@ Evidence roles require Codex CLI 0.144.6 or later and Claude Code 2.1.197 or lat
 are accepted; compatibility is then checked by the real call, so unsupported flags or tools,
 permission denial, missing structured output, and malformed provider envelopes remain visible
 blocking failures.
-Signed-in compatibility probes of later Claude and Codex releases are recorded in
+Signed-in structured probes and complete verified-plan lifecycles on later Claude and Codex
+releases are recorded in
 [`docs/minimum_provider_cli_acceptance_2026-08-16.json`](docs/minimum_provider_cli_acceptance_2026-08-16.json).
 The signed-in end-to-end record, including exact versions, packet digest, source references,
 plan-claim closure, repository-only closure, and defects found by the first real runs, is

--- a/README.md
+++ b/README.md
@@ -713,6 +713,8 @@ Evidence roles require Codex CLI 0.144.6 or later and Claude Code 2.1.197 or lat
 are accepted; compatibility is then checked by the real call, so unsupported flags or tools,
 permission denial, missing structured output, and malformed provider envelopes remain visible
 blocking failures.
+Signed-in compatibility probes of later Claude and Codex releases are recorded in
+[`docs/minimum_provider_cli_acceptance_2026-08-16.json`](docs/minimum_provider_cli_acceptance_2026-08-16.json).
 The signed-in end-to-end record, including exact versions, packet digest, source references,
 plan-claim closure, repository-only closure, and defects found by the first real runs, is
 [`docs/evidence_capture_acceptance_2026-08-10.json`](docs/evidence_capture_acceptance_2026-08-10.json).

--- a/README.md
+++ b/README.md
@@ -34,9 +34,9 @@ structured critique.
 **1. Prerequisites**
 
 - Python 3.11+ and `git` on `PATH`
-- The reviewing agent's CLI, installed and signed in on a subscription:
-  [Codex CLI](https://developers.openai.com/codex) (`codex`, ≥ 0.144) **or**
-  [Claude Code](https://code.claude.com) (`claude`)
+- The reviewing agent's stable CLI, installed and signed in on a subscription:
+  [Codex CLI](https://developers.openai.com/codex) (`codex`, ≥ 0.144.6) **or**
+  [Claude Code](https://code.claude.com) (`claude`, ≥ 2.1.197)
 - `arbitrate` needs **both** CLIs; the four review tools need only the other one
 
 **2. Install**

--- a/README.md
+++ b/README.md
@@ -709,6 +709,10 @@ Claude evidence roles use matching
 availability and permission allowlists on fresh and resumed calls; denial of a tool required by
 the active role is a visible provider-capability failure, never an empty-search success. Binding
 and text roles use explicit empty allowlists. Only server-captured packets can affect substantiation.
+Evidence roles require Codex CLI 0.144.6 or later and Claude Code 2.1.197 or later. Newer versions
+are accepted; compatibility is then checked by the real call, so unsupported flags or tools,
+permission denial, missing structured output, and malformed provider envelopes remain visible
+blocking failures.
 The signed-in end-to-end record, including exact versions, packet digest, source references,
 plan-claim closure, repository-only closure, and defects found by the first real runs, is
 [`docs/evidence_capture_acceptance_2026-08-10.json`](docs/evidence_capture_acceptance_2026-08-10.json).

--- a/docs/minimum_provider_cli_acceptance_2026-08-16.json
+++ b/docs/minimum_provider_cli_acceptance_2026-08-16.json
@@ -1,8 +1,36 @@
 {
   "acceptance_kind": "minimum-provider-cli-version-compatibility",
   "date": "2026-08-16",
-  "model_call_count": 2,
+  "model_call_count": 11,
   "operating_model": "One trusted local operator and OS; provider output is untrusted data; correctness and reachable compatibility failures only.",
+  "primary_lifecycles": [
+    {
+      "audit_sha256": "a9b9d862d0661aecf823e2241730148e7f97b5b065aaf65954a6ac98940eaad2",
+      "claim_counts": {"refuted": 0, "supported": 1, "unverified": 0},
+      "claim_duration_ms": 32013,
+      "claim_model_calls": 4,
+      "cli": "claude",
+      "elapsed_seconds_observed": 100.49,
+      "engine_error": false,
+      "engine_returncode": 0,
+      "outcome": "claim closure succeeded",
+      "structural_model_calls": 1,
+      "tested_version": "2.1.233"
+    },
+    {
+      "audit_sha256": "dcebd6e2e95e0c75e39b58984f57ee77a2292a16dd45e063ef3f80b705fb21b7",
+      "claim_counts": {"refuted": 0, "supported": 1, "unverified": 1},
+      "claim_duration_ms": 92257,
+      "claim_model_calls": 3,
+      "cli": "codex",
+      "elapsed_seconds_observed": 230.94,
+      "engine_error": false,
+      "engine_returncode": 0,
+      "outcome": "visible fail-closed capture limit after complete claim lifecycle",
+      "structural_model_calls": 1,
+      "tested_version": "0.147.0"
+    }
+  ],
   "probes": [
     {
       "cli": "claude",
@@ -40,5 +68,6 @@
     "claude_package": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
     "codex_package": "https://www.npmjs.com/package/@openai/codex"
   },
+  "structured_probe_model_calls": 2,
   "version": 1
 }

--- a/docs/minimum_provider_cli_acceptance_2026-08-16.json
+++ b/docs/minimum_provider_cli_acceptance_2026-08-16.json
@@ -1,0 +1,44 @@
+{
+  "acceptance_kind": "minimum-provider-cli-version-compatibility",
+  "date": "2026-08-16",
+  "model_call_count": 2,
+  "operating_model": "One trusted local operator and OS; provider output is untrusted data; correctness and reachable compatibility failures only.",
+  "probes": [
+    {
+      "cli": "claude",
+      "elapsed_seconds_observed": 1.3,
+      "effort": "high",
+      "minimum_version": "2.1.197",
+      "model": "sonnet",
+      "profile": "evidence-text",
+      "response": {"status": "compatible"},
+      "returncode": 0,
+      "session_ref": "79c1396e-6f7d-43a5-ba26-49fee8d063f7",
+      "tested_version": "2.1.233"
+    },
+    {
+      "cli": "codex",
+      "elapsed_seconds_observed": 4.1,
+      "effort": "high",
+      "minimum_version": "0.144.6",
+      "model": "gpt-5.6-sol",
+      "profile": "evidence-text",
+      "response": {"status": "compatible"},
+      "returncode": 0,
+      "session_ref": "01a00ba8-e2f6-7a02-877c-68b71518342a",
+      "tested_version": "0.147.0"
+    }
+  ],
+  "schema": {
+    "additionalProperties": false,
+    "properties": {"status": {"enum": ["compatible"], "type": "string"}},
+    "required": ["status"],
+    "type": "object"
+  },
+  "sources": {
+    "claude_cli_reference": "https://code.claude.com/docs/en/cli-reference",
+    "claude_package": "https://www.npmjs.com/package/@anthropic-ai/claude-code",
+    "codex_package": "https://www.npmjs.com/package/@openai/codex"
+  },
+  "version": 1
+}

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -35,8 +35,8 @@ ROLE_REPOSITORY = "evidence-repository"
 ROLE_TEXT = "evidence-text"
 EVIDENCE_ROLES = frozenset({ROLE_DISCOVERY, ROLE_BINDING, ROLE_REPOSITORY, ROLE_TEXT})
 
-SUPPORTED_CODEX_VERSION = "0.144.6"
-SUPPORTED_CLAUDE_VERSION = "2.1.197"
+MIN_CODEX_VERSION = (0, 144, 6)
+MIN_CLAUDE_VERSION = (2, 1, 197)
 
 CODEX_EXTERNAL_FEATURES = (
     "apps", "browser_use", "browser_use_external", "browser_use_full_cdp_access",
@@ -590,27 +590,29 @@ def all_engines() -> tuple[Engine, ...]:
     return tuple(cls() for cls in _ENGINES.values())
 
 
-def _cli_version(binary: str) -> str:
+def _cli_version(binary: str) -> tuple[int, int, int]:
     result = subprocess.run([binary, "--version"], capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"cannot run {binary} --version: {result.stderr.strip()}")
-    match = re.search(r"(\d+\.\d+\.\d+)", result.stdout)
+    match = re.search(r"(\d+)\.(\d+)\.(\d+)", result.stdout)
     if not match:
         raise RuntimeError(f"cannot parse {binary} version from {result.stdout.strip()!r}")
-    return match.group(1)
+    return tuple(int(part) for part in match.groups())
 
 
 def require_evidence_profile(engine: Engine) -> str:
-    expected = {
-        "codex": SUPPORTED_CODEX_VERSION,
-        "claude": SUPPORTED_CLAUDE_VERSION,
+    minimum = {
+        "codex": MIN_CODEX_VERSION,
+        "claude": MIN_CLAUDE_VERSION,
     }.get(engine.name)
-    if expected is None:
+    if minimum is None:
         raise RuntimeError(f"no evidence profile for engine {engine.name!r}")
     actual = _cli_version(engine.binary)
-    if actual != expected:
+    if actual < minimum:
+        minimum_text = ".".join(str(part) for part in minimum)
+        actual_text = ".".join(str(part) for part in actual)
         raise RuntimeError(
-            f"{engine.name} evidence mode supports CLI {expected}; found {actual}. "
-            "Install the supported version or add and accept a new explicit profile."
+            f"{engine.name} evidence mode requires CLI >= {minimum_text}; "
+            f"found {actual_text}. Install a supported version."
         )
-    return actual
+    return ".".join(str(part) for part in actual)

--- a/src/paranoia_local/engines.py
+++ b/src/paranoia_local/engines.py
@@ -594,10 +594,19 @@ def _cli_version(binary: str) -> tuple[int, int, int]:
     result = subprocess.run([binary, "--version"], capture_output=True, text=True)
     if result.returncode != 0:
         raise RuntimeError(f"cannot run {binary} --version: {result.stderr.strip()}")
-    match = re.search(r"(\d+)\.(\d+)\.(\d+)", result.stdout)
+    match = re.search(
+        r"(?<![\d.])(\d+)\.(\d+)\.(\d+)([-+][0-9A-Za-z.-]+)?",
+        result.stdout,
+    )
     if not match:
         raise RuntimeError(f"cannot parse {binary} version from {result.stdout.strip()!r}")
-    return tuple(int(part) for part in match.groups())
+    qualifier = match.group(4) or ""
+    if qualifier.startswith("-"):
+        raise RuntimeError(
+            f"{binary} evidence mode does not support prerelease CLI versions; "
+            f"found {match.group(0)}"
+        )
+    return tuple(int(part) for part in match.groups()[:3])
 
 
 def require_evidence_profile(engine: Engine) -> str:

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -1,4 +1,5 @@
 import json
+import re
 from pathlib import Path
 
 import pytest
@@ -43,6 +44,52 @@ class TestFactory:
     def test_default_models(self) -> None:
         assert "gpt-5.6" in engines.get_engine("codex").default_model
         assert "fable" in engines.get_engine("claude").default_model
+
+
+@pytest.mark.parametrize(
+    ("engine", "version", "rendered"),
+    [
+        (engines.CodexEngine(), (0, 144, 6), "0.144.6"),
+        (engines.CodexEngine(), (0, 145, 0), "0.145.0"),
+        (engines.ClaudeEngine(), (2, 1, 197), "2.1.197"),
+        (engines.ClaudeEngine(), (2, 1, 220), "2.1.220"),
+        (engines.ClaudeEngine(), (3, 0, 0), "3.0.0"),
+    ],
+)
+def test_evidence_profile_accepts_minimum_and_later_versions(
+    monkeypatch, engine, version, rendered,
+) -> None:
+    monkeypatch.setattr(engines, "_cli_version", lambda binary: version)
+
+    assert engines.require_evidence_profile(engine) == rendered
+
+
+@pytest.mark.parametrize(
+    ("engine", "version", "minimum"),
+    [
+        (engines.CodexEngine(), (0, 144, 5), "0.144.6"),
+        (engines.ClaudeEngine(), (2, 1, 196), "2.1.197"),
+    ],
+)
+def test_evidence_profile_rejects_only_versions_below_minimum(
+    monkeypatch, engine, version, minimum,
+) -> None:
+    monkeypatch.setattr(engines, "_cli_version", lambda binary: version)
+
+    with pytest.raises(RuntimeError, match=rf">= {re.escape(minimum)}"):
+        engines.require_evidence_profile(engine)
+
+
+def test_cli_version_is_compared_numerically(monkeypatch) -> None:
+    monkeypatch.setattr(
+        engines.subprocess,
+        "run",
+        lambda *args, **kwargs: RunResult(
+            returncode=0, stdout="Claude Code 2.10.3\n", stderr="",
+        ),
+    )
+
+    assert engines._cli_version("claude") == (2, 10, 3)
 
 
 def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -92,6 +92,35 @@ def test_cli_version_is_compared_numerically(monkeypatch) -> None:
     assert engines._cli_version("claude") == (2, 10, 3)
 
 
+@pytest.mark.parametrize(
+    "reported",
+    ["claude 2.1.197-alpha.1", "codex-cli 0.144.6-beta"],
+)
+def test_cli_version_rejects_prereleases(monkeypatch, reported) -> None:
+    monkeypatch.setattr(
+        engines.subprocess,
+        "run",
+        lambda *args, **kwargs: RunResult(
+            returncode=0, stdout=reported, stderr="",
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="does not support prerelease"):
+        engines._cli_version("provider")
+
+
+def test_cli_version_accepts_build_metadata(monkeypatch) -> None:
+    monkeypatch.setattr(
+        engines.subprocess,
+        "run",
+        lambda *args, **kwargs: RunResult(
+            returncode=0, stdout="claude 2.1.197+native.4", stderr="",
+        ),
+    )
+
+    assert engines._cli_version("claude") == (2, 1, 197)
+
+
 def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:
     review = engines.CodexEngine().parse_output(
         '{"type":"thread.started","thread_id":"recovered"}\n'

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -121,6 +121,27 @@ def test_cli_version_accepts_build_metadata(monkeypatch) -> None:
     assert engines._cli_version("claude") == (2, 1, 197)
 
 
+def test_minimum_provider_cli_acceptance_binds_later_real_versions() -> None:
+    artifact = json.loads(
+        (
+            Path(__file__).resolve().parents[1]
+            / "docs/minimum_provider_cli_acceptance_2026-08-16.json"
+        ).read_text()
+    )
+    assert artifact["model_call_count"] == 2
+    minimums = {
+        "codex": engines.MIN_CODEX_VERSION,
+        "claude": engines.MIN_CLAUDE_VERSION,
+    }
+    assert {probe["cli"] for probe in artifact["probes"]} == set(minimums)
+    for probe in artifact["probes"]:
+        parse = lambda value: tuple(int(part) for part in value.split("."))
+        assert parse(probe["minimum_version"]) == minimums[probe["cli"]]
+        assert parse(probe["tested_version"]) > minimums[probe["cli"]]
+        assert probe["returncode"] == 0
+        assert probe["response"] == {"status": "compatible"}
+
+
 def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:
     review = engines.CodexEngine().parse_output(
         '{"type":"thread.started","thread_id":"recovered"}\n'

--- a/tests/test_engines.py
+++ b/tests/test_engines.py
@@ -94,7 +94,11 @@ def test_cli_version_is_compared_numerically(monkeypatch) -> None:
 
 @pytest.mark.parametrize(
     "reported",
-    ["claude 2.1.197-alpha.1", "codex-cli 0.144.6-beta"],
+    [
+        "claude 2.1.197-alpha.1",
+        "codex-cli 0.144.6-beta",
+        "codex-cli 0.145.0-alpha.1",
+    ],
 )
 def test_cli_version_rejects_prereleases(monkeypatch, reported) -> None:
     monkeypatch.setattr(
@@ -128,7 +132,7 @@ def test_minimum_provider_cli_acceptance_binds_later_real_versions() -> None:
             / "docs/minimum_provider_cli_acceptance_2026-08-16.json"
         ).read_text()
     )
-    assert artifact["model_call_count"] == 2
+    assert artifact["model_call_count"] == 11
     minimums = {
         "codex": engines.MIN_CODEX_VERSION,
         "claude": engines.MIN_CLAUDE_VERSION,
@@ -140,6 +144,19 @@ def test_minimum_provider_cli_acceptance_binds_later_real_versions() -> None:
         assert parse(probe["tested_version"]) > minimums[probe["cli"]]
         assert probe["returncode"] == 0
         assert probe["response"] == {"status": "compatible"}
+    lifecycles = {row["cli"]: row for row in artifact["primary_lifecycles"]}
+    assert set(lifecycles) == set(minimums)
+    assert lifecycles["claude"]["claim_counts"] == {
+        "refuted": 0, "supported": 1, "unverified": 0,
+    }
+    assert lifecycles["codex"]["claim_counts"] == {
+        "refuted": 0, "supported": 1, "unverified": 1,
+    }
+    assert all(row["engine_returncode"] == 0 for row in lifecycles.values())
+    assert sum(
+        row["claim_model_calls"] + row["structural_model_calls"]
+        for row in lifecycles.values()
+    ) + artifact["structured_probe_model_calls"] == artifact["model_call_count"]
 
 
 def test_codex_recovered_stream_error_does_not_discard_completed_turn() -> None:


### PR DESCRIPTION
## Summary
- treat Codex 0.144.6 and Claude 2.1.197 as minimum compatible versions instead of exact pins
- compare version components numerically and conservatively reject prerelease builds
- document the runtime contract and retain signed-in later-version acceptance for Claude 2.1.233 and Codex 0.147.0

## Validation
- 1067 tests passed in 57.87s
- complete verified-plan lifecycle exercised on both later provider versions; Claude closed 1/1 claims, Codex failed closed visibly on a server capture limit after all evidence roles completed
- 11 acceptance model calls; 10 CODE-review calls over 815.67s
- Codex CODE cold final: CONVERGENCE NOT-BLOCKED, 0 blocking debt
- production diff: engines.py +24/-13 (627 lines)