### PR TITLE
Support complete authoritative source capture

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,14 +203,43 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   Treat the final redirect URL as governing UGC/self-source eligibility and persist capture
   digests plus cold authority/entailment decisions before support may freeze.
   Keep the 5,000,000-byte raw response circuit breaker and admit complete extracted text through
-  100,000 characters. Deduplicate identical final-URL/content/text captures only within one
+  1,000,000 characters. In plan verification, preserve complete-source context. Let a normalized,
+  structurally governing primary or authoritative capture that exceeds the ordinary 400,000-
+  character batch occupy one dedicated expanded packet only when the exact complete initial and
+  correction prompts fit 685,000 characters, recomputing eligibility from the final URL. Carry its
+  complete capture into the cold attestation prompt and enforce the same exact prompt bound there.
+  Before binding admission, reserve the maximum bounded validation diagnostic, location, passage,
+  correction template, and attestation envelope so later output cannot overflow unrelated evidence.
+  Pack cold attestation by exact initial-and-correction prompt size into at most five batches and
+  allow one same-session validation correction. Persist one closed server-owned capture-provenance
+  row per source outcome with explicit nullable response metadata, both digests, fallback fact, and
+  bounded error; retain it when an expanded packet cannot be bound or attested.
+  Bound the complete evidence phase to 22 model calls (the discovery + five binding + five
+  attestation topology and one reserved correction for every initial call) as a pathology guard,
+  not a quality target. Admit an initial call only when both its call-count and full latency reserve
+  fit the remaining monotonic deadline. Before the first model call, reserve the complete maximum
+  model/retry graph plus explicit non-model capture/processing time and scheduling slack.
+  Use the same pure prompt renderers for preflight and invocation and test the exact strings; do not
+  maintain parallel size estimates.
+  Packet and latency limits are circuit breakers, not
+  irretractable evidence-quality budgets. Deduplicate
+  identical final-URL/content/text captures only within one
   binding prompt or batch, using an earlier-row reference bound to all three values. Count actual
   numbered, metadata-bearing, JSON-escaped representations against aggregate binding budgets.
   When distinct arbitration captures exceed its single prompt budget, deterministically demote
   the largest capture groups to bounded server-owned binding-budget failures until it fits;
   preserve the remaining research and do not add a model call.
-  Apply the same per-source failure to a plan capture whose numbered and JSON-escaped row alone
-  exceeds one binding batch; never let one admitted page abort unrelated plan evidence.
+  Apply the same per-source failure when a row is ineligible for expansion or its complete expanded
+  prompt cannot fit; never silently truncate an admitted page or let it abort unrelated plan
+  evidence. Bound model-authored binding fields before downstream attestation, and bind replacement
+  evidence against the replacement proposition rather than the original proposition. Bypass model
+  binding for unavailable captures so omission cannot overwrite a known capture failure. A failed
+  dedicated expanded call is a diagnostic-retaining source-local failure; continue unrelated
+  batches and preserve its requested location, nullable effective HTTP(S) final URL, response
+  metadata, fallback fact, and capture digests. A non-web context location remains a valid
+  uncaptured provenance outcome and must not invalidate independently captured HTTP(S) evidence.
+  Partition unavailable captures before row construction, materialize their server-owned decision
+  directly, and never expose them to provider binding output.
   Retry HTTP 403 at most once with a browser-compatible user agent, a fresh redirect counter, and
   the original absolute deadline and public-address/final-URL policy. A persistent 403 remains
   unusable and retains final URL, numeric status, bounded error, and retry fact; never add cookies,
@@ -218,6 +247,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   Validate retained inventory before capture; attest replacement wording as its own exact
   proposition; and enforce aggregate capture/binding budgets so multiplicative per-claim maxima
   become visible debt rather than an hours-long run.
+  Reject a sixth exact binding or cold-attestation batch globally before that role settles a
+  prefix; aggregate ceilings must never become cross-round pagination.
   Treat an omitted expected indexed binding row as unusable for that exact source and demote only
   the affected claim when it has no other qualifying evidence. Preserve omission as a distinct
   conservative outcome from an explicit `usable:false` row so durable provenance remains truthful.
@@ -229,6 +260,8 @@ sizes, and convergence phases to stop pathological work while allowing valid cal
   scalar or container alias may bind authority or entailment to another claim or evidence row.
   Bound the full verified plan call below the documented MCP timeout, persist claim debt before
   structural review, and start each model phase only when its full cap fits the monotonic deadline.
+  Enforce the reserved non-model capture/pre-binding interval as one aggregate monotonic deadline;
+  it may not consume time reserved for later model phases.
   Captured binding failure debt must retain raw provider stdout, structured failure detail, and
   process stderr as distinct hashed and bounded channels, including initial and correction calls.
 - The evidence register is mechanically external-only. Retain atomic, load-bearing external

--- a/README.md
+++ b/README.md
@@ -373,13 +373,17 @@ entailment before a packet can close a claim. Claude `WebFetch` is never enabled
 this path. There is no `PARANOIA_SEARCH_ENDPOINT`, API key, plugin, or caller-supplied search
 adapter.
 Capture keeps a 5,000,000-byte response circuit breaker but admits complete Trafilatura output
-through 100,000 characters, so ordinary long reference pages are not discarded at the former
-40,000-character threshold. Repeated identical captures are rendered once per binding prompt or
+through 1,000,000 characters. Plan binding keeps complete-source context: an otherwise governing
+primary or authoritative capture that exceeds the ordinary 400,000-character batch may occupy one
+dedicated expanded packet when the exact rendered prompt fits 685,000 characters. Its complete
+capture accompanies the selected passage in the cold attestation packet, which is checked against
+the same exact bound before binding admission, including maximum output and correction-envelope
+reserves. Repeated identical captures are rendered once per binding prompt or
 batch and referenced by final URL plus content/text digests; distinct pages still obey the
 existing serialized aggregate ceilings. Arbitration deterministically marks the largest distinct
 captures unusable until its single binding prompt fits, so one large-source group fails closed
-without aborting all research. Plan binding likewise marks an individual capture unusable when
-line numbering or JSON escaping makes its row exceed one batch; other captures continue.
+without aborting all research. Plan binding sizes complete initial and correction prompts from
+their actual numbered, metadata-bearing, JSON-escaped representation.
 Requests use explicit HTML/text accept headers and identity content
 encoding (`Accept-Encoding: identity`). An HTTP 403 receives one same-URL browser-compatible retry inside
 the original deadline and redirect/public-address policy. A persistent 403 remains fail-closed
@@ -388,7 +392,11 @@ server never uses cookies, browser automation, mirrors, snippets, or provider-fe
 Redirect destinations govern URL eligibility, UGC/self-source classification, packet identity,
 and the persisted source URL; a benign discovery URL cannot launder an ineligible destination.
 Persisted claim provenance includes the captured-text digest and cold authority/entailment
-decisions, so legacy unattested support is researched once before freezing.
+decisions, so legacy unattested support is researched once before freezing. A separate closed
+server-owned `capture_provenance` row retains the requested location, nullable effective HTTP(S)
+final URL, nullable response metadata, fallback fact, both digests, and bounded failure for every
+source outcome. Non-web repository/file/custom context therefore remains representable without
+pretending it was captured; model attestation cannot overwrite this provenance.
 
 The register is mechanically limited to load-bearing external propositions in three kinds:
 
@@ -507,9 +515,20 @@ guards, but its composed execution budget is deliberately narrower: at most 200 
 and five 400,000-character binding batches. Exceeding an aggregate budget becomes visible
 blocking debt; the server never starts a multiplicative hours-long tail or truncates it into
 false closure.
-The complete evidence phase also has a 6,000-second monotonic deadline and nine model calls
-maximum. That fits discovery, five maximum-size binding batches, cold attestation, and one
-correction in both discovery and binding. The full verified plan call is bounded to 7,080 seconds.
+The complete evidence phase has a 6,960-second monotonic circuit breaker and 22 model calls
+maximum. That admits discovery, five maximum-size binding batches, five exact-size
+cold-attestation batches, and the promised one validation correction for every call. Before each
+first spend the server reserves the complete 22-call graph, 300 seconds for capture and bounded
+local processing, and 60 seconds of scheduling slack. Before each initial call it also reserves
+both call-count and two 300-second windows for its correction.
+The capture pool and exact pre-binding packing share that one enforced 300-second monotonic
+deadline; exhaustion blocks visibly before the first binding call rather than consuming time
+reserved for later model phases.
+These are pathology guards, not targets or reasons to shorten an admitted review. The full verified
+plan call remains bounded to 7,080 seconds.
+If exact packing would require a sixth binding or cold-attestation batch, the complete evidence
+phase fails globally before that role spends or settles any prefix. The limit cannot act as
+cross-round pagination for a partially supported inventory.
 Evidence state is persisted first. A staged census starts only when its full 4,320-second
 lane/consolidation/retry reserve still fits; correction and final use a 3,120-second reserve. If the
 reserve no longer fits, the result is visibly pending and the next round reuses frozen supported

--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -1,0 +1,123 @@
+{
+  "acceptance_kind": "measured-authoritative-plan-capture-v1",
+  "date": "2026-08-21",
+  "acceptance_claims": {
+    "qualifies": "The named Spotify SEC source completed the current Codex public critique_plan claim lifecycle with an ordinary sibling and survived durable reload as supported.",
+    "corroborates": "The named source also completed direct current Codex and Claude binding/cold-attestation routes with the recorded prompt and reply digests.",
+    "does_not_claim": "No exact-maximum provider transport guarantee, arbitrary page support, future provider compatibility, or success for every packet through the configured ceiling."
+  },
+  "source": {
+    "url": "https://www.sec.gov/Archives/edgar/data/1639920/000163992025000003/ck0001639920-20241231.htm",
+    "title": "Spotify Technology S.A. 2024 Annual Report",
+    "publisher": "Spotify Technology S.A.",
+    "expanded_prompt_ceiling": 685000,
+    "extracted_characters": 590177,
+    "former_limit": 100000,
+    "content_sha256": "289b7bef1c4ee87c54154982a807b6641543fbb97a1b265365f111cc51059fe6",
+    "text_sha256": "2fbc63a47b1582fa5268afb1184377f14c9d31fdaae2a2134665e263602625c2"
+  },
+  "proposition": "Spotify had 675 million monthly active users as of December 31, 2024.",
+  "routes": [
+    {
+      "engine": "codex",
+      "model": "gpt-5.6-sol",
+      "cli_version": "0.144.6",
+      "fresh_binding_bootstrap": true,
+      "resumed_binding": true,
+      "fresh_full_context_attestation": true,
+      "binding_prompt_characters": 627172,
+      "binding_prompt_sha256": "f0056e12b125b24a80ac06a383ce957abf54ab45034231ca72ebd56378b62e04",
+      "binding_correction_prompt_sha256": "76c6a15a0a0b1fe440878a6d7be2d775d26cadada3b4a9706f4e446b673257b4",
+      "attestation_prompt_characters": 627110,
+      "attestation_prompt_sha256": "8dae6abd09297d0c0f38e5e534518c8d2023a8ab5ad10e8988f0d09e8d923626",
+      "bootstrap_reply_sha256": "c2e3ac47f4a325469c1a2d5f117e463ec943c721986d5d9f09ac4540b7d80526",
+      "binding_reply_sha256": ["edfc4a50be49cc25efaa186da26e527cfeac0949b4f8f9ebc89810f13bef1069", "5806844a5a3c81d3a198b0d667a5f1277924e233ef1e0d3e5d44455a168b1534"],
+      "binding_raw_sha256": ["7fdb8f1850f213aa3d5f62054e4064595724672ccc02ca9b178a6fa7421113f9", "f691740fee3ba83982de92dd6ecfd73dd2307f3a8161c1347563153eb7ebf0ae"],
+      "attestation_raw_sha256": "e072617a20e3a4c1623424b255a6b0619dd87c4b8266d54a50df802266782da3",
+      "binding_calls": 2,
+      "binding_validation_retries": 1,
+      "initial_binding_issue": "expected exactly one === PLAN EVIDENCE BINDING JSON === marker",
+      "passage": "MAUs were 675 million as of December 31, 2024. This represented an increase of 12% from the preceding fiscal year. MAUs increased due to our continued investment in driving the growth of our Service through successful consumer marketing campaigns, enhanced content offerings, and product enhancements, resulting in continued user engagement and customer satisfaction.",
+      "publisher_authority": true,
+      "passage_entailment": true,
+      "verdict": "supported",
+      "elapsed_seconds": 41.344
+    },
+    {
+      "engine": "claude",
+      "model": "claude-fable-5",
+      "cli_version": "2.1.197",
+      "fresh_binding_bootstrap": true,
+      "resumed_binding": true,
+      "fresh_full_context_attestation": true,
+      "binding_prompt_characters": 627172,
+      "binding_prompt_sha256": "f0056e12b125b24a80ac06a383ce957abf54ab45034231ca72ebd56378b62e04",
+      "binding_correction_prompt_sha256": "76c6a15a0a0b1fe440878a6d7be2d775d26cadada3b4a9706f4e446b673257b4",
+      "attestation_prompt_characters": 626965,
+      "attestation_prompt_sha256": "9e48b40446251a1027609140412749447524c63a8d6d51dc1cbccf222f8b3335",
+      "bootstrap_reply_sha256": "c2e3ac47f4a325469c1a2d5f117e463ec943c721986d5d9f09ac4540b7d80526",
+      "binding_reply_sha256": ["95c2ac4a02c8dac2c55c3192841b3e8f90f414b4dab3f859192f1d2ddf7e5f27", "056413e60bb7d9958f75036152627617c441163a686566acfa729baf4d329708"],
+      "binding_raw_sha256": ["a1bb7ec5a6ea587e13a1e6646a9c323ee31d957b427fdacaee20bf4d73d3dccb", "80a6fb5dd684bc007bf0b64a76c3704c761c729399a122386e3d03473c357ae5"],
+      "attestation_raw_sha256": "546c4fce58e09b874f1d66e32e16e40581c45830d363994752d1725d451f5c26",
+      "binding_calls": 2,
+      "binding_validation_retries": 1,
+      "initial_binding_issue": "expected exactly one === PLAN EVIDENCE BINDING JSON === marker",
+      "passage": "We are the world’s most popular audio streaming subscription service with a community of 675 million MAUs and 263 million Premium Subscribers across 184 countries and territories as of December 31, 2024.",
+      "publisher_authority": true,
+      "passage_entailment": true,
+      "verdict": "supported",
+      "elapsed_seconds": 36.081
+    }
+  ],
+  "production_entrypoint": {
+    "engine": "codex",
+    "model": "gpt-5.6-sol",
+    "public_handler": "critique_plan",
+    "lineage_rounds": 1,
+    "ordinary_and_expanded_claims": 2,
+    "supported_claims_after_reload": 2,
+    "claim_debt": null,
+    "spotify_text_sha256": "2fbc63a47b1582fa5268afb1184377f14c9d31fdaae2a2134665e263602625c2",
+    "spotify_capture_error": null,
+    "spotify_evidence_index": 1,
+    "spotify_source_rows": 2,
+    "spotify_publisher_authority": true,
+    "spotify_passage_entailment": true,
+    "durable_reload": true,
+    "elapsed_seconds": 489.033,
+    "final_state_sha256": "1b2ea40d3a58b5f64d9717ea03dfa9fb79748e5cd61f6f715620238f166e4898"
+  },
+  "production_preflight_measurement": {
+    "binding_initial_characters": 627172,
+    "binding_correction_characters": 628805,
+    "attestation_initial_worst_case_characters": 680692,
+    "attestation_correction_worst_case_characters": 682351,
+    "configured_ceiling": 685000
+  },
+  "tests": {
+    "focused": "173 passed",
+    "full": "1188 passed",
+    "full_git_fixture_signing_disabled": true
+  },
+  "reviewed_snapshot": {
+    "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
+    "production_source_sha256": {
+      "src/paranoia_local/external_sources.py": "1e2b07e5ed04e3920378f1d7fc60f7f67c3f18a8d4e75d530ce9f95cec7cf840",
+      "src/paranoia_local/handlers.py": "94fe0ca85568baae7e219ca47ba6cf4cf756f55a79ac609178bc52ce31dc083a",
+      "src/paranoia_local/plan_claims.py": "3575588572c52016d2901498bae9dfe22e7a9c8bae64550a1671f1aebec2b8d8",
+      "src/paranoia_local/review_census.py": "94242505ae01b0adf4bf6cc8eb24598725d346359ca87b6bfa9dd840e7b3bae9",
+      "scripts/run_authoritative_capture_acceptance.py": "c07999eaf1228d83e01c3514cc7218fe5efeb82d3f987fa6738a1cc698bb76e9",
+      "scripts/run_authoritative_capture_entrypoint_acceptance.py": "5168c81590eb37d58f2377fc2802ae8bc626c7ec26adb29ba081df233491435a"
+    }
+  },
+  "implementation_diff": {
+    "scope": "production Python modules relative to reviewed_snapshot.base_commit",
+    "tracked_additions": 735,
+    "tracked_deletions": 125,
+    "largest_changed_module": "src/paranoia_local/handlers.py",
+    "largest_changed_module_additions": 544,
+    "largest_changed_module_deletions": 111,
+    "largest_changed_module_lines_after": 3415
+  },
+  "scope": "Plan claim verification only; arbitration's single-prompt policy is unchanged. This record proves the named 590177-character SEC source, the measured 682351-character worst-case production preflight, the exact source-hashed Codex public critique_plan lifecycle with durable reload, and exact-runner Codex/Claude binding and attestation routes. It does not claim that arbitrary future pages, provider releases, or every packet up to 685000 characters will succeed."
+}

--- a/docs/authoritative_capture_segmentation_plan.md
+++ b/docs/authoritative_capture_segmentation_plan.md
@@ -1,0 +1,146 @@
+# Complete-packet binding for long authoritative sources
+
+## Decision and operating model
+
+The plan-verification path must not discard a complete, otherwise admissible official source
+merely because it exceeds the ordinary 400,000-character binding batch. It will retain the
+one-source/one-decision protocol and allow a complete primary or authoritative source to occupy a
+larger dedicated packet. The complete capture will also accompany the selected exact passage in
+that source's cold attestation input, avoiding fragmented or decontextualized adjudication.
+
+This change uses the repository's default local-tool stakes: one trusted operator and OS;
+repository, plan, fetched HTTP content, and provider output are untrusted static data; public
+HTTP(S) capture is the network boundary; no repository code execution, hostile local path race,
+compromised OS/provider, or multi-tenancy. A review ordinarily has tens to low hundreds of claims
+and should finish within minutes. False support, incorrect authority/entailment, and silently
+dropped evidence are high-impact. Visible recoverable blocking is acceptable. Formal proof and
+deliberately corrupted-state recovery are excluded.
+
+## Failure class and architecture checkpoint
+
+`MAX_EXTRACTED_CHARS = 100_000` rejects ordinary primary records such as regulatory filings,
+standards, manuals, and long vendor references before binding. `_binding_batches` then assumes
+that every source must fit the ordinary batch size. Raising only the extraction constant moves the
+first boundary and still rejects the same source after capture.
+
+An initial segmentation proposal was rejected at the architecture checkpoint because it created
+new correctness protocols for cross-boundary passages, source-level aggregation, duplicate
+segment manifests, unavailable captures, replacement targeting, and downstream prompt sizing.
+Those mechanisms are disproportionate when current providers can be capability-tested with the
+complete reported filing. Packet and latency limits are circuit breakers, not evidence-quality
+targets; the smallest coherent fix is to flex the packet allocation without splitting evidence.
+
+## Complete-packet protocol
+
+1. Raise the complete extracted-text admission ceiling to 1,000,000 characters while retaining
+   the 5,000,000-byte raw-response ceiling. `Capture.text` and `text_sha256` continue to cover the
+   complete extraction.
+2. Retain the ordinary compact binding batch ceiling of 400,000 characters. Pack ordinary rows as
+   today, counting the exact compact JSON representation.
+3. If one row exceeds the ordinary ceiling, permit it only when the candidate is normalized again
+   with `capture.final_url` and is structurally governing (`primary` or `authoritative`, eligible
+   public HTTP(S) final destination, and a governing relation)
+   and the complete rendered binding prompt fits a 685,000-character expanded-packet ceiling.
+   Flush the ordinary batch and place that row alone. A duplicate reference never crosses a batch.
+4. Size the complete initial prompt and reserve the complete worst-case correction prompt, not
+   only the data array. The correction reservation includes its fixed template plus the maximum
+   bounded 2,000-character local validation diagnostic. Both envelopes must fit their ordinary or
+   expanded packet ceiling before the initial invocation, so a response-dependent error cannot
+   make an admitted correction exceed the ceiling.
+   Implement this as one pure `binding_prompts(row, diagnostic)` renderer used by both execution
+   and preflight. Preflight calls it with a diagnostic of exactly 2,000 maximally escaped
+   characters and requires both returned strings to fit; execution may invoke only those same
+   returned shapes with a shorter bounded diagnostic.
+5. Bypass model binding for unavailable captures and directly materialize their existing bounded
+   server-owned capture-failure decision. Model omission can therefore never replace a known
+   capture failure. If a usable row is not eligible for expansion, or the complete expanded
+   prompt is too large, retain
+   the existing server-owned per-source binding-budget failure and continue unrelated sources.
+   Fixed non-text metadata overflow takes this same source-local path. Aggregate sixth-batch,
+   model-call, and deadline exhaustion remain visible global debt; nothing is partially verified.
+   Concretely, partition captures before `_binding_batches`: for every `capture.usable is False`,
+   set `decisions[(claim_index, evidence_index)] = None` and do not construct a row. Final
+   materialization reads the untouched `Capture` and persists its effective URL, status, content
+   type, fallback fact, digests, and bounded server error. No provider value can participate in
+   this path.
+6. Bound model-authored binding `location` at 1,000 characters and `passage` at 8,000 characters
+   before either enters later prompts. A passage remains an exact, normalized match against the
+   complete capture.
+7. Serialize a server-owned `binding_target` in every row: `claim.replacement` for
+   `supports_replacement`, otherwise `claim.proposition`. This fixes the existing replacement
+   search ambiguity while leaving final relation and replacement attestation rules unchanged.
+8. Before admitting an expanded source to binding, render its worst-case cold-attestation envelope
+   using the complete numbered capture plus maximum 1,000-character location and 8,000-character
+   passage. It must fit 685,000 characters. Then render the exact prompt before invocation. Ordinary sources retain the existing
+   bounded exact-passage packet. Every expanded source additionally contributes its complete
+   numbered captured text, final URL, and digests, allowing the cold reviewer to assess the passage
+   in full source context. The whole prompt must fit 685,000 characters; otherwise fail visibly
+   before partial attestation. The initial and correction attestation prompts use the same check.
+   An expanded source that fails this preflight receives source-local binding-budget debt before
+   any model call, so it cannot abort attestation for unrelated evidence.
+   Implement one pure `attestation_prompts(packet, diagnostic)` renderer shared by execution and
+   preflight. The synthetic preflight packet contains the exact full capture and metadata plus a
+   maximally escaped 1,000-character location and 8,000-character passage; the diagnostic is
+   exactly 2,000 maximally escaped characters. Define
+   `expanded_preflight = all(len(prompt) <= 685_000 for prompt in
+   (*binding_prompts(max_row, max_diagnostic),
+   *attestation_prompts(max_packet, max_diagnostic)))`.
+   Failure replaces only this source's usability/error before batching. Execution cannot compose
+   another initial or correction shape: it calls these same renderers and asserts their limits
+   immediately before each provider invocation.
+9. A provider execution failure on a dedicated expanded binding call becomes a bounded
+   server-owned failure for that source, with the call's raw/failure/stderr channels retained in
+   the attempt ledger; later batches and unrelated sources continue. Validation-invalid output
+   still receives the one correction and a final invalid result remains source-local for that
+   dedicated row. In both paths, replace only `text` and `error` on the immutable capture; retain
+   effective final URL, HTTP status/content type, fallback fact, and content/text digests through
+   audit persistence. Ordinary multi-source call failures keep their existing whole-batch behavior.
+10. Unavailable captures retain exactly one truthful source-level aggregate and durable capture
+    provenance. No new segment or persistent source-aggregation protocol is introduced.
+
+The 685,000-character value is a measured compatibility ceiling, not an assumed provider promise.
+Before PR, the exact maximum prompt shape must succeed through fresh and resumed Codex and Claude
+binding routes, and the expanded cold-attestation route must pass the same probe. A later provider
+that cannot accept the request fails visibly through the existing execution path. The ceiling can
+be revised independently when real provider capability changes; evidence is never truncated to
+preserve it.
+
+Arbitration research remains outside this change. Its deliberate single 400,000-character shared
+binding call and deterministic per-capture demotion are unchanged.
+
+## Acceptance
+
+- Exact extraction boundaries admit 1,000,000 characters and reject 1,000,001.
+- A real primary source longer than 100,000 extracted characters whose complete serialized row
+  exceeds 400,000 characters receives one dedicated expanded binding call, not capture debt.
+- Exact full prompts at and below ordinary/expanded limits are admitted; the first character over
+  is source-local binding-budget failure before invocation. Admission reserves the maximum bounded
+  correction diagnostic and downstream location/passage envelope.
+- Tests compare every preflight-rendered initial/correction string byte-for-byte with the string
+  handed to the injected provider, including JSON escape amplification, and prove no invocation
+  occurs when any of the four envelopes is one character over.
+- A deep passage from the reported class of long official record reaches the cold
+  authority-and-entailment attester together with the complete capture and persists its digest.
+- A secondary/UGC/context row cannot claim expanded capacity merely by being large.
+- A redirect from an apparently official discovery URL to UGC or plan-self content is ineligible
+  for expansion under the final URL.
+- Duplicate captures, ordinary multi-source batches, batch ceilings, and omission provenance
+  retain their existing behavior. Unavailable captures bypass the model and cannot be mislabeled
+  as an omission.
+- An end-to-end unavailable capture test proves no binding row or call contains that source and
+  its exact effective URL/status/content type/fallback/digests/server error reach persisted debt.
+- Replacement-support rows expose the replacement as `binding_target`; support/refutation rows
+  expose the original proposition.
+- Oversized binding output fields reject through the one bounded correction; exact boundary values
+  reach an exactly size-checked attestation prompt. Expanded-source attestation includes the full
+  capture; overflow is detected per source before binding and cannot abort unrelated attestation.
+- Dedicated-call execution and terminal validation failures retain the effective final URL, status,
+  fallback fact, and both capture digests alongside their bounded provider channels.
+- Existing capture, 403 retry, attestation, arbitration, frozen-claim, and full test suites pass.
+- The pre-PR production run forces one ordinary binding call followed by one dedicated expanded
+  call, with decisive evidence only in the expanded call. It records extracted characters, every
+  exact rendered prompt size, batch/row and model-call counts, elapsed time, complete-context cold
+  attestation, and durable capture digest. Separate fresh/resumed Codex and Claude capability probes
+  exercise the maximum binding and attestation packet shapes.
+- Record production diff size and largest changed modules, then run tightly scoped Codex CODE
+  convergence under the operating model above.

--- a/docs/claim_verification.md
+++ b/docs/claim_verification.md
@@ -60,7 +60,12 @@ an empty, verified register.
    only the corrected complete inventory proceeds to capture.
 3. The server downloads each candidate directly under bounded HTTP(S), redirect, response-size,
    and extracted-text limits, then extracts main text with Trafilatura. Responses remain capped at
-   5,000,000 bytes; complete extracted text through 100,000 characters is admitted. Repeated
+   5,000,000 bytes; complete extracted text through 1,000,000 characters is admitted. Plan
+   binding preserves complete-source context: a structurally governing primary or authoritative
+   capture may use one dedicated expanded packet when its exact rendered prompt fits 685,000
+   characters, with eligibility recomputed from the final URL. Its complete capture accompanies
+   the selected passage into a separately size-checked cold attestation prompt. Admission reserves
+   the worst-case bounded binding correction and attestation output envelopes. Repeated
    captures with the same final URL and content/text digests appear once per serialized binding
    prompt or batch and later rows reference that exact capture. If distinct arbitration captures
    exceed its single 400,000-character binding prompt, the largest capture groups are
@@ -85,34 +90,54 @@ an empty, verified register.
    second database, CAS protocol, or journal.
 7. The cold structural reviewer receives the evidence register and an inert raw-tree repository
    materialization, with live web and Git-helper execution unavailable. It is explicitly forbidden
-   from demanding claim packets for repository mechanics or “missing atomic bridges.” It still
-   performs the complete ordinary FATAL/MAJOR review over the plan and repository every round.
+   from demanding claim packets for repository mechanics or “missing atomic bridges.” It performs
+   a broad census on a new snapshot, targeted correction reviews over durable debt and repair
+   effects, and one mandatory broad cold final regression after that debt closes.
 8. The computed verdict combines external-claim closure and structural-class closure.
 
 The active inventory ceiling is 500 external claims and 20 evidence records per claim. The
 composed execution budget additionally allows at most 200 source captures and five binding
 batches of 400,000 characters in one audit. These are pathology/corruption guards, not
-pagination limits. They cover ordinary large plans while preventing the multiplicative maxima
+evidence-quality targets. A single authoritative source may flex from an ordinary batch to one
+dedicated expanded packet. They cover ordinary large plans while preventing the multiplicative maxima
 from turning into hours of model/network work. Exceeding one creates visible audit debt and
 blocks; nothing beyond a ceiling is silently discarded or called verified.
 
-Each discovery, captured-text binding, and cold-attestation model call has a 600-second cap;
-discovery and each binding batch allow at most one correction. The complete evidence phase has
-a 6,000-second monotonic deadline and at most nine model calls, including enough capacity for
-one discovery correction and one binding correction at the five-batch maximum. These
-limits let a large real plan complete useful research without making either a call sequence or
-an individual model call unbounded.
+Each discovery, captured-text binding, and cold-attestation model call has a 300-second cap;
+each locally invalid response allows at most one same-session correction. Cold attestation is
+packed by its exact rendered initial and correction prompts into at most five batches, rather than
+assuming every accepted passage fits one call. The complete evidence phase has a 6,960-second
+monotonic circuit breaker and at most 22 model calls: discovery + five binding + five attestation
+calls, with one correction reserved for every initial call. Before discovery spend, admission
+reserves that entire graph plus 300 seconds for capture/bounded pre-binding processing and 60
+seconds of scheduling slack. The capture pool and exact local packing share an enforced monotonic
+300-second deadline; exhausting it blocks before the first binding call. The handler also checks
+both remaining calls and two full 300-second windows before each initial invocation. The retained
+acceptance record reports the measured live latency for each 627,000-character Codex and Claude
+packet. These remain generous circuit breakers, not review-quality budgets; an admitted call may
+use its full time and context to establish authoritative evidence.
 Captured sources are downloaded with up to 16 workers under the same monotonic deadline and
 per-source wall-clock bounds, then bound in deterministic indexed batches in the same corrected
-discovery session. Exact 5,000,000-byte and 100,000-character boundaries are admitted; the first
-unit above either is rejected. Serialized numbering, metadata, and JSON escaping count against
-the existing 400,000-character binding limit. Arbitration degrades the largest distinct capture
+discovery session. Exact 5,000,000-byte and 1,000,000-character boundaries are admitted; the first
+unit above either is rejected. Numbering, metadata, JSON escaping, and the full instruction
+envelope count against either the ordinary 400,000-character prompt or the dedicated
+685,000-character governing-source prompt. Arbitration degrades the largest distinct capture
 groups per-source when its aggregate would overflow; the plan path retains its five deterministic
-batches. One oversized source, a sixth plan batch, an expired capture, or a failed batch
+batches. An aggregate sixth plan batch, an expired capture, or a failed batch
 becomes visible blocking state rather than silently truncating the inventory.
-If numbering or JSON escaping makes one plan capture row exceed a batch by itself, only that
-capture becomes unusable with the bounded server-owned binding-budget reason; it cannot abort
-unrelated claim captures.
+For binding and cold attestation, that aggregate rejection is global: no prefix is settled or
+made eligible for later freezing as a way to paginate the inventory across rounds.
+If a row is ineligible for expansion or its complete expanded prompt cannot fit, only that capture
+becomes unusable with the bounded server-owned binding-budget reason; it cannot abort unrelated
+claim captures. Unavailable captures bypass model binding and retain their known server-owned
+failure rather than becoming model-omission provenance. A failed dedicated expanded call is also
+source-local and retains its attempt diagnostics; unrelated batches continue.
+Every source outcome carries a closed server-owned `capture_provenance` row with its requested
+location, nullable effective HTTP(S) final URL, explicit nullable status, content type, both capture
+digests, fallback fact, and bounded error. A null final URL preserves non-web context as an
+uncaptured outcome rather than inventing a web capture. Dedicated binding or attestation failure
+preserves that immutable provenance, records a negative attestation, and continues unrelated
+batches.
 
 The complete verified plan call has a 7,080-second deadline, leaving a 120-second teardown
 reserve within the documented 7,200-second MCP client timeout. After evidence state is persisted,
@@ -123,6 +148,13 @@ repeating research. A malformed class register gets one 600-second retry only wh
 fits the same deadline.
 
 ## Evidence and authority
+
+The retained live acceptance for the long-authoritative-source path is
+`docs/authoritative_capture_acceptance_2026-08-20.json`. It records the official 590,177-character
+Spotify SEC filing, exact 627k live prompts, the 682,351-character worst-case production preflight,
+successful Codex and Claude routes, a public two-claim `critique_plan` lifecycle with durable
+reload, bounded format retries, cold verdicts, digests, elapsed time, and full-suite
+result.
 
 Every source needs a canonical absolute URL, publisher, title, precise section/table/page,
 exact passage reproduced in the server capture, evidence relation, and an explanation of why
@@ -169,8 +201,9 @@ quotation, code, negation, relocation, parent-list changes, or surrounding asser
 re-verification while harmless line wrapping remains stable. The
 verifier receives only added or edited eligible wording, retained `refuted` or `unverified`
 claims, and removal candidates. An unchanged, fully supported register causes no evidence-model
-call or web search. This optimization applies only to claim verification: the full cold
-structural review still runs each round.
+call or web search. Structural review remains independent: the initial census and mandatory final
+regression are broad and cold, while intervening correction rounds target durable structural debt,
+the claimed repairs, and their transitive effects.
 
 An edited proposition inherits no verdict. Every unresolved or otherwise non-freezable claim,
 including an exact retained refutation, must return as a complete current server-captured and

--- a/scripts/run_authoritative_capture_acceptance.py
+++ b/scripts/run_authoritative_capture_acceptance.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+"""Live acceptance for complete-packet binding of a long official SEC filing."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import json
+import time
+from pathlib import Path
+
+from paranoia_local import engines, external_sources, handlers, plan_claims as pc
+
+
+URL = (
+    "https://www.sec.gov/Archives/edgar/data/1639920/"
+    "000163992025000003/ck0001639920-20241231.htm"
+)
+PROPOSITION = "Spotify had 675 million monthly active users as of December 31, 2024."
+
+
+def digest(value: str) -> str:
+    return hashlib.sha256(value.encode("utf-8", "surrogatepass")).hexdigest()
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("engine", choices=("codex", "claude"))
+    args = parser.parse_args()
+    engine = engines.CodexEngine() if args.engine == "codex" else engines.ClaudeEngine()
+    model = engine.default_model
+    cli_version = ".".join(str(part) for part in engines._cli_version(engine.binary))
+    started = time.monotonic()
+    candidate = external_sources.CandidateSource(
+        URL, "Spotify Technology S.A. 2024 Annual Report", "Spotify Technology S.A.",
+        "primary", "Spotify's SEC-filed annual report", "supports_claim",
+    )
+    capture = external_sources.capture(candidate, deadline=time.monotonic() + 120)
+    if not capture.usable:
+        raise SystemExit(f"capture failed: {capture.error}")
+    plan = f"# Acceptance\n\n{PROPOSITION}\n"
+    claim = {
+        "kind": "fact", "scope": "external", "anchor": PROPOSITION,
+        "proposition": PROPOSITION, "prior_claim_id": None, "verdict": "supported",
+        "evidence": [{
+            "url": URL, "title": candidate.title, "publisher": candidate.publisher,
+            "source_kind": candidate.source_kind,
+            "authority_basis": candidate.authority_basis,
+            "location": "annual report", "quote": (
+                "MAUs were 675 million as of December 31, 2024."
+            ),
+            "relation": candidate.relation,
+        }],
+        "replacement": None, "rationale": "Official issuer filing states the metric.",
+    }
+    discovery = pc.parse_audit(
+        pc.AUDIT_MARKER + "\n" + json.dumps({
+            "claims": [claim],
+            "coverage": {
+                "sections_scanned": 1, "omitted_nonfacts": 0,
+                "prior_assessments": [], "prior_dispositions": [], "notes": "complete",
+            },
+        }),
+        plan,
+    )
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=Path.cwd(), plan_repo_path=None,
+        deadline=time.monotonic() + handlers.PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC,
+    )
+    try:
+        adapter.captures = {(0, 0): capture}
+        adapter.binding_engine = engine.for_role(engines.ROLE_BINDING)
+        bootstrap = adapter.binding_engine.run(
+            "Reply with exactly READY.", adapter.launch, model, "high", False, timeout=600,
+        )
+        if bootstrap.error or not bootstrap.session_ref:
+            raise SystemExit(f"binding bootstrap failed: {bootstrap.failure_detail}")
+        batches = adapter._binding_batches(discovery, adapter.captures)
+        binding_prompt_chars = [
+            len(adapter._binding_prompt(json.dumps(batch, ensure_ascii=False, separators=(",", ":"))))
+            for batch in batches
+        ]
+        binding_prompt_sha256 = [
+            digest(adapter._binding_prompt(
+                json.dumps(batch, ensure_ascii=False, separators=(",", ":")),
+            ))
+            for batch in batches
+        ]
+        bound, binding_reviews = adapter._bind_indexed(
+            bootstrap.session_ref, discovery, adapter.captures, model, "high", {},
+        )
+        initial_binding_issue = None
+        if len(binding_reviews) > 1:
+            try:
+                adapter._parse_indexed_binding(
+                    binding_reviews[0].text, batches[0], adapter.captures,
+                )
+            except pc.AuditError as error:
+                initial_binding_issue = str(error)
+        rendered_binding = json.dumps(
+            batches[0], ensure_ascii=False, separators=(",", ":"),
+        )
+        correction_prompt_sha256 = (
+            digest(adapter._binding_prompt(
+                rendered_binding,
+                pc.bounded_diagnostic(initial_binding_issue)[
+                    :handlers.MAX_BINDING_DIAGNOSTIC_CHARS
+                ],
+            ))
+            if initial_binding_issue else None
+        )
+        item = bound.claims[0]["evidence"][0]
+        attestation_item = {
+            "claim_index": 0, "evidence_index": 0, "proposition": PROPOSITION,
+            "publisher": item["publisher"], "authority_basis": item["authority_basis"],
+            "relation": item["relation"], "location": item["location"],
+            "passage": item["quote"],
+            "capture": {
+                "final_url": capture.final_url, "status": capture.status,
+                "content_type": capture.content_type,
+                "content_sha256": capture.content_sha256,
+                "text_sha256": capture.text_sha256,
+                "complete_line_numbered_text": external_sources.numbered_text(capture.text or ""),
+            },
+        }
+        attestation_prompt_chars = len(adapter._attestation_prompt([attestation_item]))
+        worst_attestation_item = dict(attestation_item)
+        worst_attestation_item["location"] = "\x01" * handlers.MAX_BINDING_LOCATION_CHARS
+        worst_attestation_item["passage"] = "\x01" * handlers.MAX_BINDING_PASSAGE_CHARS
+        worst_rendered = json.dumps(
+            [worst_attestation_item], ensure_ascii=False, separators=(",", ":"),
+        )
+        preflight = {
+            "binding_initial_characters": binding_prompt_chars[0],
+            "binding_correction_characters": len(adapter._binding_prompt(
+                rendered_binding, "x" * handlers.MAX_BINDING_DIAGNOSTIC_CHARS,
+            )),
+            "attestation_initial_worst_case_characters": len(
+                adapter._attestation_prompt([worst_attestation_item])
+            ),
+            "attestation_correction_worst_case_characters": len(
+                adapter._attestation_correction_prompt(
+                    worst_rendered, "x" * handlers.MAX_BINDING_DIAGNOSTIC_CHARS,
+                )
+            ),
+            "configured_ceiling": handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS,
+        }
+        attested = adapter._attest(bound, model, "high")
+        if isinstance(attested, engines.Review):
+            raise SystemExit(f"attestation failed: {attested.text}")
+        evidence = attested.claims[0]["capture_attestations"][0]
+        if (
+            attested.claims[0]["verdict"] != "supported"
+            or evidence["publisher_authority"] is not True
+            or evidence["passage_entailment"] is not True
+            or evidence.get("capture_error")
+        ):
+            raise SystemExit(
+                "live acceptance did not establish authoritative support: "
+                + json.dumps(evidence, ensure_ascii=False)
+            )
+        print(json.dumps({
+            "engine": args.engine, "model": model, "cli_version": cli_version, "url": URL,
+            "extracted_characters": len(capture.text or ""),
+            "content_sha256": capture.content_sha256, "text_sha256": capture.text_sha256,
+            "expanded": (0, 0) in adapter.expanded_captures,
+            "binding_prompt_characters": binding_prompt_chars,
+            "binding_prompt_sha256": binding_prompt_sha256,
+            "binding_correction_prompt_sha256": correction_prompt_sha256,
+            "attestation_prompt_characters": attestation_prompt_chars,
+            "attestation_prompt_sha256": digest(
+                adapter._attestation_prompt([attestation_item])
+            ),
+            "bootstrap_reply_sha256": digest(bootstrap.text),
+            "binding_reply_sha256": [digest(review.text) for review in binding_reviews],
+            "binding_raw_sha256": [digest(review.raw) for review in binding_reviews],
+            "attestation_raw_sha256": digest(adapter.attestation_raw),
+            "binding_calls": len(binding_reviews), "total_adapter_model_calls": adapter.model_calls,
+            "binding_validation_retries": max(0, len(binding_reviews) - len(batches)),
+            "initial_binding_issue": initial_binding_issue,
+            "verdict": attested.claims[0]["verdict"],
+            "publisher_authority": evidence["publisher_authority"],
+            "passage_entailment": evidence["passage_entailment"],
+            "production_preflight_measurement": preflight,
+            "passage": item["quote"], "elapsed_seconds": round(time.monotonic() - started, 3),
+        }, ensure_ascii=False, indent=2))
+    finally:
+        adapter.close()
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/run_authoritative_capture_entrypoint_acceptance.py
+++ b/scripts/run_authoritative_capture_entrypoint_acceptance.py
@@ -1,0 +1,123 @@
+#!/usr/bin/env python3
+"""Run the public critique_plan lifecycle over ordinary and expanded evidence."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import tempfile
+import time
+from pathlib import Path
+
+from paranoia_local import engines, handlers
+
+
+SEC_URL = (
+    "https://www.sec.gov/Archives/edgar/data/1639920/"
+    "000163992025000003/ck0001639920-20241231.htm"
+)
+PYTHON_URL = "https://www.python.org/downloads/release/python-3110/"
+PLAN = f"""# Evidence lifecycle acceptance
+
+The implementation uses these two externally governed acceptance inputs:
+
+- Python 3.11.0 was released on October 24, 2022. [Official release]({PYTHON_URL})
+- Spotify reported 675 million monthly active users as of December 31, 2024. [2024 annual report]({SEC_URL})
+
+Before implementation, verify both inputs against their linked primary sources. Preserve the
+complete annual-report capture while binding the exact Spotify passage. Do not infer any broader
+product or investment conclusion from either input.
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("engine", choices=("codex", "claude"))
+    parser.add_argument("--state-root")
+    parser.add_argument("--round", type=int, default=1)
+    args = parser.parse_args()
+    engine = engines.CodexEngine() if args.engine == "codex" else engines.ClaudeEngine()
+    state_root = (
+        Path(args.state_root)
+        if args.state_root else Path(tempfile.mkdtemp(prefix="paranoia-entrypoint-acceptance-"))
+    )
+    os.environ["PARANOIA_STATE_ROOT"] = str(state_root)
+    lineage = f"authoritative-capture-entrypoint-{args.engine}-plan"
+    started = time.monotonic()
+    result = handlers.critique_plan(
+        {
+            "plan_text": PLAN,
+            "repo_path": str(Path.cwd()),
+            "class_closure": True,
+            "claim_verification": True,
+            "lineage": lineage,
+            "round": args.round,
+            "engine": args.engine,
+            "model": engine.default_model,
+            "effort": "high",
+            "web_search": True,
+            "stakes": (
+                "trusted single operator and OS; plan, repository, fetched pages, and provider "
+                "output are untrusted static data; false evidence support is high impact; "
+                "visible recoverable blocking is acceptable; no hostile local race or multitenancy"
+            ),
+            "focus": "Acceptance run: verify the two external inputs and review correctness only.",
+        },
+        engine=engine,
+        log_dir=state_root / "logs",
+        on_progress=lambda message: print(f"[progress] {message}", flush=True),
+    )
+    state_path = state_root / "lineages" / f"{lineage}.json"
+    state = json.loads(state_path.read_text(encoding="utf-8"))
+    claims = list(state["claim_state"]["claims"].values())
+    spotify = next(
+        claim for claim in claims
+        if any(row["url"] == SEC_URL for row in claim.get("evidence", []))
+    )
+    python = next(
+        claim for claim in claims
+        if any(row["url"] == PYTHON_URL for row in claim.get("evidence", []))
+    )
+    spotify_capture = next(
+        row for row in spotify["capture_provenance"]
+        if row["requested_url"] == SEC_URL and row["error"] is None
+    )
+    spotify_evidence_index = spotify_capture["evidence_index"]
+    spotify_attestation = next(
+        row for row in spotify.get("capture_attestations", [])
+        if row["evidence_index"] == spotify_evidence_index
+    )
+    output = {
+        "engine": args.engine,
+        "model": engine.default_model,
+        "lineage_rounds": state["rounds"],
+        "claim_count": len(claims),
+        "claim_debt": state["claim_state"].get("debt"),
+        "python_verdict": python["verdict"],
+        "spotify_verdict": spotify["verdict"],
+        "spotify_extracted_text_sha256": spotify_capture["text_sha256"],
+        "spotify_capture_error": spotify_capture["error"],
+        "spotify_evidence_index": spotify_evidence_index,
+        "spotify_source_rows": len(spotify["capture_provenance"]),
+        "spotify_attested": bool(
+            spotify_attestation["publisher_authority"]
+            and spotify_attestation["passage_entailment"]
+        ),
+        "durable_reload": True,
+        "result_has_claim_closure": "CLAIM-CLOSURE:" in result,
+        "elapsed_seconds": round(time.monotonic() - started, 3),
+        "state_root": str(state_root),
+    }
+    if not (
+        output["python_verdict"] == "supported"
+        and output["spotify_verdict"] == "supported"
+        and output["spotify_attested"]
+        and output["spotify_capture_error"] is None
+    ):
+        raise SystemExit("entrypoint acceptance failed: " + json.dumps(output))
+    print(json.dumps(output, ensure_ascii=False, indent=2))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/paranoia_local/external_sources.py
+++ b/src/paranoia_local/external_sources.py
@@ -31,7 +31,7 @@ UGC_HOSTS = (
 )
 
 MAX_RESPONSE_BYTES = 5_000_000
-MAX_EXTRACTED_CHARS = 100_000
+MAX_EXTRACTED_CHARS = 1_000_000
 CONNECT_TIMEOUT_SEC = 20
 READ_TIMEOUT_SEC = 40
 MAX_REDIRECTS = 5
@@ -56,6 +56,18 @@ BINDING_BUDGET_ERROR = (
 
 class SourceError(ValueError):
     pass
+
+
+class RedirectRejected(SourceError):
+    """A redirect response whose computed target cannot be followed safely."""
+
+    def __init__(
+        self, target: str, status: int, content_type: str | None, reason: str,
+    ) -> None:
+        super().__init__(f"rejected final URL: {reason}")
+        self.target = target
+        self.status = status
+        self.content_type = content_type
 
 
 class CaptureGroupError(RuntimeError):
@@ -181,10 +193,16 @@ class _SafeRedirect(urllib.request.HTTPRedirectHandler):
 
     def redirect_request(self, req, fp, code, msg, headers, newurl):  # type: ignore[no-untyped-def]
         self.count += 1
-        if self.count > MAX_REDIRECTS:
-            raise SourceError("too many redirects")
         target = urljoin(req.full_url, newurl)
-        _validate_public_url(target)
+        content_type = headers.get_content_type().lower() if headers else None
+        if self.count > MAX_REDIRECTS:
+            raise RedirectRejected(target, int(code), content_type, "too many redirects")
+        try:
+            _validate_public_url(target)
+        except SourceError as exc:
+            raise RedirectRejected(
+                target, int(code), content_type, _bounded_error(exc),
+            ) from exc
         return super().redirect_request(req, fp, code, msg, headers, target)
 
 
@@ -272,6 +290,11 @@ def capture(
 ) -> Capture:
     candidate = normalize_candidate(candidate)
     fallback_attempted = False
+    final_url: str | None = None
+    status: int | None = None
+    content_type: str | None = None
+    content_sha256: str | None = None
+    text_sha256: str | None = None
     try:
         started = clock()
         capture_deadline = started + CONNECT_TIMEOUT_SEC + READ_TIMEOUT_SEC
@@ -325,29 +348,50 @@ def capture(
         assert response is not None
         with response:  # type: ignore[attr-defined]
             final_url = response.geturl()
-            _validate_public_url(final_url)
             status = int(getattr(response, "status", 200))
             content_type = response.headers.get_content_type().lower()
+            _validate_public_url(final_url)
             if content_type not in {"text/html", "application/xhtml+xml", "text/plain"}:
                 raise SourceError(f"unsupported content type {content_type!r}")
             body = _read_body(response, deadline=capture_deadline, clock=clock)
+            content_sha256 = hashlib.sha256(body).hexdigest()
             if len(body) > MAX_RESPONSE_BYTES:
                 raise SourceError(f"response exceeds {MAX_RESPONSE_BYTES} bytes")
         text = _extract(body, content_type)
+        text_sha256 = hashlib.sha256(text.encode("utf-8")).hexdigest()
         return Capture(
             candidate=candidate,
             final_url=final_url,
             status=status,
             content_type=content_type,
-            content_sha256=hashlib.sha256(body).hexdigest(),
-            text_sha256=hashlib.sha256(text.encode("utf-8")).hexdigest(),
+            content_sha256=content_sha256,
+            text_sha256=text_sha256,
             text=text,
+            fallback_attempted=fallback_attempted,
+        )
+    except RedirectRejected as exc:
+        return Capture(
+            candidate=candidate,
+            final_url=exc.target,
+            status=exc.status,
+            content_type=exc.content_type,
+            content_sha256=content_sha256,
+            text_sha256=text_sha256,
+            text=None,
+            error=_bounded_error(exc),
             fallback_attempted=fallback_attempted,
         )
     except (SourceError, urllib.error.URLError, OSError, ValueError) as exc:
         return Capture(
-            candidate, None, None, None, None, None, None, _bounded_error(exc),
-            fallback_attempted,
+            candidate=candidate,
+            final_url=final_url,
+            status=status,
+            content_type=content_type,
+            content_sha256=content_sha256,
+            text_sha256=text_sha256,
+            text=None,
+            error=_bounded_error(exc),
+            fallback_attempted=fallback_attempted,
         )
 
 

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -36,8 +36,10 @@ from .worktree import worktree_at
 
 Clock = Callable[[], str]
 
-PLAN_EVIDENCE_PHASE_TIMEOUT_SEC = 600
-PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC = 6000
+PLAN_EVIDENCE_PHASE_TIMEOUT_SEC = 300
+PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC = 300
+PLAN_EVIDENCE_SCHEDULING_SLACK_SEC = 60
+PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC = 6960
 PLAN_REVIEW_TOTAL_TIMEOUT_SEC = 7080
 PLAN_STRUCTURAL_PHASE_TIMEOUT_SEC = 2400
 PLAN_REGISTER_RETRY_TIMEOUT_SEC = 600
@@ -48,11 +50,18 @@ STAGED_FOLLOWUP_TIMEOUT_SEC = 2400
 STAGED_FORMAT_RETRY_TIMEOUT_SEC = 600
 STAGED_CENSUS_RESERVE_SEC = 4320
 STAGED_FOLLOWUP_RESERVE_SEC = 3120
-MAX_PLAN_EVIDENCE_MODEL_CALLS = 9
+MAX_PLAN_EVIDENCE_MODEL_CALLS = 22
 PLAN_BINDING_MARKER = "=== PLAN EVIDENCE BINDING JSON ==="
 MAX_PLAN_BINDING_BATCH_CHARS = 400_000
+MAX_PLAN_EXPANDED_PROMPT_CHARS = 685_000
+MAX_BINDING_DIAGNOSTIC_CHARS = 2_000
+MAX_BINDING_LOCATION_CHARS = 1_000
+MAX_BINDING_PASSAGE_CHARS = 8_000
+MAX_ATTESTATION_REPLY_CHARS = 500_000
+MAX_ATTESTATION_REASON_CHARS = 1_000
 MAX_PLAN_CAPTURE_SOURCES = 200
 MAX_PLAN_BINDING_BATCHES = 5
+MAX_PLAN_ATTESTATION_BATCHES = 5
 
 
 class _OmittedBinding:
@@ -1903,6 +1912,7 @@ class _CapturedClaimEngine:
         frozen_ids: frozenset[str] = frozenset(),
         deadline: float | None = None,
         attempt_ledger: list[dict[str, Any]] | None = None,
+        clock: Callable[[], float] = time.monotonic,
     ) -> None:
         self.engine = engine
         self.plan_text = plan_text
@@ -1912,14 +1922,17 @@ class _CapturedClaimEngine:
         self.frozen_ids = frozen_ids
         self.deadline = deadline
         self.attempt_ledger = attempt_ledger
+        self.clock = clock
         self.model_calls = 0
         self.launch = Path(tempfile.mkdtemp(prefix="paranoia-plan-evidence-"))
         self.binding_engine: Engine | None = None
+        self.expanded_captures: set[tuple[int, int]] = set()
         self.last_session: str | None = None
         self.discovery: pc.Audit | None = None
         self.allow_missing = False
         self.captures: dict[tuple[int, int], external_sources.Capture] = {}
         self.attestation_raw = ""
+        self.non_model_deadline: float | None = None
 
     def close(self) -> None:
         shutil.rmtree(self.launch, ignore_errors=True)
@@ -1933,7 +1946,8 @@ class _CapturedClaimEngine:
     ) -> Review:
         discovery_kwargs = dict(kwargs)
         try:
-            discovery_kwargs["timeout"] = self._next_model_timeout()
+            self._admit_complete_graph()
+            discovery_kwargs["timeout"] = self._next_model_timeout(reserve_calls=2)
         except pc.AuditError as error:
             return self._deadline_failure(error)
         discoverer = self.engine.for_role(eng.ROLE_DISCOVERY)
@@ -1947,6 +1961,7 @@ class _CapturedClaimEngine:
         try:
             discovery = self._parse_discovery(first.text)
         except pc.AuditError as error:
+            self._mark_last_validation_invalid(str(error), first, "/claims")
             try:
                 discovery_kwargs["timeout"] = self._next_model_timeout()
             except pc.AuditError as deadline_error:
@@ -1959,13 +1974,18 @@ class _CapturedClaimEngine:
                 ),
                 self.launch, model, effort, True, **discovery_kwargs,
             )
-            self._record("claim-discovery-retry", discoverer, corrected)
+            self._record(
+                "claim-discovery-validation-retry", discoverer, corrected,
+            )
             raw_parts.append(corrected.raw)
             if corrected.error or not corrected.session_ref:
                 return corrected
             try:
                 discovery = self._parse_discovery(corrected.text)
             except pc.AuditError as second:
+                self._mark_last_validation_invalid(
+                    str(second), corrected, "/claims",
+                )
                 # The discovery role has spent its one correction. If the corrected
                 # document is otherwise valid and only retained coverage is incomplete,
                 # preserve its useful packets and let reconciliation carry each omission
@@ -1998,6 +2018,9 @@ class _CapturedClaimEngine:
             session_ref = first.session_ref
 
         try:
+            self.non_model_deadline = self.clock() + PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC
+            if self.deadline is not None:
+                self.non_model_deadline = min(self.non_model_deadline, self.deadline)
             captures = self._capture(discovery)
             self.discovery = discovery
             self.captures = captures
@@ -2030,24 +2053,57 @@ class _CapturedClaimEngine:
             duration_ms=last_binding.duration_ms,
         )
 
-    def _next_model_timeout(self) -> int:
-        if self.model_calls >= MAX_PLAN_EVIDENCE_MODEL_CALLS:
+    def _next_model_timeout(self, *, reserve_calls: int = 1) -> int:
+        if self.model_calls + reserve_calls > MAX_PLAN_EVIDENCE_MODEL_CALLS:
             raise pc.AuditError(
-                f"plan evidence model-call ceiling is {MAX_PLAN_EVIDENCE_MODEL_CALLS}"
+                "plan evidence model-call ceiling cannot admit the initial call and its "
+                f"reserved correction ({self.model_calls}+{reserve_calls} > "
+                f"{MAX_PLAN_EVIDENCE_MODEL_CALLS})"
             )
         if self.deadline is not None and (
-            time.monotonic() + PLAN_EVIDENCE_PHASE_TIMEOUT_SEC > self.deadline
+            self.clock() + PLAN_EVIDENCE_PHASE_TIMEOUT_SEC * reserve_calls
+            > self.deadline
         ):
             raise pc.AuditError(
-                "plan evidence deadline leaves insufficient time for another bounded "
-                f"{PLAN_EVIDENCE_PHASE_TIMEOUT_SEC}-second model call"
+                "plan evidence deadline leaves insufficient time for the initial call and "
+                f"its {reserve_calls - 1} reserved correction call(s)"
             )
         self.model_calls += 1
         return PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
 
+    def _admit_complete_graph(self) -> None:
+        required = (
+            MAX_PLAN_EVIDENCE_MODEL_CALLS * PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
+            + PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC
+        )
+        if self.deadline is not None and self.clock() + required > self.deadline:
+            raise pc.AuditError(
+                "plan evidence deadline cannot admit the complete maximum model-call "
+                f"graph plus {PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC} seconds of capture "
+                "and bounded local processing"
+            )
+
     def _record(self, role: str, engine: Engine, review: Review) -> None:
         if self.attempt_ledger is not None:
             self.attempt_ledger.append(_attempt(role, engine, review).json())
+
+    def _mark_last_validation_invalid(
+        self, issue: str, review: Review, pointer: str,
+    ) -> None:
+        if self.attempt_ledger:
+            row = self.attempt_ledger[-1]
+            row["outcome"] = "validation-invalid"
+            row["validation_issue"] = rc.bounded_diagnostic(
+                issue, sp.MAX_ISSUE_CHARS,
+            )
+            row["validation_pointer"] = pointer
+            row.update(_review_failure_projection(review))
+            row["rejected_reply_sha256"] = hashlib.sha256(
+                review.text.encode("utf-8", "surrogatepass")
+            ).hexdigest()
+            row["rejected_reply_excerpt"] = rc.bounded_diagnostic(
+                review.text, rc.MAX_REJECTED_PAYLOAD_CHARS,
+            )
 
     @staticmethod
     def _deadline_failure(
@@ -2125,9 +2181,141 @@ class _CapturedClaimEngine:
                 f"{MAX_PLAN_CAPTURE_SOURCES}"
             )
         captured = external_sources.capture_all(
-            candidates, workers=16, deadline=self.deadline,
+            candidates, workers=16, deadline=self.non_model_deadline,
+            clock=self.clock,
         )
+        self._check_non_model_deadline()
         return dict(zip(keys, captured, strict=True))
+
+    def _check_non_model_deadline(self) -> None:
+        if self.non_model_deadline is not None and self.clock() > self.non_model_deadline:
+            raise pc.AuditError(
+                "plan evidence capture and pre-binding processing exceeded its aggregate "
+                f"{PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC}-second reserve"
+            )
+
+    @staticmethod
+    def _binding_prompt(rendered: str, issue: str | None = None) -> str:
+        if issue is None:
+            lead = (
+                "Bind every indexed candidate below using only its server capture. Return "
+                "exactly one row per (claim_index,evidence_index); preserve both indices. "
+                "A capture_ref points to an earlier row in this batch with identical final "
+                "URL and content/text digests; use that earlier row's line-numbered text. "
+                "Use binding_target as the exact proposition to bind. Copy a precise "
+                "location and exact passage only when usable, otherwise use nulls. Do not "
+                "return claims or source metadata.\n\n"
+                f"{PLAN_BINDING_MARKER}\n"
+                '{"bindings":[{"claim_index":0,"evidence_index":0,"usable":true,'
+                '"location":"section/table/page","passage":"exact captured passage"}]}\n\n'
+            )
+        else:
+            lead = (
+                f"Your indexed binding was rejected: {issue}. Return one corrected "
+                f"{PLAN_BINDING_MARKER} object for exactly this batch. If a passage did "
+                "not match, copy it character-for-character from line_numbered_text "
+                "without line numbers, ellipses, normalization, or paraphrase.\n\n"
+            )
+        return lead + rendered
+
+    @classmethod
+    def _binding_prompts_fit(cls, rows: list[dict[str, Any]], limit: int) -> bool:
+        rendered = json.dumps(rows, ensure_ascii=False, separators=(",", ":"))
+        issue = "x" * MAX_BINDING_DIAGNOSTIC_CHARS
+        return max(
+            len(cls._binding_prompt(rendered)),
+            len(cls._binding_prompt(rendered, issue)),
+        ) <= limit
+
+    @staticmethod
+    def _binding_target(claim: dict[str, Any], item: dict[str, Any]) -> str:
+        if item["relation"] == "supports_replacement":
+            return str(claim.get("replacement") or "")
+        return str(claim["proposition"])
+
+    @staticmethod
+    def _attestation_prompt(items: list[dict[str, Any]]) -> str:
+        return (
+            "You are a cold evidence attester with no web or repository tools. Independently "
+            "judge only whether each named publisher governs the exact proposition and whether "
+            "the exact passage entails the declared relation in the supplied captured context. "
+            "Return only:\n=== EVIDENCE ATTESTATION JSON ===\n"
+            '{"attestations":[{"claim_index":0,"evidence_index":0,'
+            '"publisher_authority":true,"authority_reason":"specific reason",'
+            '"passage_entailment":true,"entailment_reason":"specific reason"}]}\n\n'
+            + json.dumps(items, ensure_ascii=False, separators=(",", ":"))
+        )
+
+    @staticmethod
+    def _attestation_correction_prompt(rendered: str, issue: str) -> str:
+        return (
+            f"Your cold evidence attestation was rejected: {issue}. Return one corrected "
+            "=== EVIDENCE ATTESTATION JSON === object for exactly this packet.\n\n"
+            + rendered
+        )
+
+    @classmethod
+    def _attestation_prompts_fit(
+        cls, items: list[dict[str, Any]], limit: int,
+    ) -> bool:
+        rendered = json.dumps(items, ensure_ascii=False, separators=(",", ":"))
+        return max(
+            len(cls._attestation_prompt(items)),
+            len(cls._attestation_correction_prompt(
+                rendered, "x" * MAX_BINDING_DIAGNOSTIC_CHARS,
+            )),
+        ) <= limit
+
+    def _expanded_source_fits(
+        self, row: dict[str, Any], claim: dict[str, Any], item: dict[str, Any],
+        capture: external_sources.Capture,
+    ) -> bool:
+        if not self._binding_prompts_fit([row], MAX_PLAN_EXPANDED_PROMPT_CHARS):
+            return False
+        worst = "\x01"
+        attestation = {
+            "claim_index": row["claim_index"],
+            "evidence_index": row["evidence_index"],
+            "proposition": self._binding_target(claim, item),
+            "publisher": item["publisher"],
+            "authority_basis": item["authority_basis"],
+            "relation": item["relation"],
+            "location": worst * MAX_BINDING_LOCATION_CHARS,
+            "passage": worst * MAX_BINDING_PASSAGE_CHARS,
+            "capture": {
+                "final_url": capture.final_url,
+                "status": capture.status,
+                "content_type": capture.content_type,
+                "content_sha256": capture.content_sha256,
+                "text_sha256": capture.text_sha256,
+                "complete_line_numbered_text": external_sources.numbered_text(
+                    capture.text or ""
+                ),
+            },
+        }
+        return self._attestation_prompts_fit(
+            [attestation], MAX_PLAN_EXPANDED_PROMPT_CHARS,
+        )
+
+    def _expanded_source_allowed(
+        self, row: dict[str, Any], claim: dict[str, Any], item: dict[str, Any],
+        capture: external_sources.Capture,
+    ) -> bool:
+        effective = replace(
+            capture.candidate,
+            url=capture.final_url or capture.candidate.url,
+        )
+        plan_self = bool(
+            self.plan_repo_path
+            and pc._is_plan_self_url(
+                effective.url, self.repo, self.plan_repo_path,
+            )
+        )
+        return (
+            external_sources.structurally_governing(effective)
+            and not plan_self
+            and self._expanded_source_fits(row, claim, item, capture)
+        )
 
     def _binding_batches(
         self, discovery: pc.Audit,
@@ -2135,21 +2323,23 @@ class _CapturedClaimEngine:
     ) -> list[list[dict[str, Any]]]:
         batches: list[list[dict[str, Any]]] = []
         current: list[dict[str, Any]] = []
-        current_chars = 2
         seen_captures: dict[
             tuple[str | None, str | None, str | None], tuple[int, int]
         ] = {}
         for (claim_index, evidence_index), capture in captures.items():
+            if not capture.usable:
+                continue
             claim = discovery.claims[claim_index]
             item = claim["evidence"][evidence_index]
             identity = (capture.final_url, capture.content_sha256, capture.text_sha256)
-            referenceable = capture.usable and all(identity)
+            referenceable = all(identity)
 
             def make_row(capture_ref: tuple[int, int] | None) -> dict[str, Any]:
                 return {
                     "claim_index": claim_index,
                     "evidence_index": evidence_index,
                     "proposition": claim["proposition"],
+                    "binding_target": self._binding_target(claim, item),
                     "candidate": {
                         key: item[key] for key in (
                             "url", "title", "publisher", "source_kind",
@@ -2180,47 +2370,42 @@ class _CapturedClaimEngine:
 
             capture_ref = seen_captures.get(identity) if referenceable else None
             row = make_row(capture_ref)
-            row_chars = len(json.dumps(row, ensure_ascii=False, separators=(",", ":"))) + 1
-            if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
-                capture = replace(
-                    capture, text=None,
-                    error=external_sources.BINDING_BUDGET_ERROR,
-                )
-                captures[(claim_index, evidence_index)] = capture
-                referenceable = False
-                capture_ref = None
-                row = make_row(None)
-                row_chars = len(
-                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
-                ) + 1
-            if current and current_chars + row_chars > MAX_PLAN_BINDING_BATCH_CHARS:
+            if current and not self._binding_prompts_fit(
+                current + [row], MAX_PLAN_BINDING_BATCH_CHARS,
+            ):
+                standalone = make_row(None)
+                if (
+                    not self._binding_prompts_fit(
+                        [standalone], MAX_PLAN_BINDING_BATCH_CHARS,
+                    )
+                    and not self._expanded_source_allowed(
+                        standalone, claim, item, capture,
+                    )
+                ):
+                    captures[(claim_index, evidence_index)] = replace(
+                        capture, text=None,
+                        error=external_sources.BINDING_BUDGET_ERROR,
+                    )
+                    continue
                 batches.append(current)
                 current = []
-                current_chars = 2
                 seen_captures = {}
                 capture_ref = None
-                row = make_row(capture_ref)
-                row_chars = len(
-                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
-                ) + 1
-            if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
+                row = standalone
+            if not self._binding_prompts_fit([row], MAX_PLAN_BINDING_BATCH_CHARS):
+                if self._expanded_source_allowed(row, claim, item, capture):
+                    batches.append([row])
+                    self.expanded_captures.add((claim_index, evidence_index))
+                    current = []
+                    seen_captures = {}
+                    continue
                 capture = replace(
                     capture, text=None,
                     error=external_sources.BINDING_BUDGET_ERROR,
                 )
                 captures[(claim_index, evidence_index)] = capture
-                referenceable = False
-                capture_ref = None
-                row = make_row(None)
-                row_chars = len(
-                    json.dumps(row, ensure_ascii=False, separators=(",", ":"))
-                ) + 1
-                if row_chars + 2 > MAX_PLAN_BINDING_BATCH_CHARS:
-                    raise pc.AuditError(
-                        "one capture's non-text metadata exceeds the plan binding batch budget"
-                    )
+                continue
             current.append(row)
-            current_chars += row_chars
             if referenceable and capture_ref is None:
                 seen_captures[identity] = (claim_index, evidence_index)
         if current:
@@ -2244,22 +2429,26 @@ class _CapturedClaimEngine:
         ] = {}
         reviews: list[Review] = []
         current_session = session_ref
-        for batch in self._binding_batches(discovery, captures):
+        batches = self._binding_batches(discovery, captures)
+        self._check_non_model_deadline()
+        self.non_model_deadline = None
+        decisions.update({key: None for key, capture in captures.items() if not capture.usable})
+        for batch in batches:
             rendered = json.dumps(batch, ensure_ascii=False, separators=(",", ":"))
-            instruction = (
-                "Bind every indexed candidate below using only its server capture. Return "
-                "exactly one row per (claim_index,evidence_index); preserve both indices. "
-                "A capture_ref points to an earlier row in this batch with identical final "
-                "URL and content/text digests; use that earlier row's line-numbered text. "
-                "Copy a precise location and exact passage only when usable, otherwise use "
-                "nulls. Do not return claims or source metadata.\n\n"
-                f"{PLAN_BINDING_MARKER}\n"
-                '{"bindings":[{"claim_index":0,"evidence_index":0,"usable":true,'
-                '"location":"section/table/page","passage":"exact captured passage"}]}\n\n'
-                + rendered
-            )
+            instruction = self._binding_prompt(rendered)
+            only_key = (batch[0]["claim_index"], batch[0]["evidence_index"])
+            expanded = len(batch) == 1 and only_key in self.expanded_captures
+
+            def source_local_failure(detail: str) -> None:
+                capture = captures[only_key]
+                captures[only_key] = replace(
+                    capture, text=None,
+                    error=pc.bounded_diagnostic(detail),
+                )
+                decisions[only_key] = None
+
             call_kwargs = dict(binding_kwargs)
-            call_kwargs["timeout"] = self._next_model_timeout()
+            call_kwargs["timeout"] = self._next_model_timeout(reserve_calls=2)
             review = self.binding_engine.resume(
                 current_session, instruction, self.launch, model, effort, False,
                 **call_kwargs,
@@ -2267,6 +2456,12 @@ class _CapturedClaimEngine:
             self._record("claim-binding", self.binding_engine, review)
             reviews.append(review)
             if review.error or not review.session_ref:
+                if expanded:
+                    source_local_failure(
+                        review.failure_detail or review.stderr or
+                        "dedicated expanded binding call failed"
+                    )
+                    continue
                 raise pc.AuditError(
                     "captured-text binding call failed", review.raw,
                     failure_detail=review.failure_detail or "", stderr=review.stderr or "",
@@ -2275,23 +2470,43 @@ class _CapturedClaimEngine:
             try:
                 parsed = self._parse_indexed_binding(review.text, batch, captures)
             except pc.AuditError as first:
+                self._mark_last_validation_invalid(str(first), review, "/bindings")
                 call_kwargs["timeout"] = self._next_model_timeout()
+                issue = pc.bounded_diagnostic(str(first))[:MAX_BINDING_DIAGNOSTIC_CHARS]
                 correction = self.binding_engine.resume(
                     review.session_ref,
-                    f"Your indexed binding was rejected: {first}. Return one corrected "
-                    f"{PLAN_BINDING_MARKER} object for exactly this batch.\n\n{rendered}",
+                    self._binding_prompt(rendered, issue),
                     self.launch, model, effort, False, **call_kwargs,
                 )
-                self._record("claim-binding-retry", self.binding_engine, correction)
+                self._record(
+                    "claim-binding-validation-retry", self.binding_engine, correction,
+                )
                 reviews.append(correction)
                 if correction.error or not correction.session_ref:
+                    if expanded:
+                        source_local_failure(
+                            correction.failure_detail or correction.stderr or
+                            "dedicated expanded binding correction failed"
+                        )
+                        continue
                     raise pc.AuditError(
                         "captured-text binding correction failed", correction.raw,
                         failure_detail=correction.failure_detail or "",
                         stderr=correction.stderr or "",
                         returncode=correction.returncode,
                     )
-                parsed = self._parse_indexed_binding(correction.text, batch, captures)
+                try:
+                    parsed = self._parse_indexed_binding(
+                        correction.text, batch, captures,
+                    )
+                except pc.AuditError as second:
+                    self._mark_last_validation_invalid(
+                        str(second), correction, "/bindings",
+                    )
+                    if expanded:
+                        source_local_failure(str(second))
+                        continue
+                    raise
                 review = correction
             decisions.update(parsed)
             current_session = review.session_ref
@@ -2299,9 +2514,25 @@ class _CapturedClaimEngine:
         claims = [deepcopy(claim) for claim in discovery.claims]
         for claim_index, claim in enumerate(claims):
             claim["capture_attestations"] = []
+            claim["capture_provenance"] = []
             for evidence_index, item in enumerate(claim["evidence"]):
                 capture = captures[(claim_index, evidence_index)]
+                requested_url = item["url"]
                 item["url"] = capture.final_url or item["url"]
+                claim["capture_provenance"].append({
+                    "evidence_index": evidence_index,
+                    "requested_url": requested_url,
+                    "final_url": capture.final_url,
+                    "status": capture.status,
+                    "content_type": capture.content_type,
+                    "fallback_attempted": capture.fallback_attempted,
+                    "content_sha256": capture.content_sha256,
+                    "text_sha256": capture.text_sha256,
+                    "error": (
+                        external_sources._bounded_error(capture.error)
+                        if capture.error else None
+                    ),
+                })
                 binding = decisions[(claim_index, evidence_index)]
                 if binding is _OMITTED_BINDING:
                     item["relation"] = "context"
@@ -2326,7 +2557,7 @@ class _CapturedClaimEngine:
         )
         audit = pc.parse_audit(
             _render_audit(combined), self.plan_text, repo=self.repo,
-            plan_repo_path=self.plan_repo_path,
+            plan_repo_path=self.plan_repo_path, require_capture_provenance=True,
         )
         return audit, reviews
 
@@ -2373,6 +2604,14 @@ class _CapturedClaimEngine:
                 passage = pc._one_line(row["passage"], "binding.passage")
             except ValueError as exc:
                 raise pc.AuditError(str(exc), text) from exc
+            if len(location) > MAX_BINDING_LOCATION_CHARS:
+                raise pc.AuditError(
+                    f"binding.location exceeds {MAX_BINDING_LOCATION_CHARS} characters", text,
+                )
+            if len(passage) > MAX_BINDING_PASSAGE_CHARS:
+                raise pc.AuditError(
+                    f"binding.passage exceeds {MAX_BINDING_PASSAGE_CHARS} characters", text,
+                )
             if not external_sources.passage_matches(passage, capture.text):
                 raise pc.AuditError("indexed binding passage is not in captured text", text)
             result[key] = (location, passage)
@@ -2422,6 +2661,7 @@ class _CapturedClaimEngine:
 
     def _attest(self, audit: pc.Audit, model: str, effort: str) -> pc.Audit | Review:
         items: list[dict[str, Any]] = []
+        local_failures: dict[tuple[int, int], str] = {}
         for claim_index, claim in enumerate(audit.claims):
             for evidence_index, item in enumerate(claim["evidence"]):
                 if item["source_kind"] not in pc.AUTHORITATIVE_KINDS:
@@ -2436,6 +2676,17 @@ class _CapturedClaimEngine:
                     if item["relation"] == "supports_replacement"
                     else claim["proposition"]
                 )
+                capture_data: dict[str, Any] = {
+                    "final_url": capture.final_url if capture else None,
+                    "status": capture.status if capture else None,
+                    "content_type": capture.content_type if capture else None,
+                    "content_sha256": capture.content_sha256 if capture else None,
+                    "text_sha256": capture.text_sha256 if capture else None,
+                }
+                if (claim_index, evidence_index) in self.expanded_captures and capture:
+                    capture_data["complete_line_numbered_text"] = (
+                        external_sources.numbered_text(capture.text or "")
+                    )
                 items.append({
                     "claim_index": claim_index,
                     "evidence_index": evidence_index,
@@ -2445,48 +2696,71 @@ class _CapturedClaimEngine:
                     "relation": item["relation"],
                     "location": item["location"],
                     "passage": item["quote"],
-                    "capture": {
-                        "final_url": capture.final_url if capture else None,
-                        "status": capture.status if capture else None,
-                        "content_type": capture.content_type if capture else None,
-                        "content_sha256": capture.content_sha256 if capture else None,
-                        "text_sha256": capture.text_sha256 if capture else None,
-                    },
+                    "capture": capture_data,
                 })
-        if not items:
-            return audit
-        prompt = (
-            "You are a cold evidence attester with no web or repository tools. Independently "
-            "judge only whether each named publisher governs the exact proposition and whether "
-            "the exact passage entails the declared relation. Return only:\n"
-            "=== EVIDENCE ATTESTATION JSON ===\n"
-            '{"attestations":[{"claim_index":0,"evidence_index":0,'
-            '"publisher_authority":true,"authority_reason":"specific reason",'
-            '"passage_entailment":true,"entailment_reason":"specific reason"}]}\n\n'
-            + json.dumps(items, ensure_ascii=False, separators=(",", ":"))
-        )
         attester = self.engine.for_role(eng.ROLE_TEXT)
-        try:
-            timeout = self._next_model_timeout()
-        except pc.AuditError as error:
-            return self._deadline_failure(error)
-        review = attester.run(
-            prompt, self.launch, model, effort, False, timeout=timeout,
-        )
-        self._record("claim-attestation", attester, review)
-        self.attestation_raw = review.raw
-        if review.error:
-            return review
-        try:
+        ordinary_items = [
+            row for row in items
+            if (row["claim_index"], row["evidence_index"]) not in self.expanded_captures
+        ]
+        ordinary: list[list[dict[str, Any]]] = []
+        current: list[dict[str, Any]] = []
+        for row in ordinary_items:
+            if current and not self._attestation_prompts_fit(
+                current + [row], MAX_PLAN_BINDING_BATCH_CHARS,
+            ):
+                ordinary.append(current)
+                current = []
+            if not self._attestation_prompts_fit(
+                [row], MAX_PLAN_BINDING_BATCH_CHARS,
+            ):
+                local_failures[(row["claim_index"], row["evidence_index"])] = (
+                    "one ordinary attestation item exceeds the exact prompt bound"
+                )
+                continue
+            current.append(row)
+        if current:
+            ordinary.append(current)
+        expanded = [
+            [row] for row in items
+            if (row["claim_index"], row["evidence_index"]) in self.expanded_captures
+        ]
+        attestation_batches = ordinary + expanded
+        if len(attestation_batches) > MAX_PLAN_ATTESTATION_BATCHES:
+            return Review(
+                text=(
+                    "[paranoia-local error] evidence attestation requires "
+                    f"{len(attestation_batches)} batches; aggregate ceiling is "
+                    f"{MAX_PLAN_ATTESTATION_BATCHES}"
+                ),
+                session_ref=None,
+                raw="",
+                returncode=1,
+                error=True,
+            )
+        decisions: dict[tuple[int, int], dict[str, Any]] = {}
+        attestation_raw: list[str] = []
+
+        def parse_attestation(
+            review: Review, attestation_batch: list[dict[str, Any]],
+        ) -> dict[tuple[int, int], dict[str, Any]]:
+            if len(review.text) > MAX_ATTESTATION_REPLY_CHARS:
+                raise ValueError(
+                    "attestation reply exceeds "
+                    f"{MAX_ATTESTATION_REPLY_CHARS} characters"
+                )
             tail = review.text.split("=== EVIDENCE ATTESTATION JSON ===", 1)[1].strip()
             value, end = json.JSONDecoder().raw_decode(tail)
             if tail[end:].strip() or set(value) != {"attestations"}:
                 raise ValueError("invalid attestation envelope")
             rows = value["attestations"]
-            if not isinstance(rows, list) or len(rows) != len(items):
+            if not isinstance(rows, list) or len(rows) != len(attestation_batch):
                 raise ValueError("attestation inventory differs from the requested inventory")
-            expected = {(row["claim_index"], row["evidence_index"]) for row in items}
-            decisions: dict[tuple[int, int], dict[str, Any]] = {}
+            expected = {
+                (row["claim_index"], row["evidence_index"])
+                for row in attestation_batch
+            }
+            parsed: dict[tuple[int, int], dict[str, Any]] = {}
             for row in rows:
                 if not isinstance(row, dict) or set(row) != {
                     "claim_index", "evidence_index", "publisher_authority",
@@ -2498,7 +2772,7 @@ class _CapturedClaimEngine:
                 ) is not int:
                     raise ValueError("attestation row indices must be integers")
                 key = (row["claim_index"], row["evidence_index"])
-                if key not in expected or key in decisions:
+                if key not in expected or key in parsed or key in decisions:
                     raise ValueError("unknown or duplicate attestation row")
                 if type(row["publisher_authority"]) is not bool or type(
                     row["passage_entailment"]
@@ -2510,30 +2784,189 @@ class _CapturedClaimEngine:
                     "entailment_reason"
                 ].strip():
                     raise ValueError("attestation reasons must be non-empty strings")
-                decisions[key] = row
-        except (ValueError, KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
-            return Review(
-                text=f"[paranoia-local error] evidence attestation invalid: {exc}",
-                session_ref=review.session_ref, raw=review.raw, error=True,
+                if len(row["authority_reason"]) > MAX_ATTESTATION_REASON_CHARS or len(
+                    row["entailment_reason"]
+                ) > MAX_ATTESTATION_REASON_CHARS:
+                    raise ValueError(
+                        "attestation reason exceeds "
+                        f"{MAX_ATTESTATION_REASON_CHARS} characters"
+                    )
+                parsed[key] = row
+            return parsed
+
+        for attestation_batch in attestation_batches:
+            prompt = self._attestation_prompt(attestation_batch)
+            limit = (
+                MAX_PLAN_EXPANDED_PROMPT_CHARS
+                if len(attestation_batch) == 1 and (
+                    attestation_batch[0]["claim_index"],
+                    attestation_batch[0]["evidence_index"],
+                ) in self.expanded_captures
+                else MAX_PLAN_BINDING_BATCH_CHARS
             )
+            if not self._attestation_prompts_fit(attestation_batch, limit):
+                for row in attestation_batch:
+                    local_failures[(row["claim_index"], row["evidence_index"])] = (
+                        "evidence attestation prompt or correction exceeds its "
+                        f"{limit}-character bound"
+                    )
+                continue
+            try:
+                timeout = self._next_model_timeout(reserve_calls=2)
+            except pc.AuditError as error:
+                return self._deadline_failure(error, raw_parts=attestation_raw)
+            review = attester.run(
+                prompt, self.launch, model, effort, False, timeout=timeout,
+            )
+            self._record("claim-attestation", attester, review)
+            attestation_raw.append(review.raw)
+            if review.error:
+                if len(attestation_batch) == 1 and (
+                    attestation_batch[0]["claim_index"],
+                    attestation_batch[0]["evidence_index"],
+                ) in self.expanded_captures:
+                    key = (
+                        attestation_batch[0]["claim_index"],
+                        attestation_batch[0]["evidence_index"],
+                    )
+                    local_failures[key] = pc.bounded_diagnostic(
+                        review.failure_detail or review.stderr or review.text
+                        or "dedicated expanded attestation call failed"
+                    )
+                    continue
+                return review
+            try:
+                parsed = parse_attestation(review, attestation_batch)
+            except (ValueError, KeyError, IndexError, TypeError, json.JSONDecodeError) as exc:
+                self._mark_last_validation_invalid(
+                    str(exc), review, "/attestations",
+                )
+                issue = pc.bounded_diagnostic(str(exc))[:MAX_BINDING_DIAGNOSTIC_CHARS]
+                if not review.session_ref:
+                    if len(attestation_batch) == 1 and (
+                        attestation_batch[0]["claim_index"],
+                        attestation_batch[0]["evidence_index"],
+                    ) in self.expanded_captures:
+                        key = (
+                            attestation_batch[0]["claim_index"],
+                            attestation_batch[0]["evidence_index"],
+                        )
+                        local_failures[key] = pc.bounded_diagnostic(str(exc))
+                        continue
+                    return Review(
+                        text="[paranoia-local error] evidence attestation invalid and "
+                        f"cannot be corrected without a provider session: {exc}",
+                        raw=review.raw, error=True,
+                    )
+                rendered = json.dumps(
+                    attestation_batch, ensure_ascii=False, separators=(",", ":"),
+                )
+                try:
+                    timeout = self._next_model_timeout()
+                except pc.AuditError as error:
+                    return self._deadline_failure(error, raw_parts=attestation_raw)
+                correction = attester.resume(
+                    review.session_ref,
+                    self._attestation_correction_prompt(rendered, issue),
+                    self.launch, model, effort, False, timeout=timeout,
+                )
+                self._record("claim-attestation-validation-retry", attester, correction)
+                attestation_raw.append(correction.raw)
+                if correction.error:
+                    if len(attestation_batch) == 1 and (
+                        attestation_batch[0]["claim_index"],
+                        attestation_batch[0]["evidence_index"],
+                    ) in self.expanded_captures:
+                        key = (
+                            attestation_batch[0]["claim_index"],
+                            attestation_batch[0]["evidence_index"],
+                        )
+                        local_failures[key] = pc.bounded_diagnostic(
+                            correction.failure_detail or correction.stderr
+                            or correction.text
+                            or "dedicated expanded attestation correction failed"
+                        )
+                        continue
+                    return correction
+                try:
+                    parsed = parse_attestation(correction, attestation_batch)
+                except (
+                    ValueError, KeyError, IndexError, TypeError, json.JSONDecodeError,
+                ) as second:
+                    self._mark_last_validation_invalid(
+                        str(second), correction, "/attestations",
+                    )
+                    if len(attestation_batch) == 1 and (
+                        attestation_batch[0]["claim_index"],
+                        attestation_batch[0]["evidence_index"],
+                    ) in self.expanded_captures:
+                        key = (
+                            attestation_batch[0]["claim_index"],
+                            attestation_batch[0]["evidence_index"],
+                        )
+                        local_failures[key] = pc.bounded_diagnostic(str(second))
+                        continue
+                    return Review(
+                        text=f"[paranoia-local error] evidence attestation invalid: {second}",
+                        session_ref=correction.session_ref, raw=correction.raw, error=True,
+                    )
+            decisions.update(parsed)
+        self.attestation_raw = "\n--- attestation ---\n".join(attestation_raw)
+        try:
+            if len(decisions) + len(local_failures) != len(items):
+                raise ValueError("attestation inventory differs from the requested inventory")
+        except ValueError as exc:
+            return Review(text=f"[paranoia-local error] {exc}", error=True)
         claims = [dict(claim) for claim in audit.claims]
         for index, claim in enumerate(claims):
             claim["capture_attestations"] = []
             for evidence_index, item in enumerate(claim["evidence"]):
                 row = decisions.get((index, evidence_index))
+                local_failure = local_failures.get((index, evidence_index))
+                bounded_local_failure = (
+                    rc.bounded_diagnostic(
+                        local_failure, MAX_ATTESTATION_REASON_CHARS,
+                    )
+                    if local_failure else None
+                )
                 capture = self.captures.get((index, evidence_index))
-                if row is None or capture is None or not capture.text_sha256:
+                if capture is None or not capture.text_sha256:
                     continue
-                claim["capture_attestations"].append({
+                provenance: dict[str, Any] = {
                     "evidence_index": evidence_index,
                     "final_url": capture.final_url or item["url"],
                     "text_sha256": capture.text_sha256,
                     "relation": item["relation"],
-                    "publisher_authority": row["publisher_authority"],
-                    "authority_reason": row["authority_reason"],
-                    "passage_entailment": row["passage_entailment"],
-                    "entailment_reason": row["entailment_reason"],
-                })
+                    "publisher_authority": row["publisher_authority"] if row else False,
+                    "authority_reason": row["authority_reason"] if row else (
+                        bounded_local_failure
+                        or "Server-owned source processing failure prevented attestation."
+                    ),
+                    "passage_entailment": row["passage_entailment"] if row else False,
+                    "entailment_reason": row["entailment_reason"] if row else (
+                        bounded_local_failure
+                        or "No provider passage was accepted from the retained capture."
+                    ),
+                    "fallback_attempted": capture.fallback_attempted,
+                }
+                if capture.content_sha256:
+                    provenance["content_sha256"] = capture.content_sha256
+                if capture.status is not None:
+                    provenance["status"] = capture.status
+                if capture.content_type:
+                    provenance["content_type"] = capture.content_type
+                if capture.error or local_failure:
+                    provenance["capture_error"] = external_sources._bounded_error(
+                        local_failure or capture.error
+                    )
+                claim["capture_attestations"].append(provenance)
+                if local_failure:
+                    for capture_row in claim.get("capture_provenance", []):
+                        if capture_row.get("evidence_index") == evidence_index:
+                            capture_row["error"] = external_sources._bounded_error(
+                                local_failure
+                            )
+                            break
             relation = "supports_claim" if claim["verdict"] == "supported" else "refutes_claim"
             qualifying = any(
                 item["relation"] == relation

--- a/src/paranoia_local/plan_claims.py
+++ b/src/paranoia_local/plan_claims.py
@@ -26,6 +26,7 @@ AUDIT_MARKER = "=== CLAIM AUDIT JSON ==="
 MAX_ACTIVE_CLAIMS = 500
 MAX_EVIDENCE_PER_CLAIM = 20
 DIAGNOSTIC_CHARS = 4000
+MAX_ATTESTATION_REASON_CHARS = 1_000
 
 VERDICTS = frozenset({"supported", "refuted", "unverified"})
 SCOPES = frozenset({"external"})
@@ -251,6 +252,7 @@ def frozen_supported_ids(
 
 def _captured_support(record: dict[str, Any]) -> bool:
     evidence = record.get("evidence", [])
+    provenance = record.get("capture_provenance", [])
     for row in record.get("capture_attestations", []):
         if not isinstance(row, dict):
             continue
@@ -258,11 +260,21 @@ def _captured_support(record: dict[str, Any]) -> bool:
         if type(index) is not int or not 0 <= index < len(evidence):
             continue
         item = evidence[index]
+        capture_row = next((
+            candidate for candidate in provenance
+            if isinstance(candidate, dict)
+            and candidate.get("evidence_index") == index
+        ), None)
         if (
             isinstance(item, dict)
+            and isinstance(capture_row, dict)
             and item.get("relation") == "supports_claim"
             and row.get("relation") == "supports_claim"
             and row.get("final_url") == item.get("url")
+            and capture_row.get("final_url") == item.get("url")
+            and isinstance(capture_row.get("requested_url"), str)
+            and capture_row.get("text_sha256") == row.get("text_sha256")
+            and capture_row.get("error") is None
             and row.get("publisher_authority") is True
             and row.get("passage_entailment") is True
         ):
@@ -286,6 +298,7 @@ def changed_plan_text(state_raw: Any, plan_text: str) -> str:
 def parse_audit(
     text: str, plan_text: str, *, allow_partial: bool = False,
     repo: Path | None = None, plan_repo_path: str | None = None,
+    require_capture_provenance: bool = False,
 ) -> Audit:
     """Parse and validate the single JSON object following ``AUDIT_MARKER``."""
     if text.count(AUDIT_MARKER) != 1:
@@ -327,6 +340,7 @@ def parse_audit(
         try:
             claim = _validate_claim(
                 item, plan_text, repo=repo, plan_repo_path=plan_repo_path,
+                require_capture_provenance=require_capture_provenance,
             )
         except ValueError as exc:
             reason = f"claim {index}: {exc}"
@@ -406,12 +420,14 @@ def _validate_assessments(raw: Any, text: str) -> tuple[dict[str, str], ...]:
 
 def _validate_claim(
     item: Any, plan_text: str, *, repo: Path | None = None,
-    plan_repo_path: str | None = None,
+    plan_repo_path: str | None = None, require_capture_provenance: bool = False,
 ) -> dict[str, Any]:
     if not isinstance(item, dict):
         raise ValueError("must be an object")
     required = {"kind", "scope", "anchor", "proposition", "verdict", "evidence", "replacement"}
-    optional = {"prior_claim_id", "rationale", "capture_attestations"}
+    optional = {
+        "prior_claim_id", "rationale", "capture_attestations", "capture_provenance",
+    }
     unknown = set(item) - required - optional
     missing = required - set(item)
     if missing or unknown:
@@ -459,6 +475,13 @@ def _validate_claim(
     capture_attestations = _validate_capture_attestations(
         item.get("capture_attestations", []), checked,
     )
+    capture_provenance = _validate_capture_provenance(
+        item.get("capture_provenance", []), checked,
+    )
+    if require_capture_provenance and len(capture_provenance) != len(checked):
+        raise ValueError(
+            "capture_provenance must contain exactly one row per evidence item"
+        )
 
     qualifying = [
         e for e in checked
@@ -491,7 +514,79 @@ def _validate_claim(
         "proposition": proposition, "verdict": verdict, "evidence": checked,
         "replacement": replacement, "prior_claim_id": prior, "rationale": rationale,
         "capture_attestations": capture_attestations,
+        "capture_provenance": capture_provenance,
     }
+
+
+def _validate_capture_provenance(
+    value: Any, evidence: list[dict[str, str]],
+) -> list[dict[str, Any]]:
+    if not isinstance(value, list) or len(value) > len(evidence):
+        raise ValueError("capture_provenance must contain at most one row per evidence item")
+    fields = {
+        "evidence_index", "requested_url", "final_url", "status", "content_type",
+        "fallback_attempted", "content_sha256", "text_sha256", "error",
+    }
+    rows: list[dict[str, Any]] = []
+    seen: set[int] = set()
+    for row in value:
+        if not isinstance(row, dict) or set(row) != fields:
+            raise ValueError("capture_provenance fields are invalid")
+        index = row["evidence_index"]
+        if type(index) is not int or not 0 <= index < len(evidence) or index in seen:
+            raise ValueError("capture_provenance evidence_index is invalid or duplicated")
+        seen.add(index)
+        requested_url = _one_line(
+            row["requested_url"], "capture_provenance.requested_url",
+        )
+        final_url = row["final_url"]
+        if final_url is not None:
+            final_url = _one_line(final_url, "capture_provenance.final_url")
+            parsed = urlparse(final_url)
+            if parsed.scheme not in {"http", "https"} or not parsed.hostname:
+                raise ValueError(
+                    "capture_provenance final_url must be null or absolute HTTP(S)"
+                )
+            if final_url != evidence[index]["url"]:
+                raise ValueError("capture_provenance final_url differs from its evidence URL")
+        elif requested_url != evidence[index]["url"]:
+            raise ValueError(
+                "capture_provenance requested_url differs from uncaptured evidence URL"
+            )
+        status = row["status"]
+        if status is not None and (type(status) is not int or not 100 <= status <= 599):
+            raise ValueError("capture_provenance status must be null or an HTTP status integer")
+        if type(row["fallback_attempted"]) is not bool:
+            raise ValueError("capture_provenance fallback_attempted must be boolean")
+
+        def optional_line(field: str, maximum: int) -> str | None:
+            raw = row[field]
+            if raw is None:
+                return None
+            checked = _one_line(raw, f"capture_provenance.{field}")
+            if len(checked) > maximum:
+                raise ValueError(
+                    f"capture_provenance {field} exceeds {maximum} characters"
+                )
+            return checked
+
+        content_sha = optional_line("content_sha256", 64)
+        text_sha = optional_line("text_sha256", 64)
+        for field, digest in (("content_sha256", content_sha), ("text_sha256", text_sha)):
+            if digest is not None and not re.fullmatch(r"[0-9a-f]{64}", digest):
+                raise ValueError(f"capture_provenance {field} must be null or lowercase SHA-256")
+        rows.append({
+            "evidence_index": index,
+            "requested_url": requested_url,
+            "final_url": final_url,
+            "status": status,
+            "content_type": optional_line("content_type", 500),
+            "fallback_attempted": row["fallback_attempted"],
+            "content_sha256": content_sha,
+            "text_sha256": text_sha,
+            "error": optional_line("error", sources.MAX_CAPTURE_ERROR_CHARS),
+        })
+    return rows
 
 
 def _validate_capture_attestations(
@@ -504,10 +599,14 @@ def _validate_capture_attestations(
         "publisher_authority", "authority_reason", "passage_entailment",
         "entailment_reason",
     }
+    optional = {
+        "content_sha256", "status", "content_type", "fallback_attempted",
+        "capture_error",
+    }
     rows: list[dict[str, Any]] = []
     seen: set[int] = set()
     for row in value:
-        if not isinstance(row, dict) or set(row) != required:
+        if not isinstance(row, dict) or not required <= set(row) or set(row) - required - optional:
             raise ValueError("capture_attestation fields are invalid")
         index = row["evidence_index"]
         if type(index) is not int or not 0 <= index < len(evidence) or index in seen:
@@ -530,7 +629,7 @@ def _validate_capture_attestations(
         for field in ("publisher_authority", "passage_entailment"):
             if type(row[field]) is not bool:
                 raise ValueError(f"capture_attestation {field} must be boolean")
-        rows.append({
+        checked = {
             "evidence_index": index,
             "final_url": final_url,
             "text_sha256": text_sha256,
@@ -543,7 +642,38 @@ def _validate_capture_attestations(
             "entailment_reason": _one_line(
                 row["entailment_reason"], "capture_attestation.entailment_reason",
             ),
-        })
+        }
+        if len(checked["authority_reason"]) > MAX_ATTESTATION_REASON_CHARS or len(
+            checked["entailment_reason"]
+        ) > MAX_ATTESTATION_REASON_CHARS:
+            raise ValueError(
+                "capture_attestation reason exceeds "
+                f"{MAX_ATTESTATION_REASON_CHARS} characters"
+            )
+        if "content_sha256" in row:
+            content_sha256 = _one_line(
+                row["content_sha256"], "capture_attestation.content_sha256",
+            )
+            if not re.fullmatch(r"[0-9a-f]{64}", content_sha256):
+                raise ValueError("capture_attestation content_sha256 must be lowercase SHA-256")
+            checked["content_sha256"] = content_sha256
+        if "status" in row:
+            if type(row["status"]) is not int or not 100 <= row["status"] <= 599:
+                raise ValueError("capture_attestation status must be an HTTP status integer")
+            checked["status"] = row["status"]
+        if "content_type" in row:
+            checked["content_type"] = _one_line(
+                row["content_type"], "capture_attestation.content_type",
+            )
+        if "fallback_attempted" in row:
+            if type(row["fallback_attempted"]) is not bool:
+                raise ValueError("capture_attestation fallback_attempted must be boolean")
+            checked["fallback_attempted"] = row["fallback_attempted"]
+        if "capture_error" in row:
+            checked["capture_error"] = _one_line(
+                row["capture_error"], "capture_attestation.capture_error",
+            )
+        rows.append(checked)
     return rows
 
 

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -48,6 +48,9 @@ class Attempt:
     stderr_sha256: str | None = None
     stderr_excerpt: str | None = None
     validation_issue: str | None = None
+    validation_pointer: str | None = None
+    rejected_reply_sha256: str | None = None
+    rejected_reply_excerpt: str | None = None
 
     def json(self) -> dict[str, Any]:
         return vars(self)

--- a/tests/test_external_sources.py
+++ b/tests/test_external_sources.py
@@ -1,4 +1,5 @@
 from email.message import Message
+import hashlib
 import threading
 import time
 import urllib.error
@@ -128,6 +129,85 @@ def test_oversized_response_is_visible_non_governing(monkeypatch):
     got = es.capture(candidate(), opener=lambda _request, _timeout: Response(body, "text/plain"))
     assert not got.usable
     assert "exceeds" in got.error
+    assert got.final_url == "https://docs.example.com/page"
+    assert got.status == 200
+    assert got.content_type == "text/plain"
+    assert got.content_sha256 == hashlib.sha256(body).hexdigest()
+    assert got.text_sha256 is None
+
+
+def test_extraction_failure_retains_known_response_provenance(monkeypatch):
+    monkeypatch.setattr(es, "_validate_public_url", lambda _url: None)
+    body = b"   \n\t"
+    got = es.capture(candidate(), opener=lambda _request, _timeout: Response(body))
+    assert not got.usable
+    assert got.final_url == "https://docs.example.com/page"
+    assert got.status == 200
+    assert got.content_type == "text/html"
+    assert got.content_sha256 == hashlib.sha256(body).hexdigest()
+    assert got.text_sha256 is None
+    assert "no text" in got.error
+
+
+def test_rejected_final_url_retains_actual_destination_and_headers(monkeypatch):
+    original = candidate("https://official.example/redirect")
+    rejected = "http://127.0.0.1/private"
+
+    def validate(url):
+        if url == original.url:
+            return
+        raise es.SourceError("non-public final address")
+
+    monkeypatch.setattr(es, "_validate_public_url", validate)
+    got = es.capture(
+        original,
+        opener=lambda _request, _timeout: Response(
+            b"must not be read", "text/plain", url=rejected,
+        ),
+    )
+    assert not got.usable
+    assert got.final_url == rejected
+    assert got.status == 200
+    assert got.content_type == "text/plain"
+    assert got.content_sha256 is None
+    assert got.text_sha256 is None
+    assert "non-public final address" in got.error
+
+
+def test_default_redirect_handler_retains_rejected_target_and_response_metadata(
+    monkeypatch,
+):
+    original = candidate("https://official.example/redirect")
+    rejected = "http://127.0.0.1/private"
+    redirect_headers = Message()
+    redirect_headers["Content-Type"] = "text/plain; charset=utf-8"
+
+    def validate(url):
+        if url == original.url:
+            return
+        raise es.SourceError("source host resolves to non-public address 127.0.0.1")
+
+    class Opener:
+        def __init__(self, handler):
+            self.handler = handler
+
+        def open(self, request, timeout):
+            return self.handler.redirect_request(
+                request, None, 302, "Found", redirect_headers, rejected,
+            )
+
+    monkeypatch.setattr(es, "_validate_public_url", validate)
+    monkeypatch.setattr(
+        es.urllib.request, "build_opener", lambda handler: Opener(handler),
+    )
+    got = es.capture(original)
+    assert not got.usable
+    assert got.final_url == rejected
+    assert got.status == 302
+    assert got.content_type == "text/plain"
+    assert got.content_sha256 is None
+    assert got.text_sha256 is None
+    assert "non-public address 127.0.0.1" in got.error
 
 
 def test_raw_response_reader_admits_exact_byte_boundary():
@@ -147,8 +227,8 @@ def test_large_extracted_page_keeps_deep_evidence(monkeypatch):
 
 
 def test_extracted_character_cap_admits_boundary_and_rejects_next_character():
-    assert len(es._extract(b"x" * es.MAX_EXTRACTED_CHARS, "text/plain")) == 100_000
-    with pytest.raises(es.SourceError, match="extracted page has 100001 characters"):
+    assert len(es._extract(b"x" * es.MAX_EXTRACTED_CHARS, "text/plain")) == 1_000_000
+    with pytest.raises(es.SourceError, match="extracted page has 1000001 characters"):
         es._extract(b"x" * (es.MAX_EXTRACTED_CHARS + 1), "text/plain")
 
 

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -3,6 +3,8 @@ from __future__ import annotations
 import hashlib
 import json
 import subprocess
+from collections.abc import Callable
+from email.message import Message
 from pathlib import Path
 
 import pytest
@@ -56,6 +58,60 @@ def test_large_page_capture_acceptance_record() -> None:
             capture_output=True, check=True,
         ).stdout
         assert hashlib.sha256(content).hexdigest() == expected
+
+
+def test_authoritative_capture_acceptance_record() -> None:
+    root = Path(__file__).resolve().parents[1]
+    artifact = json.loads(
+        (root / "docs/authoritative_capture_acceptance_2026-08-20.json").read_text()
+    )
+    assert "No exact-maximum provider transport guarantee" in artifact[
+        "acceptance_claims"
+    ]["does_not_claim"]
+    assert artifact["source"]["extracted_characters"] > artifact["source"]["former_limit"]
+    assert artifact["source"]["extracted_characters"] == 590_177
+    assert {row["engine"] for row in artifact["routes"]} == {"codex", "claude"}
+    for row in artifact["routes"]:
+        assert handlers.MAX_PLAN_BINDING_BATCH_CHARS < row["binding_prompt_characters"]
+        assert row["binding_prompt_characters"] <= handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+        assert row["attestation_prompt_characters"] <= handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+        assert row["fresh_binding_bootstrap"] and row["resumed_binding"]
+        assert row["fresh_full_context_attestation"]
+        assert len(row["binding_prompt_sha256"]) == 64
+        assert len(row["binding_correction_prompt_sha256"]) == 64
+        assert len(row["attestation_prompt_sha256"]) == 64
+        assert len(row["bootstrap_reply_sha256"]) == 64
+        assert len(row["binding_reply_sha256"]) == row["binding_calls"]
+        assert all(len(value) == 64 for value in row["binding_reply_sha256"])
+        assert all(len(value) == 64 for value in row["binding_raw_sha256"])
+        assert len(row["attestation_raw_sha256"]) == 64
+        assert row["publisher_authority"] and row["passage_entailment"]
+        assert row["verdict"] == "supported"
+    production = artifact["production_entrypoint"]
+    assert production["public_handler"] == "critique_plan"
+    assert production["ordinary_and_expanded_claims"] == 2
+    assert production["supported_claims_after_reload"] == 2
+    assert production["claim_debt"] is None
+    assert production["spotify_capture_error"] is None
+    assert production["spotify_publisher_authority"]
+    assert production["spotify_passage_entailment"]
+    assert production["durable_reload"]
+    measured = artifact["production_preflight_measurement"]
+    assert measured["attestation_correction_worst_case_characters"] <= (
+        handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+    )
+    assert measured["configured_ceiling"] == handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+    snapshot = artifact["reviewed_snapshot"]
+    assert len(snapshot["base_commit"]) == 40
+    for relative, expected in snapshot["production_source_sha256"].items():
+        assert hashlib.sha256((root / relative).read_bytes()).hexdigest() == expected
+    production_diff = artifact["implementation_diff"]
+    assert production_diff["largest_changed_module"] == "src/paranoia_local/handlers.py"
+    assert production_diff["largest_changed_module_lines_after"] == sum(
+        1 for _ in (root / production_diff["largest_changed_module"]).open(
+            encoding="utf-8"
+        )
+    )
 
 
 def test_minimal_claim_validation_acceptance_record() -> None:
@@ -1222,20 +1278,28 @@ class _RoleScript:
     default_model = "test"
 
     def __init__(
-        self, outputs: dict[str, list[str]], calls: list[tuple[str, str]] | None = None,
+        self, outputs: dict[str, list[str | Review]],
+        calls: list[tuple[str, str]] | None = None,
+        advance: Callable[[], None] | None = None,
     ) -> None:
         self.outputs = outputs
         self.role = "default"
         self.calls = calls if calls is not None else []
+        self.advance = advance
 
     def for_role(self, role: str):
-        child = _RoleScript(self.outputs, self.calls)
+        child = _RoleScript(self.outputs, self.calls, self.advance)
         child.role = role
         return child
 
     def _next(self) -> Review:
+        value = self.outputs[self.role].pop(0)
+        if self.advance is not None:
+            self.advance()
+        if isinstance(value, Review):
+            return value
         return Review(
-            text=self.outputs[self.role].pop(0), session_ref="session", raw=self.role,
+            text=value, session_ref="session", raw=self.role,
         )
 
     def run(self, *args, **kwargs):
@@ -1300,6 +1364,153 @@ def test_captured_claim_retry_cannot_bypass_capture_validation(
         adapter.close()
 
 
+def test_non_web_context_provenance_preserves_authoritative_http_sibling(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    context = _source(url="repo://docs/plan.md", kind="primary")
+    authoritative = _source()
+    discovery = _audit(_claim(evidence=[context, authoritative]))
+
+    def capture_all(candidates, **kwargs):
+        rows = []
+        for candidate in candidates:
+            if candidate.url.startswith("repo://"):
+                rows.append(external_sources.Capture(
+                    candidate, None, None, None, None, None, None,
+                    error="only public HTTP(S) sources can be captured",
+                ))
+            else:
+                rows.append(external_sources.Capture(
+                    candidate, candidate.url, 200, "text/html",
+                    "a" * 64, "b" * 64, authoritative["quote"],
+                ))
+        return rows
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": 0, "evidence_index": 1, "usable": True,
+            "location": authoritative["location"],
+            "passage": authoritative["quote"],
+        }],
+    })
+    attestation = "=== EVIDENCE ATTESTATION JSON ===\n" + json.dumps({
+        "attestations": [{
+            "claim_index": 0, "evidence_index": 1,
+            "publisher_authority": True,
+            "authority_reason": "The publisher owns the release record.",
+            "passage_entailment": True,
+            "entailment_reason": "The passage states the release date.",
+        }],
+    })
+    engine = _RoleScript({
+        "evidence-discovery": [discovery],
+        "evidence-binding": [binding],
+        "evidence-text": [attestation],
+    })
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        result = adapter.run("audit", tmp_path, "m", "high", True)
+        assert not result.error
+        audit = pc.parse_audit(
+            result.text, PLAN, require_capture_provenance=True,
+        )
+        claim = audit.claims[0]
+        assert claim["verdict"] == "supported"
+        assert claim["evidence"][0]["relation"] == "context"
+        assert claim["capture_provenance"][0] == {
+            "evidence_index": 0,
+            "requested_url": "repo://docs/plan.md",
+            "final_url": None,
+            "status": None,
+            "content_type": None,
+            "fallback_attempted": False,
+            "content_sha256": None,
+            "text_sha256": None,
+            "error": "only public HTTP(S) sources can be captured",
+        }
+        assert claim["capture_provenance"][1]["requested_url"] == authoritative["url"]
+        assert claim["capture_provenance"][1]["final_url"] == authoritative["url"]
+        state = pc.reconcile(
+            {}, audit, lineage_id="mixed-context", round_no=1, plan_text=PLAN,
+        )
+        reloaded = json.loads(json.dumps(state))
+        record = next(iter(reloaded["claims"].values()))
+        assert record["verdict"] == "supported"
+        assert record["capture_provenance"] == claim["capture_provenance"]
+    finally:
+        adapter.close()
+
+
+def test_default_redirect_rejection_reaches_durable_capture_provenance(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    source = _source(url="https://official.example/redirect")
+    rejected = "http://127.0.0.1/private"
+    redirect_headers = Message()
+    redirect_headers["Content-Type"] = "text/plain; charset=utf-8"
+
+    def validate(url):
+        if url == source["url"]:
+            return
+        raise external_sources.SourceError(
+            "source host resolves to non-public address 127.0.0.1"
+        )
+
+    class Opener:
+        def __init__(self, handler):
+            self.handler = handler
+
+        def open(self, request, timeout):
+            return self.handler.redirect_request(
+                request, None, 302, "Found", redirect_headers, rejected,
+            )
+
+    monkeypatch.setattr(external_sources, "_validate_public_url", validate)
+    monkeypatch.setattr(
+        external_sources.urllib.request,
+        "build_opener",
+        lambda handler: Opener(handler),
+    )
+    engine = _RoleScript({
+        "evidence-discovery": [_audit(_claim(evidence=[source]))],
+    })
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        result = adapter.run("audit", tmp_path, "m", "high", True)
+        assert not result.error
+        audit = pc.parse_audit(
+            result.text, PLAN, require_capture_provenance=True,
+        )
+        claim = audit.claims[0]
+        assert claim["verdict"] == "unverified"
+        assert claim["capture_provenance"] == [{
+            "evidence_index": 0,
+            "requested_url": source["url"],
+            "final_url": rejected,
+            "status": 302,
+            "content_type": "text/plain",
+            "fallback_attempted": False,
+            "content_sha256": None,
+            "text_sha256": None,
+            "error": (
+                "rejected final URL: source host resolves to non-public address "
+                "127.0.0.1"
+            ),
+        }]
+        state = pc.reconcile(
+            {}, audit, lineage_id="redirect-rejected", round_no=1, plan_text=PLAN,
+        )
+        record = next(iter(json.loads(json.dumps(state))["claims"].values()))
+        assert record["capture_provenance"] == claim["capture_provenance"]
+    finally:
+        adapter.close()
+
+
 def test_only_server_attested_supported_packets_freeze() -> None:
     unattested = pc.reconcile(
         {}, pc.parse_audit(_audit(_claim()), PLAN),
@@ -1318,8 +1529,29 @@ def test_only_server_attested_supported_packets_freeze() -> None:
         "passage_entailment": True,
         "entailment_reason": "The passage states the release date.",
     }
-    attested = pc.reconcile(
+    provenance = {
+        "evidence_index": 0,
+        "requested_url": _source()["url"],
+        "final_url": _source()["url"],
+        "status": 200,
+        "content_type": "text/html",
+        "fallback_attempted": False,
+        "content_sha256": "b" * 64,
+        "text_sha256": "a" * 64,
+        "error": None,
+    }
+    legacy = pc.reconcile(
         {}, pc.parse_audit(_audit(_claim(capture_attestations=[attestation])), PLAN),
+        lineage_id="capture-plan", round_no=1, plan_text=PLAN,
+    )
+    legacy["plan_snapshot"] = PLAN
+    assert not pc.frozen_supported_ids(
+        legacy, PLAN, require_capture_attestation=True,
+    )
+    attested = pc.reconcile(
+        {}, pc.parse_audit(_audit(_claim(
+            capture_attestations=[attestation], capture_provenance=[provenance],
+        )), PLAN),
         lineage_id="capture-plan", round_no=1, plan_text=PLAN,
     )
     assert len(pc.frozen_supported_ids(
@@ -1413,6 +1645,8 @@ def test_negative_attestation_removes_exact_replacement_but_keeps_refutation(
 
 def _run_indexed_attestation_rows(
     tmp_path: Path, rows: list[dict[str, object]],
+    correction_rows: list[dict[str, object]] | None = None,
+    attempt_ledger: list[dict] | None = None,
 ) -> pc.Audit | Review:
     second_anchor = "Python documentation also records the release date."
     plan = PLAN + "\n" + second_anchor + "\n"
@@ -1428,9 +1662,15 @@ def _run_indexed_attestation_rows(
         "=== EVIDENCE ATTESTATION JSON ===\n"
         + json.dumps({"attestations": rows})
     )
-    engine = _RoleScript({"evidence-text": [response]})
+    correction = (
+        "=== EVIDENCE ATTESTATION JSON ===\n"
+        + json.dumps({"attestations": correction_rows})
+        if correction_rows is not None else response
+    )
+    engine = _RoleScript({"evidence-text": [response, correction]})
     adapter = handlers._CapturedClaimEngine(
         engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+        attempt_ledger=attempt_ledger,
     )
     for claim_index, claim in enumerate(audit.claims):
         for evidence_index, item in enumerate(claim["evidence"]):
@@ -1495,6 +1735,25 @@ def test_attestation_identity_inventory_fails_recoverably(
     assert result.error
     assert result.session_ref == "session"
     assert message in result.text
+
+
+def test_attestation_reason_bound_uses_one_successful_correction(tmp_path: Path) -> None:
+    rows = _valid_attestation_rows()
+    rows[0]["authority_reason"] = "x" * (handlers.MAX_ATTESTATION_REASON_CHARS + 1)
+    ledger: list[dict] = []
+    result = _run_indexed_attestation_rows(
+        tmp_path, rows, correction_rows=_valid_attestation_rows(),
+        attempt_ledger=ledger,
+    )
+    assert isinstance(result, pc.Audit)
+    assert all(claim["verdict"] == "supported" for claim in result.claims)
+    assert [row["role"] for row in ledger] == [
+        "claim-attestation", "claim-attestation-validation-retry",
+    ]
+    assert ledger[0]["outcome"] == "validation-invalid"
+    assert ledger[0]["validation_pointer"] == "/attestations"
+    assert ledger[0]["rejected_reply_sha256"]
+    assert ledger[1]["outcome"] == "completed"
 
 
 def test_retained_inventory_is_corrected_before_capture(
@@ -1564,7 +1823,7 @@ def test_retained_inventory_is_corrected_before_capture(
         assert capture_sizes == [2]
         assert [role for role, _ in engine.calls].count("evidence-discovery") == 2
         assert [row["role"] for row in ledger] == [
-            "claim-discovery", "claim-discovery-retry", "claim-binding",
+            "claim-discovery", "claim-discovery-validation-retry", "claim-binding",
             "claim-attestation",
         ]
     finally:
@@ -1652,7 +1911,7 @@ def test_plan_binding_batches_large_ordinary_inventory(tmp_path: Path) -> None:
             )
             captures[(claim_index, 0)] = external_sources.Capture(
                 candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
-                "x" * external_sources.MAX_EXTRACTED_CHARS,
+                "x" * 100_000,
             )
         batches = adapter._binding_batches(audit, captures)
         assert len(batches) == 1
@@ -1683,7 +1942,7 @@ def test_plan_binding_capture_references_never_cross_batch_boundary(tmp_path: Pa
         captures[(claim_index, 0)] = external_sources.Capture(
             candidate, f"{candidate.url}?page={identity}", 200, "text/html",
             f"{identity:064x}", f"{identity + 10:064x}",
-            "x" * external_sources.MAX_EXTRACTED_CHARS,
+            "x" * 100_000,
         )
     adapter = handlers._CapturedClaimEngine(
         _RoleScript({}), plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
@@ -1702,6 +1961,93 @@ def test_plan_binding_capture_references_never_cross_batch_boundary(tmp_path: Pa
     assert batches[1][2]["capture"]["line_numbered_text"] == ""
 
 
+def test_long_primary_capture_uses_one_complete_expanded_packet(tmp_path: Path) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    text = "x" * 590_000 + "\n" + item["quote"]
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64, text,
+    )}
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batches = adapter._binding_batches(audit, captures)
+        rendered = json.dumps(batches[0], ensure_ascii=False, separators=(",", ":"))
+        assert len(batches) == 1 and len(batches[0]) == 1
+        assert (0, 0) in adapter.expanded_captures
+        assert len(adapter._binding_prompt(rendered)) > handlers.MAX_PLAN_BINDING_BATCH_CHARS
+        assert len(adapter._binding_prompt(rendered)) <= handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+        assert batches[0][0]["binding_target"] == audit.claims[0]["proposition"]
+        assert captures[(0, 0)].usable
+    finally:
+        adapter.close()
+
+
+def test_long_capture_expansion_uses_effective_final_url_policy(tmp_path: Path) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, "https://www.reddit.com/r/python/comments/x", 200, "text/html",
+        "a" * 64, "b" * 64, "x" * 590_000,
+    )}
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        assert adapter._binding_batches(audit, captures) == []
+        assert not captures[(0, 0)].usable
+        assert captures[(0, 0)].final_url == "https://www.reddit.com/r/python/comments/x"
+        assert captures[(0, 0)].content_sha256 == "a" * 64
+        assert captures[(0, 0)].text_sha256 == "b" * 64
+    finally:
+        adapter.close()
+
+
+@pytest.mark.parametrize("host_form", [
+    "https://github.com/acme/review-repo/blob/main/docs/plan.md",
+    "https://raw.githubusercontent.com/acme/review-repo/main/docs/plan.md",
+])
+def test_long_capture_redirect_to_reviewed_plan_cannot_expand(
+    tmp_path: Path, host_form: str,
+) -> None:
+    repo = tmp_path / "review-repo"
+    repo.mkdir()
+    subprocess.run(["git", "init", "-q"], cwd=repo, check=True)
+    subprocess.run(
+        ["git", "remote", "add", "origin", "https://github.com/acme/review-repo.git"],
+        cwd=repo, check=True,
+    )
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, host_form, 200, "text/html", "a" * 64, "b" * 64,
+        "x" * 590_000,
+    )}
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=repo,
+        plan_repo_path="docs/plan.md",
+    )
+    try:
+        assert adapter._binding_batches(audit, captures) == []
+        assert (0, 0) not in adapter.expanded_captures
+        assert captures[(0, 0)].error == external_sources.BINDING_BUDGET_ERROR
+    finally:
+        adapter.close()
+
+
 def test_plan_binding_demotes_one_escape_amplified_capture_per_source(tmp_path: Path) -> None:
     audit = pc.parse_audit(_audit(_claim()), PLAN)
     item = audit.claims[0]["evidence"][0]
@@ -1711,7 +2057,7 @@ def test_plan_binding_demotes_one_escape_amplified_capture_per_source(tmp_path: 
     )
     captures = {(0, 0): external_sources.Capture(
         candidate, candidate.url, 200, "text/plain", "a" * 64, "b" * 64,
-        "\n" * external_sources.MAX_EXTRACTED_CHARS,
+        "\n" * 100_000,
     )}
     adapter = handlers._CapturedClaimEngine(
         _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
@@ -1720,12 +2066,9 @@ def test_plan_binding_demotes_one_escape_amplified_capture_per_source(tmp_path: 
         batches = adapter._binding_batches(audit, captures)
     finally:
         adapter.close()
-    assert len(batches) == 1
-    assert len(batches[0]) == 1
+    assert batches == []
     assert not captures[(0, 0)].usable
     assert captures[(0, 0)].error == external_sources.BINDING_BUDGET_ERROR
-    assert batches[0][0]["capture"]["usable"] is False
-    assert batches[0][0]["capture"]["line_numbered_text"] == ""
 
 
 def test_escape_amplified_capture_is_demoted_before_flushing_current_batch(
@@ -1746,8 +2089,8 @@ def test_escape_amplified_capture_is_demoted_before_flushing_current_batch(
         captures[(claim_index, 0)] = external_sources.Capture(
             candidate, f"{candidate.url}?page={claim_index}", 200, "text/plain",
             f"{claim_index:064x}", f"{claim_index + 10:064x}",
-            ("x" * external_sources.MAX_EXTRACTED_CHARS)
-            if claim_index < 3 else ("\n" * external_sources.MAX_EXTRACTED_CHARS),
+            ("x" * 100_000)
+            if claim_index < 3 else ("\n" * 100_000),
         )
     adapter = handlers._CapturedClaimEngine(
         _RoleScript({}), plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
@@ -1757,9 +2100,48 @@ def test_escape_amplified_capture_is_demoted_before_flushing_current_batch(
     finally:
         adapter.close()
     assert len(batches) == 1
-    assert len(batches[0]) == 4
-    assert batches[0][-1]["capture"]["usable"] is False
+    assert len(batches[0]) == 3
     assert captures[(3, 0)].error == external_sources.BINDING_BUDGET_ERROR
+
+
+def test_repeated_ineligible_oversized_rows_cannot_manufacture_batches(
+    tmp_path: Path,
+) -> None:
+    lines = [f"External behavior {index} is guaranteed." for index in range(12)]
+    plan = "# Plan\n\n" + "\n".join(lines)
+    claims = [
+        _claim(
+            anchor=line, proposition=line,
+            evidence=[_source(kind="secondary" if index % 2 else "primary")],
+        )
+        for index, line in enumerate(lines)
+    ]
+    audit = pc.parse_audit(_audit(*claims), plan)
+    captures = {}
+    for claim_index, claim in enumerate(audit.claims):
+        item = claim["evidence"][0]
+        candidate = external_sources.CandidateSource(
+            item["url"], item["title"], item["publisher"], item["source_kind"],
+            item["authority_basis"], item["relation"],
+        )
+        captures[(claim_index, 0)] = external_sources.Capture(
+            candidate, f"{candidate.url}?page={claim_index}", 200, "text/plain",
+            f"{claim_index + 1:064x}", f"{claim_index + 101:064x}",
+            "\n" * 100_000 if claim_index % 2 else item["quote"],
+        )
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batches = adapter._binding_batches(audit, captures)
+    finally:
+        adapter.close()
+    assert len(batches) == 1
+    assert [row["claim_index"] for row in batches[0]] == [0, 2, 4, 6, 8, 10]
+    assert all(
+        captures[(index, 0)].error == external_sources.BINDING_BUDGET_ERROR
+        for index in range(1, 12, 2)
+    )
 
 
 def test_plan_capture_aggregate_ceiling_blocks_before_network(
@@ -1787,6 +2169,54 @@ def test_plan_capture_aggregate_ceiling_blocks_before_network(
         adapter.close()
 
 
+def test_non_model_reserve_bounds_200_source_capture_before_binding(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    count = handlers.MAX_PLAN_CAPTURE_SOURCES
+    lines = [f"External behavior {index} is guaranteed." for index in range(count)]
+    plan = "# Plan\n\n" + "\n".join(lines)
+    discovery = _audit(*[
+        _claim(anchor=line, proposition=line) for line in lines
+    ])
+    now = [0.0]
+    engine = _RoleScript(
+        {"evidence-discovery": [discovery]},
+        advance=lambda: now.__setitem__(
+            0, now[0] + handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC,
+        ),
+    )
+
+    def capture_all(candidates, **kwargs):
+        assert len(candidates) == count
+        assert kwargs["deadline"] == (
+            handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
+            + handlers.PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC
+        )
+        now[0] += handlers.PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC + 1
+        return [
+            external_sources.Capture(
+                candidate, candidate.url, 200, "text/html",
+                f"{index + 1:064x}", f"{index + 201:064x}", _source()["quote"],
+            )
+            for index, candidate in enumerate(candidates)
+        ]
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+        deadline=float(handlers.PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC),
+        clock=lambda: now[0],
+    )
+    try:
+        result = adapter.run("audit", tmp_path, "m", "high", True)
+        assert result.error
+        assert "exceeded its aggregate 300-second reserve" in result.text
+        assert [role for role, _ in engine.calls] == ["evidence-discovery"]
+        assert adapter.model_calls == 1
+    finally:
+        adapter.close()
+
+
 def test_plan_binding_aggregate_batch_ceiling_raises_before_model_calls(
     tmp_path: Path,
 ) -> None:
@@ -1809,11 +2239,64 @@ def test_plan_binding_aggregate_batch_ceiling_raises_before_model_calls(
         captures[(claim_index, 0)] = external_sources.Capture(
             candidate, f"{candidate.url}?claim={claim_index}", 200, "text/html",
             f"{claim_index:064x}", "b" * 64,
-            "x" * external_sources.MAX_EXTRACTED_CHARS,
+            "x" * 100_000,
         )
     try:
         with pytest.raises(pc.AuditError, match="aggregate ceiling"):
             adapter._binding_batches(audit, captures)
+    finally:
+        adapter.close()
+
+
+def test_sixth_attestation_batch_fails_globally_before_settling_a_prefix(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    count = handlers.MAX_PLAN_CAPTURE_SOURCES
+    passage = '"' * handlers.MAX_BINDING_PASSAGE_CHARS
+    lines = [f"External behavior {index} is guaranteed." for index in range(count)]
+    plan = "# Plan\n\n" + "\n".join(lines)
+    source = _source(quote=passage)
+    discovery = _audit(*[
+        _claim(
+            anchor=line, proposition=line,
+            evidence=[dict(source)],
+        )
+        for line in lines
+    ])
+    binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+        "bindings": [{
+            "claim_index": index, "evidence_index": 0, "usable": True,
+            "location": source["location"], "passage": passage,
+        } for index in range(count)],
+    })
+
+    def capture_all(candidates, **kwargs):
+        return [
+            external_sources.Capture(
+                candidate, source["url"], 200, "text/html",
+                "a" * 64, "b" * 64, passage,
+            )
+            for candidate in candidates
+        ]
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    engine = _RoleScript({
+        "evidence-discovery": [discovery],
+        "evidence-binding": [binding],
+    })
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        result = adapter.run("audit", tmp_path, "m", "high", True)
+        assert result.error
+        assert "evidence attestation requires" in result.text
+        assert f"aggregate ceiling is {handlers.MAX_PLAN_ATTESTATION_BATCHES}" in result.text
+        assert [role for role, _ in engine.calls] == [
+            "evidence-discovery", "evidence-binding",
+        ]
+        assert "=== CLAIM AUDIT JSON ===" not in result.text
+        assert adapter.attestation_raw == ""
     finally:
         adapter.close()
 
@@ -1832,8 +2315,134 @@ def test_plan_evidence_model_call_budget_refuses_another_phase(tmp_path: Path) -
 
 
 def test_plan_evidence_budget_composes_at_maximum_batch_count() -> None:
-    normal_path = 1 + handlers.MAX_PLAN_BINDING_BATCHES + 1
-    assert handlers.MAX_PLAN_EVIDENCE_MODEL_CALLS >= normal_path + 2
+    normal_path = (
+        1 + handlers.MAX_PLAN_BINDING_BATCHES
+        + handlers.MAX_PLAN_ATTESTATION_BATCHES
+    )
+    assert handlers.MAX_PLAN_EVIDENCE_MODEL_CALLS == normal_path * 2
+    assert handlers.PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC == (
+        handlers.MAX_PLAN_EVIDENCE_MODEL_CALLS
+        * handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
+        + handlers.PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC
+        + handlers.PLAN_EVIDENCE_SCHEDULING_SLACK_SEC
+    )
+
+
+def test_plan_evidence_budget_admits_every_initial_and_validation_retry(
+    tmp_path: Path,
+) -> None:
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+        deadline=float("inf"),
+    )
+    phases = (
+        1 + handlers.MAX_PLAN_BINDING_BATCHES
+        + handlers.MAX_PLAN_ATTESTATION_BATCHES
+    )
+    try:
+        for _ in range(phases):
+            assert adapter._next_model_timeout(reserve_calls=2) == (
+                handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
+            )
+            assert adapter._next_model_timeout() == handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC
+        with pytest.raises(pc.AuditError, match="model-call ceiling"):
+            adapter._next_model_timeout()
+    finally:
+        adapter.close()
+
+
+def test_maximum_evidence_topology_executes_every_validation_retry(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    claims: list[dict[str, object]] = []
+    anchors: list[str] = []
+    passages: list[str] = []
+    for index in range(handlers.MAX_PLAN_BINDING_BATCHES):
+        anchor = f"Vendor {index} published release {index} on January {index + 1}, 2024."
+        passage = f"Release {index} was published on January {index + 1}, 2024."
+        anchors.append(anchor)
+        passages.append(passage)
+        claims.append(_claim(
+            anchor=anchor,
+            proposition=anchor,
+            evidence=[_source(
+                url=f"https://official.example/source-{index}", quote=passage,
+            )],
+        ))
+    plan = "# Maximum topology\n\n" + "\n".join(anchors) + "\n"
+    discovery = _audit(*claims)
+    binding_outputs: list[str | Review] = []
+    attestation_outputs: list[str | Review] = []
+    for index, passage in enumerate(passages):
+        binding_outputs.extend([
+            "invalid binding",
+            handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
+                "bindings": [{
+                    "claim_index": index, "evidence_index": 0, "usable": True,
+                    "location": "release record", "passage": passage,
+                }],
+            }),
+        ])
+        attestation_outputs.extend([
+            "invalid attestation",
+            "=== EVIDENCE ATTESTATION JSON ===\n" + json.dumps({
+                "attestations": [{
+                    "claim_index": index, "evidence_index": 0,
+                    "publisher_authority": True,
+                    "authority_reason": "official publisher",
+                    "passage_entailment": True,
+                    "entailment_reason": "direct release record",
+                }],
+            }),
+        ])
+    now = [0.0]
+    engine = _RoleScript({
+        "evidence-discovery": ["invalid discovery", discovery],
+        "evidence-binding": binding_outputs,
+        "evidence-text": attestation_outputs,
+    }, advance=lambda: now.__setitem__(
+        0, now[0] + handlers.PLAN_EVIDENCE_PHASE_TIMEOUT_SEC,
+    ))
+
+    def capture_all(candidates, **kwargs):
+        now[0] += handlers.PLAN_EVIDENCE_NON_MODEL_RESERVE_SEC
+        return [
+            external_sources.Capture(
+                candidate, candidate.url, 200, "text/html",
+                f"{index + 1:064x}", f"{index + 101:064x}",
+                "x" * 450_000 + "\n" + passages[index],
+            )
+            for index, candidate in enumerate(candidates)
+        ]
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    ledger: list[dict] = []
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+        deadline=float(handlers.PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC),
+        attempt_ledger=ledger, clock=lambda: now[0],
+    )
+    try:
+        result = adapter.run("audit", tmp_path, "m", "high", True)
+        assert not result.error
+        assert adapter.model_calls == handlers.MAX_PLAN_EVIDENCE_MODEL_CALLS
+        assert now[0] == (
+            handlers.PLAN_EVIDENCE_TOTAL_TIMEOUT_SEC
+            - handlers.PLAN_EVIDENCE_SCHEDULING_SLACK_SEC
+        )
+        assert len(ledger) == handlers.MAX_PLAN_EVIDENCE_MODEL_CALLS
+        assert [row["outcome"] for row in ledger[::2]] == [
+            "validation-invalid"
+        ] * 11
+        assert [row["outcome"] for row in ledger[1::2]] == ["completed"] * 11
+        assert all(row.get("validation_pointer") for row in ledger[::2])
+        audited = pc.parse_audit(
+            result.text, plan, require_capture_provenance=True,
+        )
+        assert len(audited.claims) == 5
+        assert all(claim["verdict"] == "supported" for claim in audited.claims)
+    finally:
+        adapter.close()
 
 
 def test_evidence_deadline_debt_is_persisted_before_structural_review(
@@ -1933,6 +2542,46 @@ def test_indexed_plan_binding_defaults_omission_but_rejects_unknown_key(
         })
         with pytest.raises(pc.AuditError, match="identity is invalid or duplicated"):
             adapter._parse_indexed_binding(unknown, batch, captures)
+    finally:
+        adapter.close()
+
+
+@pytest.mark.parametrize(
+    ("field", "limit"),
+    [
+        ("location", handlers.MAX_BINDING_LOCATION_CHARS),
+        ("passage", handlers.MAX_BINDING_PASSAGE_CHARS),
+    ],
+)
+def test_binding_output_text_limits_are_exact(
+    tmp_path: Path, field: str, limit: int,
+) -> None:
+    audit = pc.parse_audit(_audit(_claim()), PLAN)
+    item = audit.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    text = "z" * (handlers.MAX_BINDING_PASSAGE_CHARS + 1)
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64, text,
+    )}
+    adapter = handlers._CapturedClaimEngine(
+        _RoleScript({}), plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        batch = adapter._binding_batches(audit, captures)[0]
+        row = {
+            "claim_index": 0, "evidence_index": 0, "usable": True,
+            "location": "l", "passage": "z",
+        }
+        row[field] = "z" * limit
+        accepted = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({"bindings": [row]})
+        assert adapter._parse_indexed_binding(accepted, batch, captures)[(0, 0)]
+        row[field] += "z"
+        rejected = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({"bindings": [row]})
+        with pytest.raises(pc.AuditError, match=f"{field} exceeds"):
+            adapter._parse_indexed_binding(rejected, batch, captures)
     finally:
         adapter.close()
 
@@ -2057,6 +2706,233 @@ def test_binding_omission_survives_capture_attestation_and_reconciliation(
         adapter.close()
 
 
+def test_mixed_ordinary_and_expanded_sources_reach_full_context_attestation(
+    tmp_path: Path, monkeypatch,
+) -> None:
+    second_anchor = "SQLite 3.45.0 was released on January 15, 2024."
+    plan = PLAN + "\n" + second_anchor + "\n"
+    second_passage = "SQLite version 3.45.0 was released on 2024-01-15."
+    second_source = _source(
+        url="https://sqlite.org/releaselog/3_45_0.html", quote=second_passage,
+    )
+    discovery_text = _audit(
+        _claim(),
+        _claim(
+            anchor=second_anchor, proposition=second_anchor,
+            evidence=[second_source],
+        ),
+    )
+    first_passage = _source()["quote"]
+    binding_rows = [
+        handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({"bindings": [{
+            "claim_index": 0, "evidence_index": 0, "usable": True,
+            "location": "release record", "passage": first_passage,
+        }]}),
+        handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({"bindings": [{
+            "claim_index": 1, "evidence_index": 0, "usable": True,
+            "location": "release record", "passage": second_passage,
+        }]}),
+    ]
+
+    def attestation(claim_index: int) -> str:
+        return "=== EVIDENCE ATTESTATION JSON ===\n" + json.dumps({
+            "attestations": [{
+                "claim_index": claim_index, "evidence_index": 0,
+                "publisher_authority": True, "authority_reason": "official publisher",
+                "passage_entailment": True, "entailment_reason": "direct release record",
+            }],
+        })
+
+    engine = _RoleScript({
+        "evidence-discovery": [discovery_text],
+        "evidence-binding": binding_rows,
+        "evidence-text": [attestation(0), attestation(1)],
+    })
+
+    def capture_all(candidates, **kwargs):
+        rows = list(candidates)
+        return [
+            external_sources.Capture(
+                rows[0], rows[0].url, 200, "text/html", "a" * 64, "b" * 64,
+                first_passage,
+            ),
+            external_sources.Capture(
+                rows[1], rows[1].url, 200, "text/html", "c" * 64, "d" * 64,
+                "x" * 450_000 + "\n" + second_passage,
+            ),
+        ]
+
+    monkeypatch.setattr(handlers.external_sources, "capture_all", capture_all)
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+    )
+    try:
+        review = adapter.run("audit", tmp_path, "m", "high", True)
+        assert not review.error
+        assert [role for role, _ in engine.calls] == [
+            "evidence-discovery", "evidence-binding", "evidence-binding",
+            "evidence-text", "evidence-text",
+        ]
+        binding_prompts = [prompt for role, prompt in engine.calls if role == "evidence-binding"]
+        assert len(binding_prompts[0]) <= handlers.MAX_PLAN_BINDING_BATCH_CHARS
+        assert handlers.MAX_PLAN_BINDING_BATCH_CHARS < len(binding_prompts[1])
+        attestation_prompts = [prompt for role, prompt in engine.calls if role == "evidence-text"]
+        assert "complete_line_numbered_text" not in attestation_prompts[0]
+        assert "complete_line_numbered_text" in attestation_prompts[1]
+        assert second_passage in attestation_prompts[1]
+        assert len(attestation_prompts[1]) <= handlers.MAX_PLAN_EXPANDED_PROMPT_CHARS
+        audited = pc.parse_audit(review.text, plan)
+        assert [claim["verdict"] for claim in audited.claims] == ["supported", "supported"]
+        assert audited.claims[1]["capture_attestations"][0]["text_sha256"] == "d" * 64
+    finally:
+        adapter.close()
+
+
+def test_expanded_binding_rejection_is_source_local_with_durable_provenance(
+    tmp_path: Path,
+) -> None:
+    discovery = pc.parse_audit(_audit(_claim()), PLAN)
+    item = discovery.claims[0]["evidence"][0]
+    candidate = external_sources.CandidateSource(
+        item["url"], item["title"], item["publisher"], item["source_kind"],
+        item["authority_basis"], item["relation"],
+    )
+    captures = {(0, 0): external_sources.Capture(
+        candidate, candidate.url, 200, "text/html", "a" * 64, "b" * 64,
+        "x" * 590_000 + "\n" + item["quote"],
+    )}
+    engine = _RoleScript({"evidence-binding": ["invalid", "still invalid"]})
+    ledger: list[dict] = []
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=PLAN, repo=_repo(tmp_path), plan_repo_path=None,
+        attempt_ledger=ledger,
+    )
+    adapter.captures = captures
+    adapter.binding_engine = engine.for_role("evidence-binding")
+    try:
+        bound, reviews = adapter._bind_indexed(
+            "session", discovery, captures, "m", "high", {},
+        )
+        assert len(reviews) == 2
+        assert [row["outcome"] for row in ledger] == [
+            "validation-invalid", "validation-invalid",
+        ]
+        assert all(row.get("validation_issue") for row in ledger)
+        assert all(row["validation_pointer"] == "/bindings" for row in ledger)
+        assert all(row["raw_sha256"] and row["failure_detail_sha256"] for row in ledger)
+        assert all(row["stderr_sha256"] and row["rejected_reply_sha256"] for row in ledger)
+        assert [row["rejected_reply_excerpt"] for row in ledger] == [
+            "invalid", "still invalid",
+        ]
+        attested = adapter._attest(bound, "m", "high")
+        assert isinstance(attested, pc.Audit)
+        persisted = pc.parse_audit(handlers._render_audit(attested), PLAN)
+        claim = persisted.claims[0]
+        assert claim["verdict"] == "unverified"
+        assert claim["evidence"][0]["relation"] == "context"
+        provenance = claim["capture_attestations"][0]
+        assert provenance["content_sha256"] == "a" * 64
+        assert provenance["text_sha256"] == "b" * 64
+        assert provenance["status"] == 200
+        assert "expected exactly one" in provenance["capture_error"]
+        assert provenance["publisher_authority"] is False
+        assert provenance["passage_entailment"] is False
+        capture_row = claim["capture_provenance"][0]
+        assert capture_row == {
+            "evidence_index": 0,
+            "requested_url": item["url"],
+            "final_url": item["url"],
+            "status": 200,
+            "content_type": "text/html",
+            "fallback_attempted": False,
+            "content_sha256": "a" * 64,
+            "text_sha256": "b" * 64,
+            "error": "expected exactly one === PLAN EVIDENCE BINDING JSON === marker",
+        }
+    finally:
+        adapter.close()
+
+
+def test_expanded_attestation_failure_is_source_local_and_preserves_sibling(
+    tmp_path: Path,
+) -> None:
+    second_anchor = "SQLite 3.45.0 was released on January 15, 2024."
+    plan = PLAN + "\n" + second_anchor + "\n"
+    second_source = _source(
+        url="https://sqlite.org/releaselog/3_45_0.html",
+        quote="SQLite version 3.45.0 was released on 2024-01-15.",
+    )
+
+    def provenance(url: str, content: str, text: str) -> list[dict[str, object]]:
+        return [{
+            "evidence_index": 0, "requested_url": url, "final_url": url, "status": 200,
+            "content_type": "text/html", "fallback_attempted": False,
+            "content_sha256": content, "text_sha256": text, "error": None,
+        }]
+
+    audit = pc.parse_audit(_audit(
+        _claim(capture_provenance=provenance(_source()["url"], "a" * 64, "b" * 64)),
+        _claim(
+            anchor=second_anchor, proposition=second_anchor, evidence=[second_source],
+            capture_provenance=provenance(second_source["url"], "c" * 64, "d" * 64),
+        ),
+    ), plan)
+    ordinary = "=== EVIDENCE ATTESTATION JSON ===\n" + json.dumps({
+        "attestations": [{
+            "claim_index": 0, "evidence_index": 0,
+            "publisher_authority": True, "authority_reason": "official publisher",
+            "passage_entailment": True, "entailment_reason": "direct release record",
+        }],
+    })
+    failed = Review(
+        text="provider failed", session_ref=None, raw="raw provider channel", error=True,
+        returncode=1, failure_detail="expanded attester failed", stderr="stderr channel",
+    )
+    engine = _RoleScript({"evidence-text": [ordinary, failed]})
+    ledger: list[dict] = []
+    adapter = handlers._CapturedClaimEngine(
+        engine, plan_text=plan, repo=_repo(tmp_path), plan_repo_path=None,
+        attempt_ledger=ledger,
+    )
+    first_candidate = external_sources.CandidateSource(
+        **{key: _source()[key] for key in (
+            "url", "title", "publisher", "source_kind", "authority_basis", "relation",
+        )}
+    )
+    second_candidate = external_sources.CandidateSource(
+        **{key: second_source[key] for key in (
+            "url", "title", "publisher", "source_kind", "authority_basis", "relation",
+        )}
+    )
+    adapter.captures = {
+        (0, 0): external_sources.Capture(
+            first_candidate, first_candidate.url, 200, "text/html", "a" * 64,
+            "b" * 64, _source()["quote"],
+        ),
+        (1, 0): external_sources.Capture(
+            second_candidate, second_candidate.url, 200, "text/html", "c" * 64,
+            "d" * 64, "x" * 450_000 + "\n" + second_source["quote"],
+        ),
+    }
+    adapter.expanded_captures.add((1, 0))
+    try:
+        result = adapter._attest(audit, "m", "high")
+        assert isinstance(result, pc.Audit)
+        assert [claim["verdict"] for claim in result.claims] == [
+            "supported", "unverified",
+        ]
+        assert "expanded attester failed" in result.claims[1][
+            "capture_attestations"
+        ][0]["capture_error"]
+        assert result.claims[1]["capture_provenance"][0]["error"] == (
+            "expanded attester failed"
+        )
+        assert ledger[-1]["outcome"] == "failed"
+        assert ledger[-1]["raw_sha256"] and ledger[-1]["stderr_sha256"]
+    finally:
+        adapter.close()
+
+
 def test_explicit_unusable_binding_has_distinct_durable_provenance(
     tmp_path: Path,
 ) -> None:
@@ -2113,8 +2989,8 @@ def test_explicit_unusable_binding_preserves_capture_failure_provenance(
         item["authority_basis"], item["relation"],
     )
     captures = {(0, 0): external_sources.Capture(
-        candidate, None, None, None, None, None, None,
-        error="capture timed out\nwhile reading response",
+        candidate, "http://127.0.0.1/private", 200, "text/plain", None, None, None,
+        error="rejected final URL: non-public final address",
     )}
     binding = handlers.PLAN_BINDING_MARKER + "\n" + json.dumps({
         "bindings": [{
@@ -2131,7 +3007,7 @@ def test_explicit_unusable_binding_preserves_capture_failure_provenance(
         audit, reviews = adapter._bind_indexed(
             "session", discovery, captures, "m", "high", {},
         )
-        assert len(reviews) == 1
+        assert reviews == []
         state = pc.reconcile(
             {}, audit, lineage_id="capture-failed", round_no=1, plan_text=PLAN,
         )
@@ -2140,8 +3016,19 @@ def test_explicit_unusable_binding_preserves_capture_failure_provenance(
         assert record["evidence"][0]["relation"] == "context"
         assert record["evidence"][0]["location"] == "Server capture unavailable"
         assert record["evidence"][0]["quote"] == (
-            "Server capture unavailable: capture timed out while reading response"
+            "Server capture unavailable: rejected final URL: non-public final address"
         )
+        assert record["capture_provenance"] == [{
+            "evidence_index": 0,
+            "requested_url": item["url"],
+            "final_url": "http://127.0.0.1/private",
+            "status": 200,
+            "content_type": "text/plain",
+            "fallback_attempted": False,
+            "content_sha256": None,
+            "text_sha256": None,
+            "error": "rejected final URL: non-public final address",
+        }]
         assert pc.is_blocked(state)
     finally:
         adapter.close()


### PR DESCRIPTION
Raises the extracted-text circuit breaker and carries complete authoritative pages through exact binding and cold attestation without truncation. Adds source-local failures, closed capture provenance, final-URL policy, bounded batch/call/deadline admission, and acceptance runners. External Codex/Claude SEC probes and a public critique_plan lifecycle passed. Paranoia CODE convergence: NOT-BLOCKED. Tests: 173 focused and 1,188 full.