### PR TITLE
Name the bound plan contract in the computed trailer

### DIFF
--- a/src/paranoia_local/class_closure.py
+++ b/src/paranoia_local/class_closure.py
@@ -971,6 +971,16 @@ def render_trailer(lineage: Lineage, *, register_status: str,
         f"CLASS-REGISTER: {register_status}",
         f"CLASS-CLOSURE: {counts}",
     ]
+    # A branch review supplied with a plan contract says so in its own computed output.
+    # Consumers quote this trailer verbatim as their durable per-stage review evidence, so
+    # without this line a plan-bound review and an unbound one are indistinguishable to
+    # anything downstream — the caller would have to be believed about its own conduct.
+    # The digest comes from the immutable contract authority on the lineage, not from
+    # caller-supplied metadata, so it cannot be asserted into existence by a review that
+    # never loaded a contract.
+    contract = lineage.branch_contract
+    if contract and contract.get("present") and contract.get("digest"):
+        lines.insert(1, f"PLAN-DIGEST: {contract['digest']}")
     # A predicate can be wrong in the SAFE direction — too narrow, matching none of the
     # violations it was written for, and closing in the very round it was registered. The
     # mechanism cannot detect that, so it says so rather than presenting an ordinary close.

--- a/tests/test_class_closure.py
+++ b/tests/test_class_closure.py
@@ -577,6 +577,39 @@ class TestLineageState:
 
 
 class TestTrailer:
+    def test_a_plan_bound_branch_review_names_its_contract_digest(self) -> None:
+        """Consumers quote this trailer verbatim as their durable per-stage evidence. Without
+        the line, a plan-bound review and an unbound one are byte-identical downstream and the
+        caller has to be believed about its own conduct."""
+        lin = lineage_with(("the invariant", cc.MAJOR, "X"))
+        lin.branch_contract = {
+            "version": 1, "present": True, "digest": "a" * 64, "text": "contract",
+        }
+        out = cc.render_trailer(lin, register_status="parsed 1")
+        assert f"PLAN-DIGEST: {'a' * 64}" in out
+        lines = [ln for ln in out.splitlines() if ln.startswith("PLAN-DIGEST:")]
+        assert len(lines) == 1, "one contract, one line"
+
+    def test_a_contract_free_branch_review_claims_no_digest(self) -> None:
+        """Immutable absence must not render as a plan that was never supplied."""
+        lin = lineage_with(("the invariant", cc.MAJOR, "X"))
+        assert lin.branch_contract is None
+        assert "PLAN-DIGEST:" not in cc.render_trailer(lin, register_status="parsed 1")
+        lin.branch_contract = {"version": 1, "present": False, "digest": None, "text": None}
+        assert "PLAN-DIGEST:" not in cc.render_trailer(lin, register_status="parsed 1")
+
+    def test_the_digest_line_does_not_disturb_the_existing_markers(self) -> None:
+        """Downstream parses this by anchored line and requires these three markers."""
+        lin = lineage_with(("the invariant", cc.MAJOR, "X"))
+        lin.branch_contract = {
+            "version": 1, "present": True, "digest": "b" * 64, "text": "contract",
+        }
+        out = cc.render_trailer(lin, register_status="parsed 1")
+        for marker in ("LINEAGE:", "CLASS-REGISTER:", "CLASS-CLOSURE:", "CONVERGENCE:"):
+            assert any(ln.startswith(marker) for ln in out.splitlines()), marker
+        assert sum(ln.startswith("CONVERGENCE:") for ln in out.splitlines()) == 1
+        assert out.splitlines()[0].startswith("LINEAGE:"), "LINEAGE stays first"
+
     def test_blocked_names_the_ids_and_voids_a_reviewer_converged(self) -> None:
         lin = lineage_with(("the invariant", cc.MAJOR, "X"))
         cid = lin.active()[0].class_id


### PR DESCRIPTION
## The gap

A `critique_branch` review supplied with a plan contract and one supplied without produce
**byte-identical trailers**. Consumers quote that trailer verbatim as their durable
per-stage review evidence, so nothing downstream can tell whether the reviewer ever saw the
plan. The caller has to be believed about its own conduct.

That matters wherever the branch review is the *only* review reading the contract. In the
delivery this came from, one card has just had its plan seam recorded as not required after
118 rounds, and both its open review classes, both reviewer procedures and every finding
from its final round were transferred to its code seam as named-test obligations. Every one
of those is now checked by a call whose plan binding leaves no trace.

## The change

`class_closure.render_trailer` emits `PLAN-DIGEST: <digest>` when the lineage carries a
present branch contract.

The digest is read from `Lineage.branch_contract` — the immutable contract authority #65
already stores — rather than from caller-supplied metadata. A review that never loaded a
contract therefore cannot assert one into existence. Contract-free reviews render no line:
immutable absence must not read as a plan that was never supplied.

Additive only. `LINEAGE:` stays first, and the three existing anchored markers
(`LINEAGE:`, `CLASS-CLOSURE:`, `CONVERGENCE:`) are untouched, which is what downstream
parses by.

No new parameter, no call-site threading, no new caller obligation — the authority was
already on the lineage.

## Tests

Three added to `TestTrailer`:

* a plan-bound review names its contract digest, exactly once;
* a contract-free review claims no digest — both `None` and an explicit `present: False`
  record;
* the line does not disturb the existing markers, `LINEAGE` stays first, and there is still
  exactly one `CONVERGENCE:`.

`tests/test_class_closure.py` and `tests/test_class_closure_integration.py` pass in full.

## What this PR does NOT do, and needs from the maintainer

`tests/test_branch_plan_fidelity.py::test_real_branch_plan_fidelity_acceptance_is_source_and_route_bound`
**fails**: the acceptance record is source-hash-bound and lists
`src/paranoia_local/class_closure.py`, so touching that file invalidates it.

Regenerating it means running `scripts/build_branch_plan_fidelity_acceptance.py`, which
projects **two real `critique_branch` audits** — live provider calls and real spend. I have
not run it, and I have not run the primary capability end to end as `AGENTS.md` requires
before opening a PR. This has also not been through a plan review or a `critique_branch`
convergence.

So this is a proposal for the maintainer to accept, extend or reject on sight — not a
change that has been through this repository's own process.

## Why the trailer rather than a consumer-side field

Decided by two-vendor arbitration over a pinned snapshot, unanimous at round 1
(`SELECTED: opt-trailer-line`, `ADVISORY: none`, `CLEANING: attested`,
`RESEARCH: complete 9 packets`).

The two alternatives were: a consumer-side manifest field written by the executing card, and
resolving the consumer's recorded session refs against `~/.paranoia/logs`. Both deciders
rejected the first because the value would originate from the party being gated, and the
second because that state is clone-local and unpushed. The research phase independently
surfaced SLSA's provenance requirements, which say the same thing: provenance *"MUST be
generated by the control plane … and not by a tenant of the build platform"*, and provenance
asserted by the party that did the work is *"trivial to bypass or forge"*.

The trailer is the tool's own computed output and is already required to be quoted verbatim,
so the evidence travels in a field consumers carry today.

Related: #65 (plan binding), #67 (persistence gating).
