### PR TITLE
Distinguish claim payload validation failures

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -258,6 +258,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   computed convergence verdict.
 - Malformed model output and required-role failure produce visible blocking debt with bounded
   diagnostics; they never become an empty register or false clear.
+- When discovery and its single correction both fail local claim-payload validation, preserve the
+  ordered bounded validator reasons and exact initial/correction raw exchange; do not describe a
+  successful provider process as a reviewer execution failure.
 - The reviewer remains read-only. The calling coding agent autonomously validates packets,
   edits the plan before round 2, increments the round, and reruns. No human is required for
   ordinary convergence, and unchanged-input reviewer churn is not correction.

--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,10 @@ CONVERGENCE: BLOCKED — external claim closure remains open.
 `CLAIM-AUDIT-DEBT` includes the validator reason, SHA-256, and a bounded rejected
 output excerpt. Malformed model JSON, a failed audit/retry, unsupported authority,
 or missing entailment blocks; it never becomes an empty successful register.
+If discovery and its single correction are both rejected locally, the debt reports the
+ordered initial and correction validator reasons and hashes the exact two provider envelopes
+joined by the discovery-correction separator. A successful provider process is not labeled as
+`reviewer failed (exit 0)` solely because its payload was invalid.
 
 ### `arbitrate` outcomes
 

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -225,6 +225,11 @@ Canonical durable state remained blocked with zero applied claims and retained d
 exact rejected-response hash, so the valid sibling row could not be misbound or partially applied.
 The run used two signed-in calls plus the controlled attestation boundary and 38.555 seconds.
 
+When discovery and its one same-session correction both fail local payload validation, the claim
+debt preserves the bounded reasons in initial/correction order. Its rejected raw identity is the
+initial provider envelope, the literal discovery-correction separator, and the corrected provider
+envelope in that order. Provider return code zero remains distinct from a reviewer execution error.
+
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).
 It covers a known false internet-only claim, an external fact, an RFC design principle, an

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -229,6 +229,16 @@ When discovery and its one same-session correction both fail local payload valid
 debt preserves the bounded reasons in initial/correction order. Its rejected raw identity is the
 initial provider envelope, the literal discovery-correction separator, and the corrected provider
 envelope in that order. Provider return code zero remains distinct from a reviewer execution error.
+The controlled signed-in acceptance record is
+[`minimal_claim_validation_acceptance_2026-08-18.json`](minimal_claim_validation_acceptance_2026-08-18.json).
+It is bound to behavior commit `af93499`, Codex CLI 0.144.6, `gpt-5.6-sol`, high effort, and web
+search enabled. Two same-session discovery calls both exited zero; controlled post-extraction text
+made both payloads invalid while preserving their real provider envelopes. The production handler
+persisted both ordered reasons, caller-visible blocking debt, and the exact aggregate raw SHA-256 in
+157.974 seconds. The behavior diff against `main` is 25 additions and five deletions across
+`handlers.py` and `plan_claims.py`; the three largest Python production modules are `handlers.py`
+(135,711 bytes; 2,917 lines), `arbitrate_handler.py` (127,166 bytes; 2,991 lines), and
+`plan_claims.py` (62,865 bytes; 1,422 lines).
 
 The current Codex acceptance record is
 [`external_claim_acceptance_2026-08-09.json`](external_claim_acceptance_2026-08-09.json).

--- a/docs/minimal_claim_validation_acceptance_2026-08-18.json
+++ b/docs/minimal_claim_validation_acceptance_2026-08-18.json
@@ -1,0 +1,66 @@
+{
+  "acceptance_kind": "minimal-claim-validation-diagnostics-v1",
+  "source_commit": "af93499dcb986f72bf456ec6c89c9949ec87b313",
+  "provider": {
+    "engine": "codex",
+    "cli_version": "codex-cli 0.144.6",
+    "model": "gpt-5.6-sol",
+    "effort": "high",
+    "web_search": true
+  },
+  "controlled_boundary": "Append fixed trailing text only to each successful discovery Review.text; preserve provider envelope, session, return code, usage, and execution.",
+  "elapsed_seconds": 157.974,
+  "model_call_count": 2,
+  "provider_calls": [
+    {
+      "role": "evidence-discovery",
+      "returncode": 0,
+      "error": false,
+      "session_ref": "01a0163c-c57d-7952-8838-dc58cdb1b465",
+      "original_text_sha256": "cac2995cf200f6fceae9439ae67c387c2c16b1b6818ce7e4c8e8a081f2f01800",
+      "exposed_text_sha256": "18d189b8c1b2fb0f21358f07e76389c8be885d1a7757e63f632967f17b46e53a",
+      "raw_sha256": "55a8f5f72ab406af49ea47e8db29eaf4368ca2cabf8d551f19f03b504685ac5a",
+      "controlled_text_mutation": true,
+      "usage": {
+        "input_tokens": 29242,
+        "cached_input_tokens": 5632,
+        "output_tokens": 440,
+        "reasoning_output_tokens": 133
+      }
+    },
+    {
+      "role": "evidence-discovery",
+      "returncode": 0,
+      "error": false,
+      "session_ref": "01a0163c-c57d-7952-8838-dc58cdb1b465",
+      "original_text_sha256": "09318c07078e6acd94dc0fcb9336f4edb21f2f1d9454b124b0b5b4b052c31c32",
+      "exposed_text_sha256": "b116360e483d5f592d95636f5a2ef10b99daf9d16dda5eb9856be7be49258f1e",
+      "raw_sha256": "0cfa3a6c8cf536f157b5fe3e71f06965836be86c8879ee30f58e3e817e84a529",
+      "controlled_text_mutation": true,
+      "usage": {
+        "input_tokens": 68630,
+        "cached_input_tokens": 38912,
+        "output_tokens": 1113,
+        "reasoning_output_tokens": 500
+      }
+    }
+  ],
+  "debt": {
+    "round": 1,
+    "reason": "initial: unexpected text after claim audit JSON\ncorrection: unexpected text after claim audit JSON",
+    "returncode": 0,
+    "raw_sha256": "03b81d174c95f1ad413fce349d8f3602612d40d5a049a777d48f449b5b922f0a",
+    "rejected_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a0163c-c57d-7952-8838-dc58cdb1b465\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-a673d473-1f54-4294-8ed1-47df0046af77\",\"query\":\"\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-a673d473-1f54-4294-8ed1-47df0046af77\",\"query\":\"site:python.org Python 3.11.0 released October 24 2022\",\"action\":{\"type\":\"search\",\"query\":\"site:python.org Python 3.11.0 released October 24 2022\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"=== CLAIM AUDIT JSON ===\\n{\\\"claims\\\":[{\\\"kind\\\":\\\"fact\\\",\\\"scope\\\":\\\"external\\\",\\\"anchor\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"proposition\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"prior_claim_id\\\":null,\\\"verdict\\\":\\\"supported\\\",\\\"evidence\\\":[{\\\"url\\\":\\\"https://www.python.org/downloads/release/python-3110/\\\",\\\"title\\\":\\\"Python Release Python 3.11.0\\\",\\\"publisher\\\":\\\"Python Software Foundation\\\",\\\"source_kind\\\":\\\"primary\\\",\\\"authority_basis\\\":\\\"The Python Software Foundation operates Python.org and publishes the official Python release record.\\\",\\\"location\\\":\\\"Python 3.11.0 release page, immediately below the page title\\\",\\\"quote\\\":\\\"Release date: Oct. 24, 2022\\\",\\\"relation\\\":\\\"supports_claim\\\"}],\\\"replacement\\\":null,\\\"rationale\\\":\\\"The official Python 3.11.0 release record states the exact asserted release date.\\\"}],\\\"coverage\\\":{\\\"sections_scanned\\\":1,\\\"omitted_nonfacts\\\":1,\\\"prior_assessments\\\":[],\\\"prior_dispositions\\\":[],\\\"notes\\\":\\\"Scanned the Acceptance heading and its sole sentence; retained the one load-bearing external fact.\\\"}}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":29242,\"cached_input_tokens\":5632,\"output_tokens\":440,\"reasoning_output_tokens\":133}}\n\n--- discovery correction ---\n{\"type\":\"thread.started\",\"thread_id\":\"01a0163c-c57d-7952-8838-dc58cdb1b465\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-6a397a4a-433b-4d35-97c2-fae88b2dfb33\",\"query\":\"\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-6a397a4a-433b-4d35-97c2-fae88b2dfb33\",\"query\":\"https://www.python.org/downloads/release/python-3110/\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"=== CLAIM AUDIT JSON ===\\n{\\\"claims\\\":[{\\\"kind\\\":\\\"fact\\\",\\\"scope\\\":\\\"external\\\",\\\"anchor\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"proposition\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"prior_claim_id\\\":null,\\\"verdict\\\":\\\"supported\\\",\\\"evidence\\\":[{\\\"url\\\":\\\"https://www.python.org/downloads/release/python-3110/\\\",\\\"title\\\":\\\"Python Release Python 3.11.0\\\",\\\"publisher\\\":\\\"Python Software Foundation\\\",\\\"source_kind\\\":\\\"primary\\\",\\\"authority_basis\\\":\\\"The Python Software Foundation publishes Python's official release records on Python.org.\\\",\\\"location\\\":\\\"Python 3.11.0 release page, lines 21\u201329, directly below the title\\\",\\\"quote\\\":\\\"Release date: Oct. 24, 2022\\\",\\\"relation\\\":\\\"supports_claim\\\"}],\\\"replacement\\\":null,\\\"rationale\\\":\\\"The official Python 3.11.0 release record gives the exact asserted release date.\\\"}],\\\"coverage\\\":{\\\"sections_scanned\\\":1,\\\"omitted_nonfacts\\\":1,\\\"prior_assessments\\\":[],\\\"prior_dispositions\\\":[],\\\"notes\\\":\\\"Scanned the Acceptance heading and its sole sentence; retained the one eligible external fact.\\\"}}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":68630,\"cached_input_tokens\":38912,\"output_tokens\":1113,\"reasoning_output_tokens\":500}}\n",
+    "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+    "failure_detail": "",
+    "stderr_sha256": "e953025cf64f6d52918495ee714518fccf622f0b2794fabf6d95ff6bf8639108",
+    "stderr": "2026-08-18T18:58:23.770318Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-18T18:58:33.801013Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n"
+  },
+  "audit_sha256": "85bbf4c50690b0cc9b447917fefa7533640add7a567e3b19c00b2ccf095e5a32",
+  "result_sha256": "f2c9b335f0e216ba8c2c434a33d9aad1fdefed5f30945116290b36b4368fc21a",
+  "caller_claim_audit_debt": true,
+  "caller_convergence_blocked": true,
+  "result_excerpt": "f0a)\nREJECTED-AUDIT-EXCERPT:\n{\"type\":\"thread.started\",\"thread_id\":\"01a0163c-c57d-7952-8838-dc58cdb1b465\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-a673d473-1f54-4294-8ed1-47df0046af77\",\"query\":\"\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-a673d473-1f54-4294-8ed1-47df0046af77\",\"query\":\"site:python.org Python 3.11.0 released October 24 2022\",\"action\":{\"type\":\"search\",\"query\":\"site:python.org Python 3.11.0 released October 24 2022\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"=== CLAIM AUDIT JSON ===\\n{\\\"claims\\\":[{\\\"kind\\\":\\\"fact\\\",\\\"scope\\\":\\\"external\\\",\\\"anchor\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"proposition\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"prior_claim_id\\\":null,\\\"verdict\\\":\\\"supported\\\",\\\"evidence\\\":[{\\\"url\\\":\\\"https://www.python.org/downloads/release/python-3110/\\\",\\\"title\\\":\\\"Python Release Python 3.11.0\\\",\\\"publisher\\\":\\\"Python Software Foundation\\\",\\\"source_kind\\\":\\\"primary\\\",\\\"authority_basis\\\":\\\"The Python Software Foundation operates Python.org and publishes the official Python release record.\\\",\\\"location\\\":\\\"Python 3.11.0 release page, immediately below the page title\\\",\\\"quote\\\":\\\"Release date: Oct. 24, 2022\\\",\\\"relation\\\":\\\"supports_claim\\\"}],\\\"replacement\\\":null,\\\"rationale\\\":\\\"The official Python 3.11.0 release record states the exact asserted release date.\\\"}],\\\"coverage\\\":{\\\"sections_scanned\\\":1,\\\"omitted_nonfacts\\\":1,\\\"prior_assessments\\\":[],\\\"prior_dispositions\\\":[],\\\"notes\\\":\\\"Scanned the Acceptance heading and its sole sentence; retained the one load-bearing external fact.\\\"}}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":29242,\"cached_input_tokens\":5632,\"output_tokens\":440,\"reasoning_output_tokens\":133}}\n\n--- discovery correction ---\n{\"type\":\"thread.started\",\"thread_id\":\"01a0163c-c57d-7952-8838-dc58cdb1b465\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-6a397a4a-433b-4d35-97c2-fae88b2dfb33\",\"query\":\"\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"web_search\",\"id\":\"exec-6a397a4a-433b-4d35-97c2-fae88b2dfb33\",\"query\":\"https://www.python.org/downloads/release/python-3110/\",\"action\":{\"type\":\"other\"}}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"agent_message\",\"text\":\"=== CLAIM AUDIT JSON ===\\n{\\\"claims\\\":[{\\\"kind\\\":\\\"fact\\\",\\\"scope\\\":\\\"external\\\",\\\"anchor\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"proposition\\\":\\\"Python 3.11.0 was released on October 24, 2022.\\\",\\\"prior_claim_id\\\":null,\\\"verdict\\\":\\\"supported\\\",\\\"evidence\\\":[{\\\"url\\\":\\\"https://www.python.org/downloads/release/python-3110/\\\",\\\"title\\\":\\\"Python Release Python 3.11.0\\\",\\\"publisher\\\":\\\"Python Software Foundation\\\",\\\"source_kind\\\":\\\"primary\\\",\\\"authority_basis\\\":\\\"The Python Software Foundation publishes Python's official release records on Python.org.\\\",\\\"location\\\":\\\"Python 3.11.0 release page, lines 21\u201329, directly below the title\\\",\\\"quote\\\":\\\"Release date: Oct. 24, 2022\\\",\\\"relation\\\":\\\"supports_claim\\\"}],\\\"replacement\\\":null,\\\"rationale\\\":\\\"The official Python 3.11.0 release record gives the exact asserted release date.\\\"}],\\\"coverage\\\":{\\\"sections_scanned\\\":1,\\\"omitted_nonfacts\\\":1,\\\"prior_assessments\\\":[],\\\"prior_dispositions\\\":[],\\\"notes\\\":\\\"Scanned the Acceptance heading and its sole sentence; retained the one eligible external fact.\\\"}}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":68630,\"cached_input_tokens\":38912,\"output_tokens\":1113,\"reasoning_output_tokens\":500}}\n\nLINEAGE: minimal-claim-validation-acceptance (rounds recorded: 1)\nCLASS-REGISTER: NONE\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nCLASS-CONVERGENCE: NOT-BLOCKED \u2014 no blocking class is unclosed; advisory classes may remain open. Reviewer findings still govern.\nCONVERGENCE: BLOCKED \u2014 external claim closure remain open.",
+  "rejected_exchange_composition": "initial provider raw + literal \\n--- discovery correction ---\\n + corrected provider raw",
+  "expected_rejected_exchange_sha256": "03b81d174c95f1ad413fce349d8f3602612d40d5a049a777d48f449b5b922f0a"
+}

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -18,7 +18,7 @@ import tempfile
 import time
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from copy import deepcopy
-from dataclasses import replace
+from dataclasses import dataclass, replace
 from datetime import datetime
 from pathlib import Path
 from threading import Lock
@@ -60,6 +60,13 @@ class _OmittedBinding:
 
 
 _OMITTED_BINDING = _OmittedBinding()
+
+
+@dataclass(frozen=True)
+class _ValidationReview(Review):
+    """A successful provider response rejected by local claim validation."""
+
+    validation_detail: str = ""
 
 
 def _attempt(
@@ -1776,15 +1783,18 @@ def _verify_plan_claims(
     if captured_engine is None and attempt_ledger is not None:
         attempt_ledger.append(_attempt("claim-audit", engine, review).json())
     if review.error:
+        validation_invalid = isinstance(review, _ValidationReview)
         error = pc.AuditError(
-            f"claim-audit reviewer failed (exit {review.returncode})",
+            review.validation_detail if validation_invalid else (
+                f"claim-audit reviewer failed (exit {review.returncode})"
+            ),
             review.raw,
             failure_detail=review.failure_detail or "", stderr=review.stderr or "",
             returncode=review.returncode,
         )
         return pc.with_debt(
             prior_state, error, round_no=round_no, plan_text=plan_text, frozen_ids=frozen,
-        ), "failed"
+        ), "validation-invalid" if validation_invalid else "failed"
     allow_missing = bool(captured_engine and captured_engine.allow_missing)
     try:
         audit = pc.parse_audit(
@@ -1960,11 +1970,16 @@ class _CapturedClaimEngine:
                         plan_repo_path=self.plan_repo_path, allow_missing=True,
                     )
                 except pc.AuditError:
-                    return Review(
+                    detail = pc.bounded_diagnostic(
+                        f"initial: {error.reason}\ncorrection: {second.reason}"
+                    )
+                    return _ValidationReview(
                         text=f"[paranoia-local error] discovery audit invalid: {second}",
                         session_ref=corrected.session_ref,
                         raw="\n--- discovery correction ---\n".join(raw_parts),
-                        error=True,
+                        returncode=corrected.returncode, error=True,
+                        failure_detail=corrected.failure_detail,
+                        stderr=corrected.stderr, validation_detail=detail,
                     )
                 self.allow_missing = True
             session_ref = corrected.session_ref

--- a/src/paranoia_local/plan_claims.py
+++ b/src/paranoia_local/plan_claims.py
@@ -79,6 +79,11 @@ class AuditError(ValueError):
         }
 
 
+def bounded_diagnostic(text: str) -> str:
+    """Bound one model-controlled diagnostic using the canonical head/tail excerpt."""
+    return _excerpt(text)
+
+
 @dataclass(frozen=True)
 class Audit:
     claims: tuple[dict[str, Any], ...]

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -20,6 +20,34 @@ from paranoia_local.engines import Review
 PLAN = "# Rollout\n\nPython 3.11 was released in October 2022.\n"
 
 
+def test_minimal_claim_validation_acceptance_record() -> None:
+    root = Path(__file__).resolve().parents[1]
+    artifact = json.loads(
+        (root / "docs/minimal_claim_validation_acceptance_2026-08-18.json").read_text()
+    )
+    assert artifact["acceptance_kind"] == "minimal-claim-validation-diagnostics-v1"
+    assert artifact["model_call_count"] == 2
+    calls = artifact["provider_calls"]
+    assert [call["role"] for call in calls] == [
+        "evidence-discovery", "evidence-discovery",
+    ]
+    assert all(call["returncode"] == 0 and not call["error"] for call in calls)
+    assert calls[0]["session_ref"] == calls[1]["session_ref"]
+    debt = artifact["debt"]
+    assert "initial: unexpected text after claim audit JSON" in debt["reason"]
+    assert "correction: unexpected text after claim audit JSON" in debt["reason"]
+    assert "reviewer failed" not in debt["reason"]
+    assert debt["raw_sha256"] == artifact["expected_rejected_exchange_sha256"]
+    assert artifact["caller_claim_audit_debt"] is True
+    assert artifact["caller_convergence_blocked"] is True
+    assert "CONVERGENCE: BLOCKED" in artifact["result_excerpt"]
+    source = subprocess.run(
+        ["git", "show", f'{artifact["source_commit"]}:src/paranoia_local/handlers.py'],
+        cwd=root, capture_output=True, text=True, check=True,
+    ).stdout
+    assert "class _ValidationReview" in source
+
+
 def _source(
     *,
     url: str = "https://www.python.org/downloads/release/python-3110/",

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import hashlib
 import json
 import subprocess
 from pathlib import Path
@@ -934,6 +935,54 @@ def _repo(tmp_path: Path) -> Path:
 
 
 class TestHandlerFlow:
+    def test_exhausted_discovery_validation_preserves_both_reasons_and_raw(
+        self, tmp_path: Path, monkeypatch,
+    ) -> None:
+        initial = _audit(_claim()) + "\nunexpected source list"
+        correction = _audit(_claim(
+            anchor="This corrected anchor is absent.",
+            proposition="This corrected anchor is absent.",
+        ))
+        engine = _RoleScript({"evidence-discovery": [initial, correction]})
+        monkeypatch.setattr(handlers.eng, "CodexEngine", _RoleScript)
+
+        state, status = handlers._verify_plan_claims(
+            PLAN, pc.empty_state(), lineage_id="validation-diagnostic", round_no=1,
+            stakes="trusted local tool", engine=engine, repo=_repo(tmp_path),
+            model="m", effort="high", plan_repo_path=None, on_progress=None,
+        )
+
+        debt = state["debt"]
+        expected_raw = (
+            "evidence-discovery\n--- discovery correction ---\nevidence-discovery"
+        )
+        assert status == "validation-invalid"
+        assert "initial: unexpected text after claim audit JSON" in debt["reason"]
+        assert "correction: claim 0: anchor is not a verbatim substring" in debt["reason"]
+        assert "reviewer failed" not in debt["reason"]
+        assert debt["returncode"] == 0
+        assert debt["raw_sha256"] == hashlib.sha256(expected_raw.encode()).hexdigest()
+        assert debt["rejected_excerpt"] == expected_raw
+
+    def test_returncode_zero_provider_error_keeps_execution_wording(
+        self, tmp_path: Path,
+    ) -> None:
+        failure = Review(
+            "provider rejected request", "session", "provider envelope",
+            returncode=0, error=True, failure_detail="in-band provider error",
+        )
+
+        state, status = handlers._verify_plan_claims(
+            PLAN, pc.empty_state(), lineage_id="provider-error", round_no=1,
+            stakes="trusted local tool", engine=ScriptedEngine(failure),
+            repo=_repo(tmp_path), model="m", effort="high", plan_repo_path=None,
+            on_progress=None,
+        )
+
+        assert status == "failed"
+        assert state["debt"]["reason"] == "claim-audit reviewer failed (exit 0)"
+        assert state["debt"]["failure_detail"] == "in-band provider error"
+
     @pytest.mark.parametrize(("returncode", "diagnostic"), [
         (124, "timed out after 3600s"),
         (127, "executable not found: codex"),


### PR DESCRIPTION
## Summary
- classify exhausted local discovery/correction payload validation separately from reviewer execution failure
- preserve ordered bounded validator reasons and the exact rejected provider exchange digest
- retain genuine return-code-zero provider failures as execution failures

## Verification
- 129 claim tests
- 1,034 non-staged tests
- 94 staged tests (1 pre-existing prompt-size baseline deselected)
- controlled signed-in two-call Codex acceptance: both provider calls exit 0; caller receives CLAIM-AUDIT-DEBT and blocked convergence
- Paranoia CODE convergence: NOT-BLOCKED (round 1)

## Scope
No binding/attestation redesign, attempt-ledger schema changes, admission-budget work, transport changes, or large-page/403 work.