### PR TITLE
Handle large evidence pages and ordinary 403s

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -181,6 +181,14 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   other real capability failures block visibly.
   Treat the final redirect URL as governing UGC/self-source eligibility and persist capture
   digests plus cold authority/entailment decisions before support may freeze.
+  Keep the 5,000,000-byte raw response circuit breaker and admit complete extracted text through
+  100,000 characters. Deduplicate identical final-URL/content/text captures only within one
+  binding prompt or batch, using an earlier-row reference bound to all three values. Count actual
+  numbered, metadata-bearing, JSON-escaped representations against aggregate binding budgets.
+  Retry HTTP 403 at most once with a browser-compatible user agent, a fresh redirect counter, and
+  the original absolute deadline and public-address/final-URL policy. A persistent 403 remains
+  unusable and retains final URL, numeric status, bounded error, and retry fact; never add cookies,
+  browser automation, access-control bypass, third-party mirrors, snippets, or provider bodies.
   Validate retained inventory before capture; attest replacement wording as its own exact
   proposition; and enforce aggregate capture/binding budgets so multiplicative per-claim maxima
   become visible debt rather than an hours-long run.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,9 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   100,000 characters. Deduplicate identical final-URL/content/text captures only within one
   binding prompt or batch, using an earlier-row reference bound to all three values. Count actual
   numbered, metadata-bearing, JSON-escaped representations against aggregate binding budgets.
+  When distinct arbitration captures exceed its single prompt budget, deterministically demote
+  the largest capture groups to bounded server-owned binding-budget failures until it fits;
+  preserve the remaining research and do not add a model call.
   Retry HTTP 403 at most once with a browser-compatible user agent, a fresh redirect counter, and
   the original absolute deadline and public-address/final-URL policy. A persistent 403 remains
   unusable and retains final URL, numeric status, bounded error, and retry fact; never add cookies,

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -188,6 +188,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   When distinct arbitration captures exceed its single prompt budget, deterministically demote
   the largest capture groups to bounded server-owned binding-budget failures until it fits;
   preserve the remaining research and do not add a model call.
+  Apply the same per-source failure to a plan capture whose numbered and JSON-escaped row alone
+  exceeds one binding batch; never let one admitted page abort unrelated plan evidence.
   Retry HTTP 403 at most once with a browser-compatible user agent, a fresh redirect counter, and
   the original absolute deadline and public-address/final-URL policy. A persistent 403 remains
   unusable and retains final URL, numeric status, bounded error, and retry fact; never add cookies,

--- a/README.md
+++ b/README.md
@@ -370,7 +370,9 @@ through 100,000 characters, so ordinary long reference pages are not discarded a
 batch and referenced by final URL plus content/text digests; distinct pages still obey the
 existing serialized aggregate ceilings. Arbitration deterministically marks the largest distinct
 captures unusable until its single binding prompt fits, so one large-source group fails closed
-without aborting all research. Requests use explicit HTML/text accept headers and identity content
+without aborting all research. Plan binding likewise marks an individual capture unusable when
+line numbering or JSON escaping makes its row exceed one batch; other captures continue.
+Requests use explicit HTML/text accept headers and identity content
 encoding (`Accept-Encoding: identity`). An HTTP 403 receives one same-URL browser-compatible retry inside
 the original deadline and redirect/public-address policy. A persistent 403 remains fail-closed
 with its final URL, status, bounded error, and retry fact visible in durable provenance; the

--- a/README.md
+++ b/README.md
@@ -364,6 +364,15 @@ passages. A separate cold, tool-free attester must accept both publisher authori
 entailment before a packet can close a claim. Claude `WebFetch` is never enabled or trusted in
 this path. There is no `PARANOIA_SEARCH_ENDPOINT`, API key, plugin, or caller-supplied search
 adapter.
+Capture keeps a 5,000,000-byte response circuit breaker but admits complete Trafilatura output
+through 100,000 characters, so ordinary long reference pages are not discarded at the former
+40,000-character threshold. Repeated identical captures are rendered once per binding prompt or
+batch and referenced by final URL plus content/text digests; distinct pages still obey the
+existing serialized aggregate ceilings. Requests use explicit HTML/text accept headers and
+identity transfer encoding. An HTTP 403 receives one same-URL browser-compatible retry inside
+the original deadline and redirect/public-address policy. A persistent 403 remains fail-closed
+with its final URL, status, bounded error, and retry fact visible in durable provenance; the
+server never uses cookies, browser automation, mirrors, snippets, or provider-fetched text.
 Redirect destinations govern URL eligibility, UGC/self-source classification, packet identity,
 and the persisted source URL; a benign discovery URL cannot launder an ineligible destination.
 Persisted claim provenance includes the captured-text digest and cold authority/entailment

--- a/README.md
+++ b/README.md
@@ -368,8 +368,10 @@ Capture keeps a 5,000,000-byte response circuit breaker but admits complete Traf
 through 100,000 characters, so ordinary long reference pages are not discarded at the former
 40,000-character threshold. Repeated identical captures are rendered once per binding prompt or
 batch and referenced by final URL plus content/text digests; distinct pages still obey the
-existing serialized aggregate ceilings. Requests use explicit HTML/text accept headers and
-identity transfer encoding. An HTTP 403 receives one same-URL browser-compatible retry inside
+existing serialized aggregate ceilings. Arbitration deterministically marks the largest distinct
+captures unusable until its single binding prompt fits, so one large-source group fails closed
+without aborting all research. Requests use explicit HTML/text accept headers and identity content
+encoding (`Accept-Encoding: identity`). An HTTP 403 receives one same-URL browser-compatible retry inside
 the original deadline and redirect/public-address policy. A persistent 403 remains fail-closed
 with its final URL, status, bounded error, and retry fact visible in durable provenance; the
 server never uses cookies, browser automation, mirrors, snippets, or provider-fetched text.

--- a/docs/arbitration_fallback_acceptance_2026-08-16.json
+++ b/docs/arbitration_fallback_acceptance_2026-08-16.json
@@ -1,5 +1,6 @@
 {
   "acceptance_kind": "arbitration-original-fallback-v2",
+  "source_commit": "321c1d20849934a5a7eec2139441f0bc25ca701c",
   "acceptance_scope": {
     "proves": [
       "a reported destructive cleaner candidate was retained as rejected audit data",

--- a/docs/arbitration_research_plan.md
+++ b/docs/arbitration_research_plan.md
@@ -305,13 +305,17 @@ Budgets are corruption/pathology guards, not sampling targets. Each researcher m
 12 unique normalized propositions and one candidate record per proposition; duplicate normalized
 propositions within one producer are rejected. Bound fields are: proposition 1,200 characters,
 URL 2,048, title 400, publisher 200, authority basis 600, location 400, and exact passage 1,200.
-Each captured document is at most 40,000 extracted characters and each producer's binding input is
-at most 400,000 rendered characters. The deterministic two-producer union may contain at most 24
+Each captured document is at most 100,000 extracted characters and each producer's binding input is
+at most 400,000 rendered characters after line numbering, metadata, and JSON escaping. Identical
+final-URL/content/text captures render once and later rows reference the first. When distinct
+captures would overflow the aggregate, the server deterministically marks the largest capture
+groups unusable with a binding-budget reason until the prompt fits; it does not abort otherwise
+usable research or add another model call. The deterministic two-producer union may contain at most 24
 propositions, two records per normalized proposition, and 200,000 rendered packet characters.
 The maximum accepted field payload plus fixed rendering overhead is below that union limit.
-Exceeding a producer, field, capture, binding-input, or union budget fails visibly rather than
-truncating evidence and calling the result complete. These limits compose without assuming that
-independently worded claims deduplicate.
+Exceeding a producer, field, capture, or union budget fails visibly rather than truncating evidence
+and calling the result complete. Binding-input overflow is localized into visible per-source
+unusable capture state. These limits do not assume independently worded claims deduplicate.
 
 The shared engine diagnostic contract also applies to captured plan-claim binding: durable debt
 stores provider stdout, structured failure detail, and process stderr as separate hashed, bounded

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -62,7 +62,10 @@ an empty, verified register.
    and extracted-text limits, then extracts main text with Trafilatura. Responses remain capped at
    5,000,000 bytes; complete extracted text through 100,000 characters is admitted. Repeated
    captures with the same final URL and content/text digests appear once per serialized binding
-   prompt or batch and later rows reference that exact capture. The same reviewer session
+   prompt or batch and later rows reference that exact capture. If distinct arbitration captures
+   exceed its single 400,000-character binding prompt, the largest capture groups are
+   deterministically made unusable with a server-owned binding-budget reason until the prompt
+   fits; other research continues. The same reviewer session
    is resumed with web and repository access disabled and may bind exact passages only from those
    captures. Search snippets, provider summaries, and provider-fetched page bodies never count.
    The initial attributable request carries explicit accept/language/identity-encoding headers.
@@ -103,7 +106,9 @@ Captured sources are downloaded with up to 16 workers under the same monotonic d
 per-source wall-clock bounds, then bound in deterministic indexed batches in the same corrected
 discovery session. Exact 5,000,000-byte and 100,000-character boundaries are admitted; the first
 unit above either is rejected. Serialized numbering, metadata, and JSON escaping count against
-the existing 400,000-character binding limit. One oversized source, a sixth batch, an expired capture, or a failed batch
+the existing 400,000-character binding limit. Arbitration degrades the largest distinct capture
+groups per-source when its aggregate would overflow; the plan path retains its five deterministic
+batches. One oversized source, a sixth plan batch, an expired capture, or a failed batch
 becomes visible blocking state rather than silently truncating the inventory.
 
 The complete verified plan call has a 7,080-second deadline, leaving a 120-second teardown

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -59,9 +59,17 @@ an empty, verified register.
    bounded correction therefore repairs omissions while discovery search is still available;
    only the corrected complete inventory proceeds to capture.
 3. The server downloads each candidate directly under bounded HTTP(S), redirect, response-size,
-   and extracted-text limits, then extracts main text with Trafilatura. The same reviewer session
+   and extracted-text limits, then extracts main text with Trafilatura. Responses remain capped at
+   5,000,000 bytes; complete extracted text through 100,000 characters is admitted. Repeated
+   captures with the same final URL and content/text digests appear once per serialized binding
+   prompt or batch and later rows reference that exact capture. The same reviewer session
    is resumed with web and repository access disabled and may bind exact passages only from those
    captures. Search snippets, provider summaries, and provider-fetched page bodies never count.
+   The initial attributable request carries explicit accept/language/identity-encoding headers.
+   Only HTTP 403 receives one browser-compatible same-URL retry, using a fresh five-redirect
+   handler but the same absolute deadline and public-address/final-URL checks. Persistent 403
+   remains unusable and retains its final URL, numeric status, bounded error, and retry fact; no
+   authentication, cookies, headless browser, CAPTCHA/paywall bypass, or mirror is attempted.
 4. A fresh tool-free attester receives only each atomic proposition, declared publisher and
    authority basis, capture metadata, relation, location, and exact passage. A source governs
    only when the attester independently accepts publisher authority and passage entailment. A
@@ -93,7 +101,9 @@ limits let a large real plan complete useful research without making either a ca
 an individual model call unbounded.
 Captured sources are downloaded with up to 16 workers under the same monotonic deadline and
 per-source wall-clock bounds, then bound in deterministic indexed batches in the same corrected
-discovery session. One oversized source, a sixth batch, an expired capture, or a failed batch
+discovery session. Exact 5,000,000-byte and 100,000-character boundaries are admitted; the first
+unit above either is rejected. Serialized numbering, metadata, and JSON escaping count against
+the existing 400,000-character binding limit. One oversized source, a sixth batch, an expired capture, or a failed batch
 becomes visible blocking state rather than silently truncating the inventory.
 
 The complete verified plan call has a 7,080-second deadline, leaving a 120-second teardown
@@ -255,3 +265,14 @@ The server-capture migration is separately recorded in
 It records a fresh two-vendor external arbitration, two fresh Codex plan claims closed only after
 server capture and cold attestation, and an explicit repository-only arbitration. It also records
 the timeout and Claude inert-root defects those real runs exposed before the successful reruns.
+
+The long-page follow-up is recorded in
+[`large_page_capture_acceptance_2026-08-18.json`](large_page_capture_acceptance_2026-08-18.json).
+A signed-in Codex run discovered the official Python decimal reference, captured all 70,378
+extracted characters, compacted two identical capture payloads in the binding batch, bound two
+exact passages with browsing disabled, and obtained independent positive authority/entailment
+attestations. It completed in 53.384 seconds with three model calls and no validation retry.
+The production diff is 173 additions and 43 deletions across `external_sources.py`,
+`arbitration_research.py`, and `handlers.py`. At acceptance time the three largest production
+Python modules were `handlers.py` (137,306 bytes; 2,947 lines), `arbitrate_handler.py` (127,166
+bytes; 2,991 lines), and `plan_claims.py` (62,865 bytes; 1,422 lines).

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -277,12 +277,12 @@ the timeout and Claude inert-root defects those real runs exposed before the suc
 The long-page follow-up is recorded in
 [`large_page_capture_acceptance_2026-08-18.json`](large_page_capture_acceptance_2026-08-18.json).
 A signed-in Codex run discovered the official Python decimal reference, captured all 70,378
-extracted characters, compacted two identical capture payloads in the binding batch, bound two
-exact passages with browsing disabled, and obtained independent positive authority/entailment
-attestations. A separate signed-in arbitration researcher then discovered six sources and bound
-all six through the bounded capture-reference envelope. Both paths completed in 122.571 seconds
+extracted characters, bound an exact passage with browsing disabled, and obtained an independent
+positive authority/entailment attestation. A separate signed-in arbitration researcher then
+discovered four sources and bound all four through the bounded capture-reference envelope.
+Both paths completed in 90.602 seconds
 with five model calls and no validation retry.
-The production diff is 218 additions and 49 deletions across `external_sources.py`,
+The production diff is 231 additions and 49 deletions across `external_sources.py`,
 `arbitration_research.py`, `handlers.py`, and `arbitrate_handler.py`. At acceptance time the three largest production
-Python modules were `handlers.py` (137,306 bytes; 2,947 lines), `arbitrate_handler.py` (127,184
+Python modules were `handlers.py` (137,863 bytes; 2,959 lines), `arbitrate_handler.py` (127,184
 bytes; 2,991 lines), and `plan_claims.py` (62,865 bytes; 1,422 lines).

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -110,6 +110,9 @@ the existing 400,000-character binding limit. Arbitration degrades the largest d
 groups per-source when its aggregate would overflow; the plan path retains its five deterministic
 batches. One oversized source, a sixth plan batch, an expired capture, or a failed batch
 becomes visible blocking state rather than silently truncating the inventory.
+If numbering or JSON escaping makes one plan capture row exceed a batch by itself, only that
+capture becomes unusable with the bounded server-owned binding-budget reason; it cannot abort
+unrelated claim captures.
 
 The complete verified plan call has a 7,080-second deadline, leaving a 120-second teardown
 reserve within the documented 7,200-second MCP client timeout. After evidence state is persisted,

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -276,8 +276,10 @@ The long-page follow-up is recorded in
 A signed-in Codex run discovered the official Python decimal reference, captured all 70,378
 extracted characters, compacted two identical capture payloads in the binding batch, bound two
 exact passages with browsing disabled, and obtained independent positive authority/entailment
-attestations. It completed in 53.384 seconds with three model calls and no validation retry.
-The production diff is 173 additions and 43 deletions across `external_sources.py`,
-`arbitration_research.py`, and `handlers.py`. At acceptance time the three largest production
-Python modules were `handlers.py` (137,306 bytes; 2,947 lines), `arbitrate_handler.py` (127,166
+attestations. A separate signed-in arbitration researcher then discovered six sources and bound
+all six through the bounded capture-reference envelope. Both paths completed in 122.571 seconds
+with five model calls and no validation retry.
+The production diff is 218 additions and 49 deletions across `external_sources.py`,
+`arbitration_research.py`, `handlers.py`, and `arbitrate_handler.py`. At acceptance time the three largest production
+Python modules were `handlers.py` (137,306 bytes; 2,947 lines), `arbitrate_handler.py` (127,184
 bytes; 2,991 lines), and `plan_claims.py` (62,865 bytes; 1,422 lines).

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -279,10 +279,10 @@ The long-page follow-up is recorded in
 A signed-in Codex run discovered the official Python decimal reference, captured all 70,378
 extracted characters, bound an exact passage with browsing disabled, and obtained an independent
 positive authority/entailment attestation. A separate signed-in arbitration researcher then
-discovered four sources and bound all four through the bounded capture-reference envelope.
-Both paths completed in 90.602 seconds
+discovered five sources and bound all five through the bounded capture-reference envelope.
+Both paths completed in 79.361 seconds
 with five model calls and no validation retry.
-The production diff is 231 additions and 49 deletions across `external_sources.py`,
+The production diff is 241 additions and 47 deletions across `external_sources.py`,
 `arbitration_research.py`, `handlers.py`, and `arbitrate_handler.py`. At acceptance time the three largest production
-Python modules were `handlers.py` (137,863 bytes; 2,959 lines), `arbitrate_handler.py` (127,184
+Python modules were `handlers.py` (138,392 bytes; 2,971 lines), `arbitrate_handler.py` (127,184
 bytes; 2,991 lines), and `plan_claims.py` (62,865 bytes; 1,422 lines).

--- a/docs/cleaning_attestation_acceptance_2026-08-13.json
+++ b/docs/cleaning_attestation_acceptance_2026-08-13.json
@@ -1,5 +1,6 @@
 {
   "acceptance_kind": "cleaning-attestation-v1",
+  "source_commit": "321c1d20849934a5a7eec2139441f0bc25ca701c",
   "acceptance_scope": {
     "proves": [
       "caller context and normalized options reached both deciders in the recorded runs",

--- a/docs/large_page_capture_acceptance_2026-08-18.json
+++ b/docs/large_page_capture_acceptance_2026-08-18.json
@@ -2,7 +2,7 @@
   "acceptance_kind": "large-page-plan-claim-capture",
   "date": "2026-08-18",
   "branch": "fix/large-page-evidence-capture",
-  "source_commit": "2f57b7cd57278bb41bd387ce9edf918df7f230a3",
+  "source_commit": "a56b59a23cfc0d6d1158654b5317c74f3f8a9117",
   "provider": {
     "engine": "codex",
     "cli_version": "codex-cli 0.144.6",
@@ -12,7 +12,7 @@
   },
   "runtime": {
     "trafilatura_version": "2.2.0",
-    "elapsed_seconds": 122.571,
+    "elapsed_seconds": 90.602,
     "model_calls": [
       "plan-evidence-discovery",
       "plan-evidence-binding",
@@ -23,9 +23,9 @@
     "validation_retries": 0
   },
   "source_sha256": {
-    "src/paranoia_local/external_sources.py": "eec4089ab6d416b89538d05ccfedc408e322304526abd6ba0f60c91960653d81",
-    "src/paranoia_local/arbitration_research.py": "09eb07231cbef4c5810bc7fd618fc854ed0bd989f49cbe57f0f842cc787329d4",
-    "src/paranoia_local/handlers.py": "6f64582a70a8c895f1fbf108ef529c0f94b39d8854bc195d86e2016e802c74bb",
+    "src/paranoia_local/external_sources.py": "166bfd4bf987714f9a9f500217d4f1cce6f74a4313fadd709e01d7d6a9ddb483",
+    "src/paranoia_local/arbitration_research.py": "539c577558fea4b43ee5a9e813788649a7d02e500296082feba6f59899867813",
+    "src/paranoia_local/handlers.py": "1698f2f4115eb1ef143fa18bb713cc2dbfa0cdaa5e9d21fc392ffae856920c67",
     "src/paranoia_local/arbitrate_handler.py": "cda50974be9c83261da808c94eca553265d460960e17c79c1001f9305a01caff"
   },
   "direct_capture": {
@@ -43,21 +43,14 @@
     "status": "parsed 1 new + 0 targeted retained + 0 frozen",
     "claim_count": 1,
     "blocked": false,
-    "claim_id": "C-57ad3abe93",
-    "proposition": "Python's decimal module is designed to permit exact representation of decimal numbers.",
+    "claim_id": "C-ca24537844",
+    "proposition": "Python's decimal module can represent decimal numbers exactly.",
     "verdict": "supported",
     "evidence": [
       {
         "url": "https://docs.python.org/3/library/decimal.html",
-        "location": "Introduction, lines 3–9",
+        "location": "Module introduction, advantages over float, second bullet, line 7",
         "passage": "Decimal numbers can be represented exactly.",
-        "publisher_authority": true,
-        "passage_entailment": true
-      },
-      {
-        "url": "https://docs.python.org/3/library/decimal.html",
-        "location": "Introduction, line 24",
-        "passage": "The decimal module was designed to support “without prejudice, both exact unrounded decimal arithmetic (sometimes called fixed-point arithmetic) and rounded floating-point arithmetic.”",
         "publisher_authority": true,
         "passage_entailment": true
       }
@@ -65,18 +58,17 @@
   },
   "arbitration_research": {
     "model_calls": ["arbitration-discovery", "arbitration-binding"],
-    "claim_count": 6,
-    "capture_count": 6,
-    "bound_count": 6,
+    "claim_count": 4,
+    "capture_count": 4,
+    "bound_count": 4,
     "binding_budget_demotions": 0,
     "validation_retries": 0
   },
   "assertions": [
     "The live server captured and extracted a 70,378-character authoritative page that the former 40,000-character policy rejected.",
-    "The signed-in discovery session resumed with tools disabled and bound two exact passages from the server capture.",
-    "The two evidence rows shared identical final URL and content/text digests, exercising per-batch capture-reference compaction.",
-    "A fresh tool-less attester independently accepted publisher authority and passage entailment for both rows.",
+    "The signed-in discovery session resumed with tools disabled and bound an exact passage from the server capture.",
+    "A fresh tool-less attester independently accepted publisher authority and passage entailment.",
     "The final durable claim state was supported and unblocked without a validation retry.",
-    "A separate signed-in arbitration researcher accepted the new bounded capture-reference envelope and bound all six captured claims in two calls."
+    "A separate signed-in arbitration researcher accepted the new bounded capture-reference envelope and bound all four captured claims in two calls."
   ]
 }

--- a/docs/large_page_capture_acceptance_2026-08-18.json
+++ b/docs/large_page_capture_acceptance_2026-08-18.json
@@ -1,0 +1,65 @@
+{
+  "acceptance_kind": "large-page-plan-claim-capture",
+  "date": "2026-08-18",
+  "branch": "fix/large-page-evidence-capture",
+  "provider": {
+    "engine": "codex",
+    "cli_version": "codex-cli 0.144.6",
+    "model": "gpt-5.6-sol",
+    "effort": "high",
+    "web_search": true
+  },
+  "runtime": {
+    "trafilatura_version": "2.2.0",
+    "elapsed_seconds": 53.384,
+    "model_calls": ["evidence-discovery", "evidence-binding", "evidence-text"],
+    "validation_retries": 0
+  },
+  "source_sha256": {
+    "src/paranoia_local/external_sources.py": "65f4f8fedeb655545afda3d4af1d40091e0502030307ff859653a5cd444469b2",
+    "src/paranoia_local/arbitration_research.py": "961f290029720df41e9ee30cd3570c8fc08cf49342f71063824b260cf4b282f3",
+    "src/paranoia_local/handlers.py": "6f64582a70a8c895f1fbf108ef529c0f94b39d8854bc195d86e2016e802c74bb"
+  },
+  "direct_capture": {
+    "url": "https://docs.python.org/3/library/decimal.html",
+    "status": 200,
+    "content_type": "text/html",
+    "content_sha256": "55fc6cbb881fee55c002bdc642cb7c1cbcaad6c0c74574417d0e6d2f328db104",
+    "text_sha256": "0cbe258434bc4ae6167a8b2f6f32db6776e2aa660b48d0de60e1c8166603b62d",
+    "extracted_characters": 70378,
+    "former_limit": 40000,
+    "current_limit": 100000,
+    "fallback_attempted": false
+  },
+  "verified_plan": {
+    "status": "parsed 1 new + 0 targeted retained + 0 frozen",
+    "claim_count": 1,
+    "blocked": false,
+    "claim_id": "C-17f09e37e2",
+    "proposition": "Python's decimal module is designed to support exact representation of decimal numbers.",
+    "verdict": "supported",
+    "evidence": [
+      {
+        "url": "https://docs.python.org/3/library/decimal.html",
+        "location": "Introduction, line 7",
+        "passage": "Decimal numbers can be represented exactly.",
+        "publisher_authority": true,
+        "passage_entailment": true
+      },
+      {
+        "url": "https://docs.python.org/3/library/decimal.html",
+        "location": "Introduction, line 24",
+        "passage": "The decimal module was designed to support “without prejudice, both exact unrounded decimal arithmetic (sometimes called fixed-point arithmetic) and rounded floating-point arithmetic.” – excerpt from the decimal arithmetic specification.",
+        "publisher_authority": true,
+        "passage_entailment": true
+      }
+    ]
+  },
+  "assertions": [
+    "The live server captured and extracted a 70,378-character authoritative page that the former 40,000-character policy rejected.",
+    "The signed-in discovery session resumed with tools disabled and bound two exact passages from the server capture.",
+    "The two evidence rows shared identical final URL and content/text digests, exercising per-batch capture-reference compaction.",
+    "A fresh tool-less attester independently accepted publisher authority and passage entailment for both rows.",
+    "The final durable claim state was supported and unblocked without a validation retry."
+  ]
+}

--- a/docs/large_page_capture_acceptance_2026-08-18.json
+++ b/docs/large_page_capture_acceptance_2026-08-18.json
@@ -2,7 +2,7 @@
   "acceptance_kind": "large-page-plan-claim-capture",
   "date": "2026-08-18",
   "branch": "fix/large-page-evidence-capture",
-  "source_commit": "fe8fa8c5ed404e5186e203ef91fa350066d69e86",
+  "source_commit": "2f57b7cd57278bb41bd387ce9edf918df7f230a3",
   "provider": {
     "engine": "codex",
     "cli_version": "codex-cli 0.144.6",
@@ -12,14 +12,21 @@
   },
   "runtime": {
     "trafilatura_version": "2.2.0",
-    "elapsed_seconds": 53.384,
-    "model_calls": ["evidence-discovery", "evidence-binding", "evidence-text"],
+    "elapsed_seconds": 122.571,
+    "model_calls": [
+      "plan-evidence-discovery",
+      "plan-evidence-binding",
+      "plan-evidence-text",
+      "arbitration-discovery",
+      "arbitration-binding"
+    ],
     "validation_retries": 0
   },
   "source_sha256": {
-    "src/paranoia_local/external_sources.py": "65f4f8fedeb655545afda3d4af1d40091e0502030307ff859653a5cd444469b2",
-    "src/paranoia_local/arbitration_research.py": "961f290029720df41e9ee30cd3570c8fc08cf49342f71063824b260cf4b282f3",
-    "src/paranoia_local/handlers.py": "6f64582a70a8c895f1fbf108ef529c0f94b39d8854bc195d86e2016e802c74bb"
+    "src/paranoia_local/external_sources.py": "eec4089ab6d416b89538d05ccfedc408e322304526abd6ba0f60c91960653d81",
+    "src/paranoia_local/arbitration_research.py": "09eb07231cbef4c5810bc7fd618fc854ed0bd989f49cbe57f0f842cc787329d4",
+    "src/paranoia_local/handlers.py": "6f64582a70a8c895f1fbf108ef529c0f94b39d8854bc195d86e2016e802c74bb",
+    "src/paranoia_local/arbitrate_handler.py": "cda50974be9c83261da808c94eca553265d460960e17c79c1001f9305a01caff"
   },
   "direct_capture": {
     "url": "https://docs.python.org/3/library/decimal.html",
@@ -36,13 +43,13 @@
     "status": "parsed 1 new + 0 targeted retained + 0 frozen",
     "claim_count": 1,
     "blocked": false,
-    "claim_id": "C-17f09e37e2",
-    "proposition": "Python's decimal module is designed to support exact representation of decimal numbers.",
+    "claim_id": "C-57ad3abe93",
+    "proposition": "Python's decimal module is designed to permit exact representation of decimal numbers.",
     "verdict": "supported",
     "evidence": [
       {
         "url": "https://docs.python.org/3/library/decimal.html",
-        "location": "Introduction, line 7",
+        "location": "Introduction, lines 3–9",
         "passage": "Decimal numbers can be represented exactly.",
         "publisher_authority": true,
         "passage_entailment": true
@@ -50,17 +57,26 @@
       {
         "url": "https://docs.python.org/3/library/decimal.html",
         "location": "Introduction, line 24",
-        "passage": "The decimal module was designed to support “without prejudice, both exact unrounded decimal arithmetic (sometimes called fixed-point arithmetic) and rounded floating-point arithmetic.” – excerpt from the decimal arithmetic specification.",
+        "passage": "The decimal module was designed to support “without prejudice, both exact unrounded decimal arithmetic (sometimes called fixed-point arithmetic) and rounded floating-point arithmetic.”",
         "publisher_authority": true,
         "passage_entailment": true
       }
     ]
+  },
+  "arbitration_research": {
+    "model_calls": ["arbitration-discovery", "arbitration-binding"],
+    "claim_count": 6,
+    "capture_count": 6,
+    "bound_count": 6,
+    "binding_budget_demotions": 0,
+    "validation_retries": 0
   },
   "assertions": [
     "The live server captured and extracted a 70,378-character authoritative page that the former 40,000-character policy rejected.",
     "The signed-in discovery session resumed with tools disabled and bound two exact passages from the server capture.",
     "The two evidence rows shared identical final URL and content/text digests, exercising per-batch capture-reference compaction.",
     "A fresh tool-less attester independently accepted publisher authority and passage entailment for both rows.",
-    "The final durable claim state was supported and unblocked without a validation retry."
+    "The final durable claim state was supported and unblocked without a validation retry.",
+    "A separate signed-in arbitration researcher accepted the new bounded capture-reference envelope and bound all six captured claims in two calls."
   ]
 }

--- a/docs/large_page_capture_acceptance_2026-08-18.json
+++ b/docs/large_page_capture_acceptance_2026-08-18.json
@@ -2,7 +2,7 @@
   "acceptance_kind": "large-page-plan-claim-capture",
   "date": "2026-08-18",
   "branch": "fix/large-page-evidence-capture",
-  "source_commit": "a56b59a23cfc0d6d1158654b5317c74f3f8a9117",
+  "source_commit": "c25a1ab6c6f1a66705dba3ac7bcd0ff81ed5498b",
   "provider": {
     "engine": "codex",
     "cli_version": "codex-cli 0.144.6",
@@ -12,7 +12,7 @@
   },
   "runtime": {
     "trafilatura_version": "2.2.0",
-    "elapsed_seconds": 90.602,
+    "elapsed_seconds": 79.361,
     "model_calls": [
       "plan-evidence-discovery",
       "plan-evidence-binding",
@@ -25,7 +25,7 @@
   "source_sha256": {
     "src/paranoia_local/external_sources.py": "166bfd4bf987714f9a9f500217d4f1cce6f74a4313fadd709e01d7d6a9ddb483",
     "src/paranoia_local/arbitration_research.py": "539c577558fea4b43ee5a9e813788649a7d02e500296082feba6f59899867813",
-    "src/paranoia_local/handlers.py": "1698f2f4115eb1ef143fa18bb713cc2dbfa0cdaa5e9d21fc392ffae856920c67",
+    "src/paranoia_local/handlers.py": "afb37aa4110617e65c44dd32fff6bc8d279ac9a908853cc3c489a1e118473faf",
     "src/paranoia_local/arbitrate_handler.py": "cda50974be9c83261da808c94eca553265d460960e17c79c1001f9305a01caff"
   },
   "direct_capture": {
@@ -43,13 +43,13 @@
     "status": "parsed 1 new + 0 targeted retained + 0 frozen",
     "claim_count": 1,
     "blocked": false,
-    "claim_id": "C-ca24537844",
-    "proposition": "Python's decimal module can represent decimal numbers exactly.",
+    "claim_id": "C-aaf8826076",
+    "proposition": "Python's decimal module supports exact representation of decimal numbers.",
     "verdict": "supported",
     "evidence": [
       {
         "url": "https://docs.python.org/3/library/decimal.html",
-        "location": "Module introduction, advantages over float, second bullet, line 7",
+        "location": "Introduction, second bullet under advantages over the float datatype, lines 3–9",
         "passage": "Decimal numbers can be represented exactly.",
         "publisher_authority": true,
         "passage_entailment": true
@@ -58,9 +58,9 @@
   },
   "arbitration_research": {
     "model_calls": ["arbitration-discovery", "arbitration-binding"],
-    "claim_count": 4,
-    "capture_count": 4,
-    "bound_count": 4,
+    "claim_count": 5,
+    "capture_count": 5,
+    "bound_count": 5,
     "binding_budget_demotions": 0,
     "validation_retries": 0
   },
@@ -69,6 +69,6 @@
     "The signed-in discovery session resumed with tools disabled and bound an exact passage from the server capture.",
     "A fresh tool-less attester independently accepted publisher authority and passage entailment.",
     "The final durable claim state was supported and unblocked without a validation retry.",
-    "A separate signed-in arbitration researcher accepted the new bounded capture-reference envelope and bound all four captured claims in two calls."
+    "A separate signed-in arbitration researcher accepted the new bounded capture-reference envelope and bound all five captured claims in two calls."
   ]
 }

--- a/docs/large_page_capture_acceptance_2026-08-18.json
+++ b/docs/large_page_capture_acceptance_2026-08-18.json
@@ -2,6 +2,7 @@
   "acceptance_kind": "large-page-plan-claim-capture",
   "date": "2026-08-18",
   "branch": "fix/large-page-evidence-capture",
+  "source_commit": "fe8fa8c5ed404e5186e203ef91fa350066d69e86",
   "provider": {
     "engine": "codex",
     "cli_version": "codex-cli 0.144.6",

--- a/scripts/validate_arbitration_fallback_acceptance.py
+++ b/scripts/validate_arbitration_fallback_acceptance.py
@@ -369,7 +369,7 @@ def validate(artifact_path: Path, repo: Path) -> None:
     artifact = json.loads(artifact_path.read_text(encoding="utf-8"))
     if set(artifact) != {
         "acceptance_kind", "acceptance_scope", "audits", "timings",
-        "snapshot_binding", "source_sha256", "tests",
+        "snapshot_binding", "source_commit", "source_sha256", "tests",
     }:
         raise ValueError("fallback acceptance top-level schema mismatch")
     if artifact["acceptance_kind"] != "arbitration-original-fallback-v2":
@@ -378,8 +378,16 @@ def validate(artifact_path: Path, repo: Path) -> None:
         raise ValueError("fallback acceptance claim scope mismatch")
     if set(artifact["source_sha256"]) != SOURCES:
         raise ValueError("fallback acceptance source set mismatch")
+    source_commit = artifact.get("source_commit")
+    if not isinstance(source_commit, str) or not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("fallback acceptance source commit is invalid")
     for relative, digest in artifact["source_sha256"].items():
-        if not _is_sha256(digest) or _sha256(repo / relative) != digest:
+        blob = inert_git.invoke(repo, ["show", f"{source_commit}:{relative}"])
+        if (
+            not _is_sha256(digest)
+            or blob.returncode != 0
+            or hashlib.sha256(blob.stdout).hexdigest() != digest
+        ):
             raise ValueError(f"fallback acceptance source hash mismatch: {relative}")
 
     if set(artifact["audits"]) != {"ordinary", "fallback"} or set(artifact["timings"]) != {

--- a/scripts/validate_cleaning_attestation_acceptance.py
+++ b/scripts/validate_cleaning_attestation_acceptance.py
@@ -17,6 +17,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[1] / "src"))
 from paranoia_local import arbitrate_handler as production_arbitrate  # noqa: E402
 from paranoia_local import arbitration as production_protocol  # noqa: E402
 from paranoia_local import evidence as production_evidence  # noqa: E402
+from paranoia_local import inert_git  # noqa: E402
 from paranoia_local import prompts as production_prompts  # noqa: E402
 
 PRODUCTION_SOURCES = frozenset({
@@ -150,11 +151,19 @@ def _exact_numeric_schema(artifact: dict) -> None:
             raise ValueError(f"{prefix} test exit status schema mismatch")
 
 
-def _validate_hashes(hashes: dict[str, str], expected: frozenset[str], repo: Path) -> None:
+def _validate_hashes(
+    hashes: dict[str, str], expected: frozenset[str], repo: Path, source_commit: str,
+) -> None:
     if set(hashes) != expected:
         raise ValueError("production_source_sha256 does not name the complete source set")
+    if not re.fullmatch(r"[0-9a-f]{40}", source_commit):
+        raise ValueError("production source_commit is invalid")
     for relative, expected_hash in hashes.items():
-        if _sha256(repo / relative) != expected_hash:
+        blob = inert_git.invoke(repo, ["show", f"{source_commit}:{relative}"])
+        if (
+            blob.returncode != 0
+            or hashlib.sha256(blob.stdout).hexdigest() != expected_hash
+        ):
             raise ValueError(f"production hash mismatch: {relative}")
 
 
@@ -296,7 +305,7 @@ def _derived_outcome_bound(audit: dict, fixture_repo: Path) -> bool:
 def _validate_cleaning_acceptance(artifact: dict, repo: Path) -> None:
     expected_top = {
         "acceptance_kind", "acceptance_scope", "delivery_metrics", "positive_long_context",
-        "original_report_input", "production_source_sha256",
+        "original_report_input", "production_source_sha256", "source_commit",
         "timing_record", "tests",
     }
     if set(artifact) != expected_top:
@@ -341,7 +350,10 @@ def _validate_cleaning_acceptance(artifact: dict, repo: Path) -> None:
     }:
         raise ValueError("test record schema is incomplete or contains unverified fields")
     _exact_numeric_schema(artifact)
-    _validate_hashes(artifact["production_source_sha256"], CLEANING_SOURCES, repo)
+    _validate_hashes(
+        artifact["production_source_sha256"], CLEANING_SOURCES, repo,
+        artifact["source_commit"],
+    )
     audits: dict[str, dict] = {}
     for name in ("positive_long_context", "original_report_input"):
         summary = artifact[name]

--- a/src/paranoia_local/arbitrate_handler.py
+++ b/src/paranoia_local/arbitrate_handler.py
@@ -2081,7 +2081,7 @@ def _research_one(
                 rejected=rejected, claims=claims, captures=completed_captures,
             ) from exc
         try:
-            rendered = research_core.binding_input(claims, captures)
+            rendered, captures = research_core.bounded_binding_input(claims, captures)
         except Exception as exc:
             raise _research_failure(
                 engine=engine, model=model, phase="binding-input", kind="validation",

--- a/src/paranoia_local/arbitration_research.py
+++ b/src/paranoia_local/arbitration_research.py
@@ -142,7 +142,13 @@ def binding_input(claims: Sequence[DiscoveryClaim], captures: Sequence[sources.C
     if len(claims) != len(captures):
         raise ResearchError("capture count does not match discovery count")
     rows: list[dict[str, object]] = []
+    seen_captures: dict[tuple[str | None, str | None, str | None], int] = {}
     for index, (claim, capture) in enumerate(zip(claims, captures, strict=True)):
+        identity = (capture.final_url, capture.content_sha256, capture.text_sha256)
+        referenceable = capture.usable and all(identity)
+        capture_ref = seen_captures.get(identity) if referenceable else None
+        if referenceable and capture_ref is None:
+            seen_captures[identity] = index
         rows.append({
             "claim_index": index,
             "proposition": claim.proposition,
@@ -162,7 +168,16 @@ def binding_input(claims: Sequence[DiscoveryClaim], captures: Sequence[sources.C
                 "content_sha256": capture.content_sha256,
                 "text_sha256": capture.text_sha256,
                 "error": capture.error,
-                "line_numbered_text": sources.numbered_text(capture.text or ""),
+                "fallback_attempted": capture.fallback_attempted,
+                "capture_ref": capture_ref,
+                "capture_ref_semantics": (
+                    "non-null names an earlier claim_index in this input with identical "
+                    "final URL and content/text digests; use that row's line-numbered text"
+                ),
+                "line_numbered_text": (
+                    "" if capture_ref is not None
+                    else sources.numbered_text(capture.text or "")
+                ),
             },
         })
     rendered = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))

--- a/src/paranoia_local/arbitration_research.py
+++ b/src/paranoia_local/arbitration_research.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 import hashlib
 import json
-from dataclasses import dataclass
+from dataclasses import dataclass, replace
 from typing import Iterable, Sequence
 
 from . import external_sources as sources
@@ -138,7 +138,19 @@ def parse_discovery(text: str, *, forbidden: Iterable[str] = ()) -> tuple[Discov
     return tuple(claims)
 
 
-def binding_input(claims: Sequence[DiscoveryClaim], captures: Sequence[sources.Capture]) -> str:
+CAPTURE_REF_SEMANTICS = (
+    "A non-null capture_ref names an earlier claim_index in rows with identical final URL "
+    "and content/text digests; use that row's line-numbered text."
+)
+BINDING_BUDGET_ERROR = (
+    "capture excluded from binding input because distinct captured pages exceed the "
+    f"{MAX_BINDING_INPUT_CHARS}-character aggregate binding budget"
+)
+
+
+def _render_binding_input(
+    claims: Sequence[DiscoveryClaim], captures: Sequence[sources.Capture],
+) -> str:
     if len(claims) != len(captures):
         raise ResearchError("capture count does not match discovery count")
     rows: list[dict[str, object]] = []
@@ -170,19 +182,54 @@ def binding_input(claims: Sequence[DiscoveryClaim], captures: Sequence[sources.C
                 "error": capture.error,
                 "fallback_attempted": capture.fallback_attempted,
                 "capture_ref": capture_ref,
-                "capture_ref_semantics": (
-                    "non-null names an earlier claim_index in this input with identical "
-                    "final URL and content/text digests; use that row's line-numbered text"
-                ),
                 "line_numbered_text": (
                     "" if capture_ref is not None
                     else sources.numbered_text(capture.text or "")
                 ),
             },
         })
-    rendered = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
-    if len(rendered) > MAX_BINDING_INPUT_CHARS:
-        raise ResearchError(f"binding input exceeds {MAX_BINDING_INPUT_CHARS} characters")
+    return json.dumps(
+        {"capture_ref_semantics": CAPTURE_REF_SEMANTICS, "rows": rows},
+        ensure_ascii=False, separators=(",", ":"),
+    )
+
+
+def bounded_binding_input(
+    claims: Sequence[DiscoveryClaim], captures: Sequence[sources.Capture],
+) -> tuple[str, tuple[sources.Capture, ...]]:
+    """Fit arbitration binding input by failing only the largest distinct captures closed."""
+    effective = list(captures)
+    while True:
+        rendered = _render_binding_input(claims, effective)
+        if len(rendered) <= MAX_BINDING_INPUT_CHARS:
+            return rendered, tuple(effective)
+        groups: dict[
+            tuple[str | None, str | None, str | None], list[int]
+        ] = {}
+        for index, capture in enumerate(effective):
+            identity = (capture.final_url, capture.content_sha256, capture.text_sha256)
+            if capture.usable and all(identity):
+                groups.setdefault(identity, []).append(index)
+        if not groups:
+            raise ResearchError(
+                f"binding input exceeds {MAX_BINDING_INPUT_CHARS} characters even with "
+                "every captured page unusable"
+            )
+        _identity, indices = max(
+            groups.items(),
+            key=lambda item: (
+                len(sources.numbered_text(effective[item[1][0]].text or "")),
+                tuple(-index for index in item[1]),
+            ),
+        )
+        for index in indices:
+            effective[index] = replace(
+                effective[index], text=None, error=BINDING_BUDGET_ERROR,
+            )
+
+
+def binding_input(claims: Sequence[DiscoveryClaim], captures: Sequence[sources.Capture]) -> str:
+    rendered, _ = bounded_binding_input(claims, captures)
     return rendered
 
 

--- a/src/paranoia_local/arbitration_research.py
+++ b/src/paranoia_local/arbitration_research.py
@@ -142,10 +142,7 @@ CAPTURE_REF_SEMANTICS = (
     "A non-null capture_ref names an earlier claim_index in rows with identical final URL "
     "and content/text digests; use that row's line-numbered text."
 )
-BINDING_BUDGET_ERROR = (
-    "capture excluded from binding input because distinct captured pages exceed the "
-    f"{MAX_BINDING_INPUT_CHARS}-character aggregate binding budget"
-)
+BINDING_BUDGET_ERROR = sources.BINDING_BUDGET_ERROR
 
 
 def _render_binding_input(

--- a/src/paranoia_local/external_sources.py
+++ b/src/paranoia_local/external_sources.py
@@ -314,14 +314,6 @@ def capture(
             except urllib.error.HTTPError as exc:
                 if exc.code == 403 and not browser_compatible:
                     first_403 = exc
-                    if clock() >= capture_deadline:
-                        return _http_error_capture(
-                            candidate, exc, fallback_attempted=False,
-                            detail=(
-                                "HTTP 403; browser-compatible retry not attempted because "
-                                "the source capture deadline expired"
-                            ),
-                        )
                     continue
                 return _http_error_capture(
                     candidate, exc, fallback_attempted=fallback_attempted,

--- a/src/paranoia_local/external_sources.py
+++ b/src/paranoia_local/external_sources.py
@@ -48,6 +48,10 @@ BROWSER_USER_AGENT = (
     "Chrome/127.0.0.0 Safari/537.36"
 )
 MAX_CAPTURE_ERROR_CHARS = 1200
+BINDING_BUDGET_ERROR = (
+    "capture excluded from binding input because its serialized captured text exceeds "
+    "the available binding budget"
+)
 
 
 class SourceError(ValueError):

--- a/src/paranoia_local/external_sources.py
+++ b/src/paranoia_local/external_sources.py
@@ -31,11 +31,23 @@ UGC_HOSTS = (
 )
 
 MAX_RESPONSE_BYTES = 5_000_000
-MAX_EXTRACTED_CHARS = 40_000
+MAX_EXTRACTED_CHARS = 100_000
 CONNECT_TIMEOUT_SEC = 20
 READ_TIMEOUT_SEC = 40
 MAX_REDIRECTS = 5
 READ_CHUNK_BYTES = 64 * 1024
+BASE_REQUEST_HEADERS = {
+    "User-Agent": "paranoia-local/0.1 evidence-capture",
+    "Accept": "text/html,application/xhtml+xml,text/plain;q=0.9,*/*;q=0.1",
+    "Accept-Language": "en-US,en;q=0.8",
+    "Accept-Encoding": "identity",
+}
+BROWSER_USER_AGENT = (
+    "Mozilla/5.0 (Windows NT 10.0; Win64; x64) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) "
+    "Chrome/127.0.0.0 Safari/537.36"
+)
+MAX_CAPTURE_ERROR_CHARS = 1200
 
 
 class SourceError(ValueError):
@@ -70,6 +82,7 @@ class Capture:
     text_sha256: str | None
     text: str | None
     error: str | None = None
+    fallback_attempted: bool = False
 
     @property
     def usable(self) -> bool:
@@ -213,6 +226,39 @@ def _read_body(response: object, *, deadline: float, clock: Callable[[], float])
     return bytes(body)
 
 
+def _bounded_error(value: object) -> str:
+    text = " ".join(str(value).split()) or type(value).__name__
+    if len(text) <= MAX_CAPTURE_ERROR_CHARS:
+        return text
+    return text[: MAX_CAPTURE_ERROR_CHARS - 1] + "…"
+
+
+def _http_error_capture(
+    candidate: CandidateSource,
+    error: urllib.error.HTTPError,
+    *,
+    fallback_attempted: bool,
+    detail: str | None = None,
+) -> Capture:
+    final_url: str | None = None
+    try:
+        proposed = error.geturl()
+        _validate_public_url(proposed)
+        final_url = proposed
+    except (SourceError, OSError, ValueError) as exc:
+        detail = f"HTTP {error.code}; rejected final URL: {_bounded_error(exc)}"
+    content_type = None
+    if error.headers is not None:
+        content_type = error.headers.get_content_type().lower()
+    message = detail or _bounded_error(error)
+    if fallback_attempted and error.code == 403:
+        message = f"{message}; browser-compatible retry attempted"
+    return Capture(
+        candidate, final_url, int(error.code), content_type, None, None, None,
+        _bounded_error(message), fallback_attempted,
+    )
+
+
 def capture(
     candidate: CandidateSource,
     *,
@@ -221,6 +267,7 @@ def capture(
     clock: Callable[[], float] = time.monotonic,
 ) -> Capture:
     candidate = normalize_candidate(candidate)
+    fallback_attempted = False
     try:
         started = clock()
         capture_deadline = started + CONNECT_TIMEOUT_SEC + READ_TIMEOUT_SEC
@@ -232,21 +279,55 @@ def capture(
         remaining = capture_deadline - clock()
         if remaining <= 0:
             raise SourceError("source capture deadline expired before request")
-        request = urllib.request.Request(
-            candidate.url,
-            headers={"User-Agent": "paranoia-local/0.1 evidence-capture"},
-        )
-        if opener is None:
-            handler = _SafeRedirect()
-            built_opener = urllib.request.build_opener(handler)
+        response = None
+        first_403: urllib.error.HTTPError | None = None
+        for browser_compatible in (False, True):
+            remaining = capture_deadline - clock()
+            if remaining <= 0:
+                if browser_compatible and first_403 is not None:
+                    return _http_error_capture(
+                        candidate, first_403, fallback_attempted=False,
+                        detail=(
+                            "HTTP 403; browser-compatible retry not attempted because the "
+                            "source capture deadline expired"
+                        ),
+                    )
+                raise SourceError("source capture deadline expired before request")
+            headers = dict(BASE_REQUEST_HEADERS)
+            if browser_compatible:
+                headers["User-Agent"] = BROWSER_USER_AGENT
+                fallback_attempted = True
+            request = urllib.request.Request(candidate.url, headers=headers)
+            if opener is None:
+                handler = _SafeRedirect()
+                built_opener = urllib.request.build_opener(handler)
 
-            def open_call(req: urllib.request.Request, timeout: float):
-                return built_opener.open(req, timeout=timeout)
-        else:
-            open_call = opener
-        with open_call(
-            request, min(CONNECT_TIMEOUT_SEC + READ_TIMEOUT_SEC, remaining),
-        ) as response:  # type: ignore[attr-defined]
+                def open_call(req: urllib.request.Request, timeout: float):
+                    return built_opener.open(req, timeout=timeout)
+            else:
+                open_call = opener
+            try:
+                response = open_call(
+                    request, min(CONNECT_TIMEOUT_SEC + READ_TIMEOUT_SEC, remaining),
+                )
+                break
+            except urllib.error.HTTPError as exc:
+                if exc.code == 403 and not browser_compatible:
+                    first_403 = exc
+                    if clock() >= capture_deadline:
+                        return _http_error_capture(
+                            candidate, exc, fallback_attempted=False,
+                            detail=(
+                                "HTTP 403; browser-compatible retry not attempted because "
+                                "the source capture deadline expired"
+                            ),
+                        )
+                    continue
+                return _http_error_capture(
+                    candidate, exc, fallback_attempted=fallback_attempted,
+                )
+        assert response is not None
+        with response:  # type: ignore[attr-defined]
             final_url = response.geturl()
             _validate_public_url(final_url)
             status = int(getattr(response, "status", 200))
@@ -265,9 +346,13 @@ def capture(
             content_sha256=hashlib.sha256(body).hexdigest(),
             text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
             text=text,
+            fallback_attempted=fallback_attempted,
         )
     except (SourceError, urllib.error.URLError, OSError, ValueError) as exc:
-        return Capture(candidate, None, None, None, None, None, None, str(exc))
+        return Capture(
+            candidate, None, None, None, None, None, None, _bounded_error(exc),
+            fallback_attempted,
+        )
 
 
 def capture_all(

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2125,41 +2125,69 @@ class _CapturedClaimEngine:
         batches: list[list[dict[str, Any]]] = []
         current: list[dict[str, Any]] = []
         current_chars = 2
+        seen_captures: dict[
+            tuple[str | None, str | None, str | None], tuple[int, int]
+        ] = {}
         for (claim_index, evidence_index), capture in captures.items():
             claim = discovery.claims[claim_index]
             item = claim["evidence"][evidence_index]
-            row = {
-                "claim_index": claim_index,
-                "evidence_index": evidence_index,
-                "proposition": claim["proposition"],
-                "candidate": {
-                    key: item[key] for key in (
-                        "url", "title", "publisher", "source_kind",
-                        "authority_basis", "relation",
-                    )
-                },
-                "capture": {
-                    "usable": capture.usable,
-                    "final_url": capture.final_url,
-                    "status": capture.status,
-                    "content_type": capture.content_type,
-                    "content_sha256": capture.content_sha256,
-                    "text_sha256": capture.text_sha256,
-                    "error": capture.error,
-                    "line_numbered_text": external_sources.numbered_text(capture.text or ""),
-                },
-            }
+            identity = (capture.final_url, capture.content_sha256, capture.text_sha256)
+            referenceable = capture.usable and all(identity)
+
+            def make_row(capture_ref: tuple[int, int] | None) -> dict[str, Any]:
+                return {
+                    "claim_index": claim_index,
+                    "evidence_index": evidence_index,
+                    "proposition": claim["proposition"],
+                    "candidate": {
+                        key: item[key] for key in (
+                            "url", "title", "publisher", "source_kind",
+                            "authority_basis", "relation",
+                        )
+                    },
+                    "capture": {
+                        "usable": capture.usable,
+                        "final_url": capture.final_url,
+                        "status": capture.status,
+                        "content_type": capture.content_type,
+                        "content_sha256": capture.content_sha256,
+                        "text_sha256": capture.text_sha256,
+                        "error": capture.error,
+                        "fallback_attempted": capture.fallback_attempted,
+                        "capture_ref": (
+                            None if capture_ref is None else {
+                                "claim_index": capture_ref[0],
+                                "evidence_index": capture_ref[1],
+                            }
+                        ),
+                        "line_numbered_text": (
+                            "" if capture_ref is not None else
+                            external_sources.numbered_text(capture.text or "")
+                        ),
+                    },
+                }
+
+            capture_ref = seen_captures.get(identity) if referenceable else None
+            row = make_row(capture_ref)
             row_chars = len(json.dumps(row, ensure_ascii=False, separators=(",", ":"))) + 1
-            if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
-                raise pc.AuditError(
-                    "one captured source exceeds the plan binding batch budget"
-                )
             if current and current_chars + row_chars > MAX_PLAN_BINDING_BATCH_CHARS:
                 batches.append(current)
                 current = []
                 current_chars = 2
+                seen_captures = {}
+                capture_ref = None
+                row = make_row(capture_ref)
+                row_chars = len(
+                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+                ) + 1
+            if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
+                raise pc.AuditError(
+                    "one captured source exceeds the plan binding batch budget"
+                )
             current.append(row)
             current_chars += row_chars
+            if referenceable and capture_ref is None:
+                seen_captures[identity] = (claim_index, evidence_index)
         if current:
             batches.append(current)
         if len(batches) > MAX_PLAN_BINDING_BATCHES:
@@ -2186,6 +2214,8 @@ class _CapturedClaimEngine:
             instruction = (
                 "Bind every indexed candidate below using only its server capture. Return "
                 "exactly one row per (claim_index,evidence_index); preserve both indices. "
+                "A capture_ref points to an earlier row in this batch with identical final "
+                "URL and content/text digests; use that earlier row's line-numbered text. "
                 "Copy a precise location and exact passage only when usable, otherwise use "
                 "nulls. Do not return claims or source metadata.\n\n"
                 f"{PLAN_BINDING_MARKER}\n"

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2170,6 +2170,18 @@ class _CapturedClaimEngine:
             capture_ref = seen_captures.get(identity) if referenceable else None
             row = make_row(capture_ref)
             row_chars = len(json.dumps(row, ensure_ascii=False, separators=(",", ":"))) + 1
+            if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
+                capture = replace(
+                    capture, text=None,
+                    error=external_sources.BINDING_BUDGET_ERROR,
+                )
+                captures[(claim_index, evidence_index)] = capture
+                referenceable = False
+                capture_ref = None
+                row = make_row(None)
+                row_chars = len(
+                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+                ) + 1
             if current and current_chars + row_chars > MAX_PLAN_BINDING_BATCH_CHARS:
                 batches.append(current)
                 current = []

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -2181,9 +2181,21 @@ class _CapturedClaimEngine:
                     json.dumps(row, ensure_ascii=False, separators=(",", ":"))
                 ) + 1
             if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
-                raise pc.AuditError(
-                    "one captured source exceeds the plan binding batch budget"
+                capture = replace(
+                    capture, text=None,
+                    error=external_sources.BINDING_BUDGET_ERROR,
                 )
+                captures[(claim_index, evidence_index)] = capture
+                referenceable = False
+                capture_ref = None
+                row = make_row(None)
+                row_chars = len(
+                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
+                ) + 1
+                if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
+                    raise pc.AuditError(
+                        "one capture's non-text metadata exceeds the plan binding batch budget"
+                    )
             current.append(row)
             current_chars += row_chars
             if referenceable and capture_ref is None:

--- a/tests/test_acceptance_validator.py
+++ b/tests/test_acceptance_validator.py
@@ -396,6 +396,10 @@ def cleaning_fixture(tmp_path: Path) -> tuple[Path, Path]:
         ["git", "-c", "commit.gpgsign=false", "commit", "--amend", "--no-edit", "-q"],
         cwd=repo, check=True,
     )
+    source_commit = subprocess.run(
+        ["git", "rev-parse", "HEAD"], cwd=repo, check=True,
+        capture_output=True, text=True,
+    ).stdout.strip()
     diff_rows = subprocess.run(
         ["git", "diff", "--numstat", f"{base}..HEAD"], cwd=repo, check=True,
         capture_output=True, text=True,
@@ -410,6 +414,7 @@ def cleaning_fixture(tmp_path: Path) -> tuple[Path, Path]:
     artifact = tmp_path / "cleaning-acceptance.json"
     artifact.write_text(json.dumps({
         "acceptance_kind": "cleaning-attestation-v1",
+        "source_commit": source_commit,
         "acceptance_scope": {
             "proves": [
                 "caller context and normalized options reached both deciders in the recorded runs",

--- a/tests/test_arbitration_research.py
+++ b/tests/test_arbitration_research.py
@@ -53,6 +53,28 @@ def test_binding_requires_exact_captured_passage():
         ar.parse_binding(bad, claims, captures)
 
 
+def test_binding_input_compacts_repeated_large_capture():
+    value = json.loads(discovery().split("\n", 1)[1])
+    second = json.loads(json.dumps(value["claims"][0]))
+    second["proposition"] = "The API waits before retrying."
+    value["claims"].append(second)
+    claims = ar.parse_discovery(ar.DISCOVERY_MARKER + "\n" + json.dumps(value))
+    text = "x" * 70_000
+    captures = [
+        es.Capture(
+            claim.candidate, claim.candidate.url, 200, "text/html",
+            "a" * 64, "b" * 64, text,
+        )
+        for claim in claims
+    ]
+    rendered = json.loads(ar.binding_input(claims, captures))
+    assert rendered[0]["capture"]["capture_ref"] is None
+    assert rendered[1]["capture"]["capture_ref"] == 0
+    assert rendered[1]["capture"]["line_numbered_text"] == ""
+    assert rendered[0]["capture"]["line_numbered_text"].endswith(text)
+    assert "earlier claim_index" in rendered[1]["capture"]["capture_ref_semantics"]
+
+
 def test_packet_union_is_deterministic_and_governing():
     claims = ar.parse_discovery(discovery())
     captures = [captured(claims[0])]

--- a/tests/test_arbitration_research.py
+++ b/tests/test_arbitration_research.py
@@ -68,11 +68,43 @@ def test_binding_input_compacts_repeated_large_capture():
         for claim in claims
     ]
     rendered = json.loads(ar.binding_input(claims, captures))
-    assert rendered[0]["capture"]["capture_ref"] is None
-    assert rendered[1]["capture"]["capture_ref"] == 0
-    assert rendered[1]["capture"]["line_numbered_text"] == ""
-    assert rendered[0]["capture"]["line_numbered_text"].endswith(text)
-    assert "earlier claim_index" in rendered[1]["capture"]["capture_ref_semantics"]
+    rows = rendered["rows"]
+    assert rows[0]["capture"]["capture_ref"] is None
+    assert rows[1]["capture"]["capture_ref"] == 0
+    assert rows[1]["capture"]["line_numbered_text"] == ""
+    assert rows[0]["capture"]["line_numbered_text"].endswith(text)
+    assert "earlier claim_index" in rendered["capture_ref_semantics"]
+
+
+def test_distinct_large_captures_degrade_per_source_to_fit_binding_budget():
+    value = json.loads(discovery().split("\n", 1)[1])
+    template = value["claims"][0]
+    value["claims"] = []
+    for index in range(5):
+        item = json.loads(json.dumps(template))
+        item["proposition"] = f"The API behavior {index} is documented."
+        item["candidate"]["url"] = f"https://docs.example.com/api/{index}"
+        value["claims"].append(item)
+    claims = ar.parse_discovery(ar.DISCOVERY_MARKER + "\n" + json.dumps(value))
+    captures = tuple(
+        es.Capture(
+            claim.candidate, claim.candidate.url, 200, "text/html",
+            f"{index:064x}", f"{index + 10:064x}", "x" * 100_000,
+        )
+        for index, claim in enumerate(claims)
+    )
+    rendered, effective = ar.bounded_binding_input(claims, captures)
+    assert len(rendered) <= ar.MAX_BINDING_INPUT_CHARS
+    assert any(not capture.usable for capture in effective)
+    assert any(capture.usable for capture in effective)
+    assert all(
+        capture.error == ar.BINDING_BUDGET_ERROR
+        for capture in effective if not capture.usable
+    )
+    rows = json.loads(rendered)["rows"]
+    assert [row["capture"]["usable"] for row in rows] == [
+        capture.usable for capture in effective
+    ]
 
 
 def test_packet_union_is_deterministic_and_governing():

--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -1,6 +1,7 @@
 from email.message import Message
 import threading
 import time
+import urllib.error
 
 import pytest
 
@@ -78,8 +79,9 @@ def test_exact_passage_matching_is_unicode_and_whitespace_conservative():
 class Response:
     status = 200
 
-    def __init__(self, body: bytes, content_type="text/html"):
+    def __init__(self, body: bytes, content_type="text/html", *, url=None):
         self.body = body
+        self.url = url or "https://docs.example.com/page"
         self.headers = Message()
         self.headers["Content-Type"] = content_type
 
@@ -90,7 +92,7 @@ class Response:
         return False
 
     def geturl(self):
-        return "https://docs.example.com/page"
+        return self.url
 
     def read(self, size):
         return self.body[:size]
@@ -126,6 +128,150 @@ def test_oversized_response_is_visible_non_governing(monkeypatch):
     got = es.capture(candidate(), opener=lambda _request, _timeout: Response(body, "text/plain"))
     assert not got.usable
     assert "exceeds" in got.error
+
+
+def test_raw_response_reader_admits_exact_byte_boundary():
+    body = b"x" * es.MAX_RESPONSE_BYTES
+    got = es._read_body(Response(body), deadline=1.0, clock=lambda: 0.0)
+    assert len(got) == es.MAX_RESPONSE_BYTES
+
+
+def test_large_extracted_page_keeps_deep_evidence(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    passage = "The governing behavior is stated near the end."
+    body = (("x" * 70_000) + "\n" + passage).encode()
+    got = es.capture(candidate(), opener=lambda _request, _timeout: Response(body, "text/plain"))
+    assert got.usable
+    assert len(got.text) > 40_000
+    assert es.passage_matches(passage, got.text)
+
+
+def test_extracted_character_cap_admits_boundary_and_rejects_next_character():
+    assert len(es._extract(b"x" * es.MAX_EXTRACTED_CHARS, "text/plain")) == 100_000
+    with pytest.raises(es.SourceError, match="extracted page has 100001 characters"):
+        es._extract(b"x" * (es.MAX_EXTRACTED_CHARS + 1), "text/plain")
+
+
+def _http_error(url: str, code: int) -> urllib.error.HTTPError:
+    headers = Message()
+    headers["Content-Type"] = "text/html"
+    return urllib.error.HTTPError(url, code, "Forbidden", headers, None)
+
+
+def test_capture_sends_compatible_headers_and_retries_403_once(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    requests = []
+
+    def opener(request, _timeout):
+        requests.append(request)
+        if len(requests) == 1:
+            raise _http_error("https://docs.example.com/blocked", 403)
+        return Response(b"Authoritative text", "text/plain", url="https://docs.example.com/final")
+
+    got = es.capture(candidate(), opener=opener)
+    assert got.usable
+    assert got.fallback_attempted
+    assert got.final_url == "https://docs.example.com/final"
+    assert len(requests) == 2
+    assert requests[0].get_header("User-agent") == es.BASE_REQUEST_HEADERS["User-Agent"]
+    assert requests[1].get_header("User-agent") == es.BROWSER_USER_AGENT
+    for name in ("Accept", "Accept-language", "Accept-encoding"):
+        assert requests[0].get_header(name) == requests[1].get_header(name)
+
+
+def test_persistent_403_retains_status_url_and_retry_provenance(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    calls = []
+
+    def opener(request, _timeout):
+        calls.append(request)
+        raise _http_error("https://docs.example.com/forbidden", 403)
+
+    got = es.capture(candidate(), opener=opener)
+    assert not got.usable
+    assert got.final_url == "https://docs.example.com/forbidden"
+    assert got.status == 403
+    assert got.fallback_attempted
+    assert "browser-compatible retry attempted" in got.error
+    assert len(calls) == 2
+
+
+def test_non_403_http_error_is_not_retried(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    calls = []
+
+    def opener(request, _timeout):
+        calls.append(request)
+        raise _http_error("https://docs.example.com/missing", 404)
+
+    got = es.capture(candidate(), opener=opener)
+    assert got.status == 404
+    assert not got.fallback_attempted
+    assert len(calls) == 1
+
+
+def test_403_retry_does_not_reset_or_outlive_deadline(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    now = [0.0]
+    calls = []
+
+    def opener(request, _timeout):
+        calls.append(request)
+        now[0] = 5.0
+        raise _http_error("https://docs.example.com/forbidden", 403)
+
+    got = es.capture(candidate(), opener=opener, deadline=5.0, clock=lambda: now[0])
+    assert got.status == 403
+    assert not got.fallback_attempted
+    assert "deadline expired" in got.error
+    assert len(calls) == 1
+
+
+def test_default_403_retry_uses_fresh_redirect_handler(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    handlers = []
+
+    class Opener:
+        def __init__(self, handler):
+            self.handler = handler
+
+        def open(self, _request, *, timeout):
+            assert timeout > 0
+            if len(handlers) == 1:
+                raise _http_error("https://docs.example.com/forbidden", 403)
+            return Response(b"Authoritative text", "text/plain")
+
+    def build_opener(handler):
+        handlers.append(handler)
+        return Opener(handler)
+
+    monkeypatch.setattr(es.urllib.request, "build_opener", build_opener)
+    got = es.capture(candidate())
+    assert got.usable
+    assert got.fallback_attempted
+    assert len(handlers) == 2
+    assert handlers[0] is not handlers[1]
+
+
+def test_403_fallback_rejects_non_public_final_url(monkeypatch):
+    def validate(url):
+        if url == "http://127.0.0.1/private":
+            raise es.SourceError("source host resolves to non-public address 127.0.0.1")
+
+    monkeypatch.setattr(es, "_validate_public_url", validate)
+    calls = []
+
+    def opener(request, _timeout):
+        calls.append(request)
+        if len(calls) == 1:
+            raise _http_error("https://docs.example.com/forbidden", 403)
+        return Response(b"private", "text/plain", url="http://127.0.0.1/private")
+
+    got = es.capture(candidate(), opener=opener)
+    assert not got.usable
+    assert got.fallback_attempted
+    assert "non-public address" in got.error
+    assert len(calls) == 2
 
 
 def test_slow_stream_cannot_outlive_capture_deadline(monkeypatch):

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -43,9 +43,9 @@ def test_large_page_capture_acceptance_record() -> None:
     )
     assert artifact["arbitration_research"] == {
         "model_calls": ["arbitration-discovery", "arbitration-binding"],
-        "claim_count": 4,
-        "capture_count": 4,
-        "bound_count": 4,
+        "claim_count": 5,
+        "capture_count": 5,
+        "bound_count": 5,
         "binding_budget_demotions": 0,
         "validation_retries": 0,
     }

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -40,8 +40,13 @@ def test_large_page_capture_acceptance_record() -> None:
         row["publisher_authority"] and row["passage_entailment"]
         for row in artifact["verified_plan"]["evidence"]
     )
+    source_commit = artifact["source_commit"]
     for relative, expected in artifact["source_sha256"].items():
-        assert hashlib.sha256((root / relative).read_bytes()).hexdigest() == expected
+        content = subprocess.run(
+            ["git", "show", f"{source_commit}:{relative}"], cwd=root,
+            capture_output=True, check=True,
+        ).stdout
+        assert hashlib.sha256(content).hexdigest() == expected
 
 
 def test_minimal_claim_validation_acceptance_record() -> None:
@@ -1650,6 +1655,42 @@ def test_plan_binding_batches_large_ordinary_inventory(tmp_path: Path) -> None:
         assert batches[0][1]["capture"]["line_numbered_text"] == ""
     finally:
         adapter.close()
+
+
+def test_plan_binding_capture_references_never_cross_batch_boundary(tmp_path: Path) -> None:
+    lines = [f"External behavior {index} is guaranteed." for index in range(6)]
+    plan = "# Plan\n\n" + "\n".join(lines)
+    audit = pc.parse_audit(_audit(*[
+        _claim(anchor=line, proposition=line) for line in lines
+    ]), plan)
+    identities = [0, 1, 2, 3, 0, 0]
+    captures = {}
+    for claim_index, (claim, identity) in enumerate(zip(audit.claims, identities)):
+        item = claim["evidence"][0]
+        candidate = external_sources.CandidateSource(
+            item["url"], item["title"], item["publisher"], item["source_kind"],
+            item["authority_basis"], item["relation"],
+        )
+        captures[(claim_index, 0)] = external_sources.Capture(
+            candidate, f"{candidate.url}?page={identity}", 200, "text/html",
+            f"{identity:064x}", f"{identity + 10:064x}",
+            "x" * external_sources.MAX_EXTRACTED_CHARS,
+        )
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batches = adapter._binding_batches(audit, captures)
+    finally:
+        adapter.close()
+    assert len(batches) == 2
+    assert [row["claim_index"] for row in batches[1]] == [3, 4, 5]
+    assert batches[1][1]["capture"]["capture_ref"] is None
+    assert batches[1][1]["capture"]["line_numbered_text"]
+    assert batches[1][2]["capture"]["capture_ref"] == {
+        "claim_index": 4, "evidence_index": 0,
+    }
+    assert batches[1][2]["capture"]["line_numbered_text"] == ""
 
 
 def test_plan_capture_aggregate_ceiling_blocks_before_network(

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -27,7 +27,8 @@ def test_large_page_capture_acceptance_record() -> None:
     )
     assert artifact["acceptance_kind"] == "large-page-plan-claim-capture"
     assert artifact["runtime"]["model_calls"] == [
-        "evidence-discovery", "evidence-binding", "evidence-text",
+        "plan-evidence-discovery", "plan-evidence-binding", "plan-evidence-text",
+        "arbitration-discovery", "arbitration-binding",
     ]
     assert artifact["runtime"]["validation_retries"] == 0
     assert artifact["direct_capture"]["extracted_characters"] == 70_378
@@ -40,6 +41,14 @@ def test_large_page_capture_acceptance_record() -> None:
         row["publisher_authority"] and row["passage_entailment"]
         for row in artifact["verified_plan"]["evidence"]
     )
+    assert artifact["arbitration_research"] == {
+        "model_calls": ["arbitration-discovery", "arbitration-binding"],
+        "claim_count": 6,
+        "capture_count": 6,
+        "bound_count": 6,
+        "binding_budget_demotions": 0,
+        "validation_retries": 0,
+    }
     source_commit = artifact["source_commit"]
     for relative, expected in artifact["source_sha256"].items():
         content = subprocess.run(

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1728,6 +1728,40 @@ def test_plan_binding_demotes_one_escape_amplified_capture_per_source(tmp_path: 
     assert batches[0][0]["capture"]["line_numbered_text"] == ""
 
 
+def test_escape_amplified_capture_is_demoted_before_flushing_current_batch(
+    tmp_path: Path,
+) -> None:
+    lines = [f"External behavior {index} is guaranteed." for index in range(4)]
+    plan = "# Plan\n\n" + "\n".join(lines)
+    audit = pc.parse_audit(_audit(*[
+        _claim(anchor=line, proposition=line) for line in lines
+    ]), plan)
+    captures = {}
+    for claim_index, claim in enumerate(audit.claims):
+        item = claim["evidence"][0]
+        candidate = external_sources.CandidateSource(
+            item["url"], item["title"], item["publisher"], item["source_kind"],
+            item["authority_basis"], item["relation"],
+        )
+        captures[(claim_index, 0)] = external_sources.Capture(
+            candidate, f"{candidate.url}?page={claim_index}", 200, "text/plain",
+            f"{claim_index:064x}", f"{claim_index + 10:064x}",
+            ("x" * external_sources.MAX_EXTRACTED_CHARS)
+            if claim_index < 3 else ("\n" * external_sources.MAX_EXTRACTED_CHARS),
+        )
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batches = adapter._binding_batches(audit, captures)
+    finally:
+        adapter.close()
+    assert len(batches) == 1
+    assert len(batches[0]) == 4
+    assert batches[0][-1]["capture"]["usable"] is False
+    assert captures[(3, 0)].error == external_sources.BINDING_BUDGET_ERROR
+
+
 def test_plan_capture_aggregate_ceiling_blocks_before_network(
     tmp_path: Path, monkeypatch,
 ) -> None:

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -36,16 +36,16 @@ def test_large_page_capture_acceptance_record() -> None:
     assert artifact["direct_capture"]["current_limit"] >= 70_378
     assert artifact["verified_plan"]["verdict"] == "supported"
     assert artifact["verified_plan"]["blocked"] is False
-    assert len(artifact["verified_plan"]["evidence"]) == 2
+    assert len(artifact["verified_plan"]["evidence"]) == 1
     assert all(
         row["publisher_authority"] and row["passage_entailment"]
         for row in artifact["verified_plan"]["evidence"]
     )
     assert artifact["arbitration_research"] == {
         "model_calls": ["arbitration-discovery", "arbitration-binding"],
-        "claim_count": 6,
-        "capture_count": 6,
-        "bound_count": 6,
+        "claim_count": 4,
+        "capture_count": 4,
+        "bound_count": 4,
         "binding_budget_demotions": 0,
         "validation_retries": 0,
     }

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -20,6 +20,30 @@ from paranoia_local.engines import Review
 PLAN = "# Rollout\n\nPython 3.11 was released in October 2022.\n"
 
 
+def test_large_page_capture_acceptance_record() -> None:
+    root = Path(__file__).resolve().parents[1]
+    artifact = json.loads(
+        (root / "docs/large_page_capture_acceptance_2026-08-18.json").read_text()
+    )
+    assert artifact["acceptance_kind"] == "large-page-plan-claim-capture"
+    assert artifact["runtime"]["model_calls"] == [
+        "evidence-discovery", "evidence-binding", "evidence-text",
+    ]
+    assert artifact["runtime"]["validation_retries"] == 0
+    assert artifact["direct_capture"]["extracted_characters"] == 70_378
+    assert artifact["direct_capture"]["former_limit"] < 70_378
+    assert artifact["direct_capture"]["current_limit"] >= 70_378
+    assert artifact["verified_plan"]["verdict"] == "supported"
+    assert artifact["verified_plan"]["blocked"] is False
+    assert len(artifact["verified_plan"]["evidence"]) == 2
+    assert all(
+        row["publisher_authority"] and row["passage_entailment"]
+        for row in artifact["verified_plan"]["evidence"]
+    )
+    for relative, expected in artifact["source_sha256"].items():
+        assert hashlib.sha256((root / relative).read_bytes()).hexdigest() == expected
+
+
 def test_minimal_claim_validation_acceptance_record() -> None:
     root = Path(__file__).resolve().parents[1]
     artifact = json.loads(
@@ -1617,8 +1641,13 @@ def test_plan_binding_batches_large_ordinary_inventory(tmp_path: Path) -> None:
                 "x" * external_sources.MAX_EXTRACTED_CHARS,
             )
         batches = adapter._binding_batches(audit, captures)
-        assert len(batches) == 2
+        assert len(batches) == 1
         assert sum(map(len, batches)) == 11
+        assert batches[0][0]["capture"]["capture_ref"] is None
+        assert batches[0][1]["capture"]["capture_ref"] == {
+            "claim_index": 0, "evidence_index": 0,
+        }
+        assert batches[0][1]["capture"]["line_numbered_text"] == ""
     finally:
         adapter.close()
 
@@ -1668,7 +1697,8 @@ def test_plan_binding_aggregate_batch_ceiling_raises_before_model_calls(
             item["authority_basis"], item["relation"],
         )
         captures[(claim_index, 0)] = external_sources.Capture(
-            candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+            candidate, f"{candidate.url}?claim={claim_index}", 200, "text/html",
+            f"{claim_index:064x}", "b" * 64,
             "x" * external_sources.MAX_EXTRACTED_CHARS,
         )
     try:
@@ -2252,3 +2282,42 @@ def test_plan_binding_demotes_a_redirect_to_ugc(tmp_path: Path) -> None:
         assert bound.claims[0]["evidence"][0]["source_kind"] == "ugc"
     finally:
         adapter.close()
+
+
+def test_persistent_403_provenance_survives_claim_state_reload(tmp_path: Path) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    capture = external_sources.Capture(
+        candidate, "https://www.python.org/forbidden", 403, "text/html",
+        None, None, None,
+        "HTTP Error 403: Forbidden; browser-compatible retry attempted", True,
+    )
+    binding = (
+        handlers.PLAN_BINDING_MARKER
+        + '\n{"bindings":[{"claim_index":0,"evidence_index":0,"usable":false,'
+        '"location":null,"passage":null}]}'
+    )
+    engine = _RoleScript({"evidence-binding": [binding]})
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        bound, _ = adapter._bind_indexed(
+            "session", audit, {(0, 0): capture}, "m", "high", {"timeout": 300},
+        )
+    finally:
+        adapter.close()
+    state = pc.reconcile(
+        {}, bound, lineage_id="persistent-403", round_no=1, plan_text=PLAN,
+    )
+    reloaded = pc.normalize_state(json.loads(json.dumps(state)))
+    evidence = next(iter(reloaded["claims"].values()))["evidence"][0]
+    assert evidence["url"] == "https://www.python.org/forbidden"
+    assert evidence["location"] == "Server capture unavailable"
+    assert "HTTP Error 403" in evidence["quote"]
+    assert "browser-compatible retry attempted" in evidence["quote"]

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1702,6 +1702,32 @@ def test_plan_binding_capture_references_never_cross_batch_boundary(tmp_path: Pa
     assert batches[1][2]["capture"]["line_numbered_text"] == ""
 
 
+def test_plan_binding_demotes_one_escape_amplified_capture_per_source(tmp_path: Path) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/plain", "a" * 64, "b" * 64,
+        "\n" * external_sources.MAX_EXTRACTED_CHARS,
+    )}
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batches = adapter._binding_batches(audit, captures)
+    finally:
+        adapter.close()
+    assert len(batches) == 1
+    assert len(batches[0]) == 1
+    assert not captures[(0, 0)].usable
+    assert captures[(0, 0)].error == external_sources.BINDING_BUDGET_ERROR
+    assert batches[0][0]["capture"]["usable"] is False
+    assert batches[0][0]["capture"]["line_numbered_text"] == ""
+
+
 def test_plan_capture_aggregate_ceiling_blocks_before_network(
     tmp_path: Path, monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary

- admit complete extracted evidence pages through 100,000 characters while preserving the 5,000,000-byte raw-response circuit breaker
- compact identical captures and fail serialized budget overflow per source, preserving bounded plan and arbitration calls
- retry HTTP 403 once with browser-compatible headers under the original deadline and redirect/public-address policy
- retain persistent 403 URL, status, bounded error, and retry provenance without cookies, browser automation, mirrors, or access-control bypass
- pin dated acceptance source hashes to immutable commits

## Verification

- 1,144 tests passed; one unrelated historical staged replay baseline deselected
- signed-in plan discovery, 70,378-character server capture, tool-less binding, and cold attestation passed
- signed-in arbitration discovery/binding passed: 5 claims, 5 captures, 5 bound, 0 validation retries
- PLAN convergence: NOT-BLOCKED
- CODE convergence: NOT-BLOCKED, 3 classes closed, 0 open