### PR TITLE
Refresh plan-digest branch fidelity acceptance

### DIFF
--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -1,27 +1,6 @@
 {
   "acceptance_kind": "branch-plan-fidelity-public-handler-v1",
-  "allowed_later_source_diffs": {
-    "scripts/build_branch_plan_fidelity_acceptance.py": {
-      "scope": "Adds exact later-diff validation for this retained record; does not alter branch plan-contract binding, snapshot construction, settlement, or fidelity verdict semantics.",
-      "sha256": "0fccaece63ec121011259d908b1171bff7f397c0d66714dc0d1ea464e09f9771"
-    },
-    "src/paranoia_local/handlers.py": {
-      "scope": "Adds staged correction control, failure diagnostics, and audited strict-round handling after this acceptance; does not alter branch plan-contract binding, immutable contract authority, packet binding, or fidelity verdict semantics.",
-      "sha256": "8f019466c292f4e114266cee0bc5555f1bbc7ad7c754b66df828fd6c191feee6"
-    },
-    "src/paranoia_local/prompts.py": {
-      "scope": "Changes staged evidence and correction protocol instructions after this acceptance; does not alter branch plan-contract binding or the required implementation-fidelity checklist.",
-      "sha256": "6edc39d0c534248f3daa4ceb83bffe630f4b32826c19f95d370cf82cdcebaf6a"
-    },
-    "src/paranoia_local/server.py": {
-      "scope": "Documents later correction-control and rebut arguments after this acceptance; does not alter branch plan-contract binding or fidelity settlement semantics.",
-      "sha256": "cb8af61a0e58e11703bd01b88b27857798cb5461b5173d407b9e01f566902eba"
-    },
-    "tests/test_branch_plan_fidelity.py": {
-      "scope": "Teaches the retained-record test to defer exact later-source exceptions to the shared validator; does not alter branch plan-contract binding or the recorded production-handler assertions.",
-      "sha256": "4639b95768e3cb5fee8a7796cdd636b1250f82d9114811277e1d466cd09006ad"
-    }
-  },
+  "allowed_later_source_diffs": {},
   "claims": {
     "does_not_prove": [
       "Every future provider response will classify implementation fidelity correctly.",
@@ -31,7 +10,8 @@
     "proves": [
       "A signed-in Codex census accepted plan anchors and blocked a nonconforming branch.",
       "A separate signed-in Codex census cleared a genuinely conforming branch through critique_branch.",
-      "Both routes used the production staged handler with immutable plan digests and retained attempt ledgers."
+      "Both routes used the production staged handler with immutable plan digests and retained attempt ledgers.",
+      "Both public result trailers rendered the exact immutable plan digest once."
     ]
   },
   "date": "2026-08-22",
@@ -62,109 +42,109 @@
       ],
       "attempt_ledger": [
         {
-          "duration_ms": 86005,
+          "duration_ms": 73294,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-68b8-7080-96fa-117a6f2dacea\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files | sort; git log --oneline --all -- reviewer.py; git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files | sort; git log --oneline --all -- reviewer.py; git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n13b5dc3 separate negative fidelity failures\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --all --oneline --decorate --graph; git show --stat --oneline 9819227; git show 9819227:reviewer.py; git show 9819227:tests/test_fidelity.py; git show 95a9c63:reviewer.py; git show 95a9c63:tests/test_fidelity.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --all --oneline --decorate --graph; git show --stat --oneline 9819227; git show 9819227:reviewer.py; git show 9819227:tests/test_fidelity.py; git show 95a9c63:reviewer.py; git show 95a9c63:tests/test_fidelity.py'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n* 13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n* 649f94c nonconforming\\n| * 95a9c63 (conforming) preserve public return contract\\n| * 9819227 conform\\n|/  \\n* 521b4a1 (main) initial\\n9819227 conform\\n reviewer.py            | 14 ++++++++++++--\\n tests/test_fidelity.py | 12 ++++++++++++\\n 2 files changed, 24 insertions(+), 2 deletions(-)\\nimport json\\nfrom pathlib import Path\\n\\n\\ndef critique_branch(contract: str) -> Path:\\n    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n    output = Path(\\\"fidelity.json\\\")\\n    output.write_text(\\n        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n        encoding=\\\"utf-8\\\",\\n    )\\n    return output\\nimport json\\n\\nfrom reviewer import critique_branch\\n\\n\\ndef test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\\n    monkeypatch.chdir(tmp_path)\\n    output = critique_branch(\\\"frozen\\\")\\n    assert output.name == \\\"fidelity.json\\\"\\n    assert json.loads(output.read_text(encoding=\\\"utf-8\\\")) == {\\n        \\\"branch_contract\\\": \\\"frozen\\\",\\n    }\\nimport json\\nfrom pathlib import Path\\n\\n\\ndef critique_branch(contract: str) -> None:\\n    \\\"\\\"\\\"Emit ",
-          "raw_sha256": "7e028804aca548d13f63728a63b773e5dde6dc33e9a2f57485a497c1de4b5714",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-657a-72a1-a2a7-4a4a99ca631f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking the repository context and history against all three obligations before issuing findings.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Repository premises are being verified.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted transformation behavior is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Public-entry-point consumers are being traced.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Failure behavior is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance coverage is being traced through the required entry point.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Operational artifacts are being checked within the stated acceptance scope.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Plan, implementation, and public behavior consistency are being compared.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Review scope is calibrated to the three tiny-branch obligations and recoverable blocking stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"behaviour\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-3u1xehgj/tree\\n7ec163a Add nonconforming fidelity fixture\\n4afe149 Base fidelity fixture\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def crit",
+          "raw_sha256": "c1a92063d592bc7280221ac4b65b7a31fb7eaea313fd0f0ed0d73eb3ded34cba",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract requires a specifically named artifact, an exact persisted shape, and acceptance through the public entry point.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation writes the wrong artifact name and an additional persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a local helper unrelated to the contracted behavior.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three implementation-contract obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The established public entry point and None return contract remain intact, while the implementation explicitly describes itself as a negative fixture.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository documentation acknowledges that the feature branch remains incomplete.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The public function signature is preserved and the repository itself does not substantiate a fidelity-complete premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-9\",\"rationale\":\"The persistence transformation selects result.json and serializes extra_state alongside branch_contract.\"},{\"anchor\":\"plan:2\",\"rationale\":\"The required transformation target is fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The permitted persisted addition is limited to branch_contract.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The output destination and serialized object shape both contradict the contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"Consumers are entitled to locate fidelity.json and observe only branch_contract through critique_branch.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"Calling the public entry point instead produces a differently named and differently shaped artifact.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"A contract-compliant consumer cannot find or validate the produced artifact.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission, entry-point coverage, and persisted shape but no recovery behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery obligation is in scope, and the stated stakes exclude corrupt-state recovery.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test invokes only helper_that_does_not_invoke_the_public_entry_point and asserts a constant truthy string, so it exercises neither critique_branch nor either persisted-output requirement.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The acceptance test cannot detect either production defect because it never reaches the public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README warns that the branch's completeness claim is not realized rather than advertising the artifact as complete.\"},{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains no deployment or operational-documentation requirement.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation does not falsely clear the incomplete branch, and no operational procedure is required.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persisted contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The public persisted shape permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-9\",\"rationale\":\"Runtime behavior silently substitutes result.json and adds extra_state.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Persisted ",
-          "response_sha256": "d7bdcf6043865dffb888fcddf45265ff398f46fcb56eae40086435fbc0114ca8",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract has three obligations, and the implementation violates each through the wrong output path, an additional persisted field, and acceptance coverage that bypasses the public entry point.\"},{\"anchor\":\"repository/reviewer.py:4-10\",\"rationale\":\"The sole public implementation writes result.json with both branch_contract and extra_state.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a standalone helper rather than critique_branch.\"}],\"finding_ids\":[\"BHV-001\",\"BHV-002\",\"BHV-003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen-contract obligations is faithfully completed.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:4-10\",\"rationale\":\"The repository's public behavior is directly visible in the small implementation: critique_branch persists one JSON object to a fixed relative path.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The repository's only supplied test surface contains no call to the production entry point.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The relevant production and test premises are explicit and require no unsupported runtime assumptions.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted transformation must limit additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The generated object also contains extra_state, changing the required persisted shape.\"}],\"finding_ids\":[\"BHV-002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The JSON transformation introduces state expressly excluded by the contract.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test consumes only a test-local helper and never reaches critique_branch or its artifact.\"}],\"finding_ids\":[\"BHV-003\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer is disconnected from the public production behavior.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:6-10\",\"rationale\":\"The implementation performs one sequential filesystem write and allows write or serialization failures to propagate; the contract states no recovery behavior and the calibrated stakes accept recoverable blocking.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"No additional recovery mechanism is required under the stated contract and stakes.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion requires O1 to be exercised through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test calls helper_that_does_not_invoke_the_public_entry_point, so it cannot detect either the wrong artifact name or production write failures.\"}],\"finding_ids\":[\"BHV-003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The required public-entry-point acceptance path is untested.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README mismatch is explicit negative-fixture context and documentation accuracy is excluded from this acceptance by the supplied stakes.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is intentionally outside the three-obligation acceptance scope.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public artifact contract names fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The implementation silently chooses result.json instead.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The implementation persists the contradictory extra_state field.\"}],\"finding_ids\":[\"BHV-001\",\"BHV-002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The public persisted behavior contradicts both the required a",
+          "response_sha256": "61a8ea5f8f1d8821037f0f6ed302772697ab6f369d6015cbacf915ae19677804",
           "returncode": 0,
           "role": "census-behaviour",
           "sequence": 1,
-          "session_ref": "01a02ad2-68b8-7080-96fa-117a6f2dacea",
-          "stderr_excerpt": "2026-08-22T18:53:47.100868Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:53:58.661527Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:02.093996Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:07.987728Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:16.575742Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:12.109413Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-22T18:55:12.114538Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02ad2-68b8-7080-96fa-117a6f2dacea.1787424827600622627.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
-          "stderr_sha256": "6f10c2aa4bf68aa233222923e46158d61e5498d317d07d9e3be6abffa0148cf4",
+          "session_ref": "01a02fe3-657a-72a1-a2a7-4a4a99ca631f",
+          "stderr_excerpt": "2026-08-23T18:30:26.325443Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:27.984438Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-6484-7663-b6e1-d9434ba52f98.1787509826716329233.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-23T18:30:29.630010Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:46.363017Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:52.003980Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:38.614268Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+          "stderr_sha256": "2558c4e9c8406fb74c9f831cf85e4e8a42bda939a0bcbae16ecfc409d24eb040",
           "usage": {
-            "cached_input_tokens": 68608,
-            "input_tokens": 90199,
-            "output_tokens": 3212,
-            "reasoning_output_tokens": 1327
+            "cached_input_tokens": 46336,
+            "input_tokens": 54715,
+            "output_tokens": 3121,
+            "reasoning_output_tokens": 1061
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 89524,
+          "duration_ms": 63892,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-68ac-78f1-aa22-7d3772cb350b\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --all --decorate -12 && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --all --decorate -12 && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-_n4x4bny/tree\\n13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n95a9c63 (conforming) preserve public return contract\\n649f94c nonconforming\\n9819227 conform\\n521b4a1 (main) initial\\ncommit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && git ls-tree -r --name-only HEAD && git log --all --oneline --stat --decorate\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && git ls-tree -r --name-only HEAD && git log --all --oneline --stat --decorate\\\"\",\"aggregated_output\":\"\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git ls-tree -r --name-only HEAD; git log --all --oneline --stat --decorate'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git ls-tree -r --name-only HEAD; git log --all --oneline --stat --decorate'\",\"aggregated_output\":\"README.md\\nreviewer.py\\ntests/test_fidelity.py\\n13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n reviewer.py            | 10 +++++++++-\\n tests/test_fidelity.py |  6 ++++++\\n 2 files changed, 15 insertions(+), 1 deletion(-)\\n95a9c63 (conforming) preserve public return contract\\n reviewer.py            | 3 +-",
-          "raw_sha256": "4aed7ddfc9e09cfebae5b7be5b9c25633d68bf158dbb71d453e7dad0f18b7113",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-64a5-7911-a6bc-01161a81e8b9\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . ; git log --oneline --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . ; git log --oneline --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-3u1xehgj/tree\\n7ec163a Add nonconforming fidelity fixture\\n4afe149 Base fidelity fixture\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'; find .. -name AGENTS.md -o -name CLAUDE.md; git log --follow --format=fuller --stat -- reviewer.py; git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'; find .. -name AGENTS.md -o -name CLAUDE.md; git log --follow --format=fuller --stat -- reviewer.py; git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor:     Codex Acceptance <acceptance@example.invalid>\\nAuthorDate: Sun Aug 23 19:22:41 2026 +0100\\nCommit:     Codex Acceptance <acceptance@example.invalid>\\nCommitDate: Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\n reviewer.py | 10 +++++++++-\\n 1 file changed, 9 insertions(+), 1 deletion(-)\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor:     Codex Acceptance <acceptance@example.invalid>\\nAuthorDate: Sun Aug 23 19:22:10 2026 +0100\\nCommit:     Codex Acceptance <acceptance@example.invalid>\\nCommitDate: Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\n reviewer.py | 2 ++\\n 1 file changed, 2 insertions(+)\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The contract contains three concrete obligations: the output filename, public-entry-point acceptance coverage, and the persisted-field restriction.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-9\\\",\\\"rationale\\\":\\\"The implementation writes a differently named artifact with an additional persisted field.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The only test bypasses the production entry point and artifact behavior.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\",\\\"F2\\\",\\\"F3\\\"],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"None of the three frozen contract obligations is fully satisfied.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-9\\\",\\\"rationale\\\":\\\"The implementation explicitly describes and implements a deliberately nonconforming negative fixture, so its beh",
+          "raw_sha256": "d856027935795fa8be27ed456385e0d3977bc6450664d55809544a728f384b5c",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains three obligations: the output filename, the required public-entry-point acceptance path, and the persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The only implementation writes a differently named artifact containing an additional field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a local helper rather than the required public entry point.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the contract's three independently stated obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The public entry point and its None-returning signature remain present, but its behavior is deliberately nonconforming.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository's own description says a placeholder remains, which does not match the implemented writer.\"}],\"finding_ids\":[\"F4\"],\"id\":\"repository-premises\",\"status\":\"finding\",\"summary\":\"The public API premise is preserved, but the README inaccurately characterizes the current implementation.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:8\",\"rationale\":\"The contract argument is preserved under branch_contract, but the serialized object also introduces extra_state.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The contract limits persisted additions to branch_contract.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The input value is serialized faithfully, but the persisted object shape violates the explicit field restriction.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"This snapshot defines only the artifact producer.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test does not read or otherwise consume either the required or actual artifact.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"not_applicable\",\"summary\":\"The repository contains no downstream artifact consumer; filename and shape fidelity are assessed directly against the frozen contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission and acceptance behavior but no recovery semantics.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The implementation is a single local write, and the stated stakes exclude corrupt-state recovery and data-loss consequences.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required at the calibrated stakes.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance criterion A1 explicitly requires exercising O1 through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The sole test invokes only helper_that_does_not_invoke_the_public_entry_point and makes no artifact assertion.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The named acceptance criterion is not exercised through its required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The README says a placeholder remains.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The entry point is no longer a placeholder; it performs a concrete, intentionally incorrect write.\"}],\"finding_ids\":[\"F4\"],\"id\":\"docs-operations\",\"status\":\"finding\",\"summary\":\"The repository documentation is stale or misleading about the implementation state.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public artifact contract names fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"Runtime behavior instead persists result.json with an additional field.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F4\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Runtime persistence and repository documentation contradict the frozen pu",
-          "response_sha256": "b736b8dc1dbc9bd23cf923393028efb5913f8a373ca0592a330e63bbd5f92737",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains three concrete obligations: the output filename, public-entry-point acceptance coverage, and the persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation writes a differently named artifact with an additional persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test bypasses the production entry point and artifact behavior.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen contract obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation explicitly describes and implements a deliberately nonconforming negative fixture, so its behavior is established directly rather than resting on an unverified runtime premise.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The complete test artifact plainly exercises only its local helper.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The tiny repository contains direct evidence of the implementation and test seams; no unsupported runtime premise is needed.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"The contract string is serialized under branch_contract, but the transformation also introduces extra_state.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted representation is restricted to branch_contract.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"Serialization preserves the supplied contract but produces a forbidden extra field.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must consume O1 through the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The sole test consumes only a local helper and never calls critique_branch.\"}],\"finding_ids\":[\"F3\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer bypasses the production API entirely.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract defines no recovery, retry, cleanup, or atomicity obligation.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"Write failures naturally propagate to the trusted sequential caller, consistent with the stated acceptance of recoverable blocking.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required for this fixture.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion requires exercising artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test merely checks that a constant nonempty string is truthy and cannot detect either artifact defect.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The test does not exercise the named public entry point or any persisted output.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The accepted implementation contract contains no documentation or operational-runbook obligation.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The README openly identifies the branch as an intentionally incomplete negative fixture, which is outside the stated three-obligation acceptance scope.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is expressly outside this acceptance contract.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persisted-artifact contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The public persisted shape permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"Runtime behavior silently substitutes result.json and adds extra_state.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Both the artifact name and persisted shape contradict the frozen contract",
+          "response_sha256": "7ab24c74bcc1626a52d6f7840ccb3ed3ba82ba67547af65f1d7bf6e84b015e5d",
           "returncode": 0,
           "role": "census-execution",
           "sequence": 2,
-          "session_ref": "01a02ad2-68ac-78f1-aa22-7d3772cb350b",
-          "stderr_excerpt": "2026-08-22T18:53:47.081775Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:01.075901Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:04.482336Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:15.642621Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "64dd43c987843955c8cb20b0c3c8f0c0b0901d8659b3f0d3ca22c1361f0f8422",
+          "session_ref": "01a02fe3-64a5-7911-a6bc-01161a81e8b9",
+          "stderr_excerpt": "2026-08-23T18:30:26.308043Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:29.461841Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:36.464964Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:43.317963Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:29.223695Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:31:29.229527Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-64a5-7911-a6bc-01161a81e8b9.1787509827674279073.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+          "stderr_sha256": "4db8cc35c9a8e2931a84655c511999f2fbac76bb04c247cfa81ae97832b6b480",
           "usage": {
-            "cached_input_tokens": 51456,
-            "input_tokens": 72044,
-            "output_tokens": 3945,
-            "reasoning_output_tokens": 2165
+            "cached_input_tokens": 17152,
+            "input_tokens": 53380,
+            "output_tokens": 2712,
+            "reasoning_output_tokens": 1174
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 67657,
+          "duration_ms": 68663,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-6913-7663-9e58-ecb59fb203eb\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-_n4x4bny/tree\\n\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follow -- reviewer.py'\",\"aggregated_output\":\"13b5dc3 separate negative fidelity failures\\n521b4a1 initial\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"commit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_3\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_3\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files'\",\"aggregated_output\":\"reviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_4\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' .\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"i",
-          "raw_sha256": "c503e41b75e154787c71add2e8f416caff006c9ed56132904763d3ce359f9487",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-6484-7663-b6e1-d9434ba52f98\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m tracing the three contract obligations against the production entry point, consumers, and history before assigning findings.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied production entry point is the starting point for repository-premise validation.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied serialization transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Public-entry-point consumers and acceptance coverage are being traced.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"Write failure and recovery behavior are being assessed proportionally to the stated fixture stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The supplied test seam is being compared with the named acceptance criterion.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/README.md:1-3\\\",\\\"rationale\\\":\\\"The intentional negative-fixture documentation context is noted.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted shape consistency is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The review is bounded to the three small fixture obligations and stated recoverability.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"integrity\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files; rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' .; git log --follow --format='%H %s' -- reviewer.py; git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files; rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' .; git log --follow --format='%H %s' -- reviewer.py; git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nreviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n7ec163a68fc158d349118694b41f4796ec336353 Add nonconforming fidelity fixture\\n4afe14967bd0ef81ab2a68d8c3abe6a3d372f209 Base fidelity fixture\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py",
+          "raw_sha256": "a85e02bdee91d75424a93724f2e1ea9ef43d480bc8a5a859e5ccb060af637976",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract requires a specific artifact name, acceptance through the public entry point, and an exact persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"The implementation writes the wrong filename and adds prohibited persisted state.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a helper rather than the required public entry point.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the contract's three substantive obligations is fully implemented and verified.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository itself acknowledges that the claimed contract completion is false.\"},{\"anchor\":\"repository/reviewer.py:5-8\",\"rationale\":\"The public entry point explicitly documents and produces a deliberately incorrect artifact.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"repository-premises\",\"status\":\"finding\",\"summary\":\"Repository evidence directly disproves the premise that the frozen contract is complete.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted transformation is restricted to the branch_contract field.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"Serialization transforms the input into an object containing both branch_contract and extra_state.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The serialization transformation introduces state expressly excluded by the contract.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The declared persisted artifact consumed downstream is fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The production entry point instead writes result.json, leaving the contracted artifact absent.\"}],\"finding_ids\":[\"F1\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"Consumers looking for the contracted fidelity.json artifact cannot find the implementation's output.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies output, acceptance seam, and persisted shape but no failure or recovery behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required by this narrowly scoped contract.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance criterion A1 requires exercising O1 through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test calls only a local helper and neither invokes critique_branch nor observes its persisted output.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The named acceptance criterion is not exercised through its required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The documentation accurately warns that the branch's completeness claim is not realized.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"The README communicates the incomplete state; the contract imposes no additional operational-documentation obligation.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The contract names fidelity.json as the public persisted artifact.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The contract limits persisted additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:6-8\",\"rationale\":\"Runtime behavior contradicts both contracts by naming result.json and persisting extra_state.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The persisted filename and schema silently contradict the frozen contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"Each defect maps directly to one of the four-line contract's explicit obligations and has a bounded local repair.\"}],\"finding_ids\":[],\"id\":\"proportionality\",\"status\":\"covered\",\"summary\":\"The findings and remedies are limited to the tiny branch's explicit fidelity obligations.\"}],\"findings\":[{\"evidence\":[{\"",
-          "response_sha256": "31c52dc77eb78732864be2bc863adf91cfee87c4079bc15a5e54369b33e2e97d",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains three obligations: output filename, public-entry-point acceptance coverage, and persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The implementation violates the filename and persisted-shape obligations.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a helper instead of the required public entry point.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen-contract obligations is fully implemented and verified.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The repository's sole production entry point and its complete persistence path are visible here.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The repository's only consumer-like test does not import or call the production entry point.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The tiny repository has no additional consumers, configuration, or production counterpart that alters the observed contract violations.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Serialization preserves the required branch_contract value, but directs it to the wrong artifact and adds a prohibited field.\"},{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the required artifact name and the complete allowed persisted shape.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The persistence transformation produces the wrong named artifact with an over-broad object shape.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise output generation through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test consumes only its local helper and never reaches critique_branch.\"}],\"finding_ids\":[\"F003\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer bypasses the public production seam.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Write and serialization errors propagate to the trusted sequential caller; under the stated recoverable-blocking stakes, no additional recovery mechanism is required.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Fail-fast behavior is proportionate for this single-operator negative fixture.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion explicitly requires the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test asserts only that a constant nonempty string is truthy and neither invokes critique_branch nor inspects a persisted artifact.\"}],\"finding_ids\":[\"F003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The required public-entry-point acceptance behavior is entirely untested.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README explicitly describes the branch as a deliberately incomplete fixture, matching the stated intentional negative-fixture context.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is explicitly outside this acceptance's three-obligation scope.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persistence contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted object contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The implementation silently writes result.json and includes extra_state alongside branch_contract.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The persisted filename and object shape contradict the frozen public contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The findings are limited to the three explicit obligations in this tiny branch.\"},{\"anchor\":\"rep",
+          "response_sha256": "78953df859d9de386a80516439404123a13a59cf78109bd87c0a2258ce7a7d5a",
           "returncode": 0,
           "role": "census-integrity",
           "sequence": 3,
-          "session_ref": "01a02ad2-6913-7663-9e58-ecb59fb203eb",
-          "stderr_excerpt": "2026-08-22T18:53:47.092946Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:53:48.691335Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02ad2-68b8-7080-96fa-117a6f2dacea.1787424827600622627.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-22T18:54:00.852413Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:09.346099Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:53.685038Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "435a56aec8fcc99a558e1a99c375e0a7f2678c79deb123dc63959dfb502158bf",
+          "session_ref": "01a02fe3-6484-7663-b6e1-d9434ba52f98",
+          "stderr_excerpt": "2026-08-23T18:30:26.332136Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:30.643595Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:47.115847Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:53.237130Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:33.871337Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:31:33.876855Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-6484-7663-b6e1-d9434ba52f98.1787509826716329233.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+          "stderr_sha256": "593f896bbe58ed04813440fb8729f8cae3512ea27a4b8911b149a4c8ac1ea9c7",
           "usage": {
-            "cached_input_tokens": 34304,
-            "input_tokens": 53557,
-            "output_tokens": 2794,
-            "reasoning_output_tokens": 1159
+            "cached_input_tokens": 33280,
+            "input_tokens": 53865,
+            "output_tokens": 2966,
+            "reasoning_output_tokens": 876
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 29316,
+          "duration_ms": 27535,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad3-c5c9-7651-9c16-3f0b59296a8f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[{\\\"classification\\\":{\\\"kind\\\":\\\"one_off\\\",\\\"reason\\\":\\\"This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class.\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"These lines prescribe fidelity.json as the required output artifact.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:6-7\\\",\\\"rationale\\\":\\\"These lines show the public entry point selecting result.json instead of the required filename.\\\"}],\\\"id\\\":\\\"census:F001\\\",\\\"remedy\\\":\\\"Change the public entry point to write Path(\\\\\\\"fidelity.json\\\\\\\") and assert that exact filename through the public entry point.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F001\\\",\\\"execution:F1\\\",\\\"integrity:F1\\\"],\\\"summary\\\":\\\"The public entry point writes result.json instead of the required fidelity.json artifact.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"Persisted JSON objects containing fields prohibited by the governing contract.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"These lines restrict the persisted object to branch_contract only.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7-8\\\",\\\"rationale\\\":\\\"These lines show extra_state being included in the serialized object.\\\"}],\\\"id\\\":\\\"census:F002\\\",\\\"remedy\\\":\\\"Remove extra_state and serialize exactly {\\\\\\\"branch_contract\\\\\\\": contract}; add an exact decoded-object assertion that rejects additional keys.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F002\\\",\\\"execution:F2\\\",\\\"integrity:F2\\\"],\\\"summary\\\":\\\"The persisted JSON object contains the contract-forbidden extra_state field.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.\\\",\\\"procedure\\\":\\\"For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"These lines require acceptance through the public entry point.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"These lines show a helper-only test that never invokes critique_branch or checks its produced artifact.\\\"}],\\\"id\\\":\\\"census:F003\\\",\\\"remedy\\\":\\\"Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F003\\\",\\\"execution:F3\\\",\\\"integrity:F3\\\"],\\\"summary\\\":\\\"The acceptance test bypasses the contracted public production entry point.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.\\\",\\\"pathspec\\\":\\\"repository/README.md\\\",\\\"pattern\\\":\\\"Implementation-status claims contradicted by the current implementation.\\\",\\\"severity\\\":\\\"MINOR\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/README.md:3\\\",\\\"rationale\\\":\\\"This line characterizes the implementation as a placeholder.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"These lines contain a substantive implementation, contradicting the placeholder characterization.\\\"}],\\\"id\\\":\\\"census:F004\\\",\\\"remedy\\\":\\\"Update the README to describe the actual",
-          "raw_sha256": "27f047cded722bbea7ef4b1f1a016821da114080ebf0cb1505a831e851873854",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe4-82a6-7151-b034-6b767de2c23f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"The plan requires the serialized contract artifact to be written to fidelity.json.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:6\\\",\\\"rationale\\\":\\\"The public entry point instead targets result.json, so the required artifact is not emitted.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"These lines show the persistence operation completing against the incorrectly named artifact.\\\"}],\\\"id\\\":\\\"census:GF-001\\\",\\\"remedy\\\":\\\"Change the public entry point to write the serialized contract artifact to fidelity.json.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-001\\\",\\\"execution:F1\\\",\\\"integrity:F001\\\"],\\\"summary\\\":\\\"The public entry point emits result.json instead of the contract-required fidelity.json.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A persisted object governed by an exact-field contract must contain all and only the permitted fields.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The plan requires the persisted object to contain exactly branch_contract and forbids extra fields.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7\\\",\\\"rationale\\\":\\\"The constructed output object adds extra_state alongside branch_contract.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:8\\\",\\\"rationale\\\":\\\"This line identifies the forbidden extra_state field in the object that is persisted.\\\"}],\\\"id\\\":\\\"census:GF-002\\\",\\\"remedy\\\":\\\"Remove extra_state and persist an object whose sole field is branch_contract.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-002\\\",\\\"execution:F2\\\",\\\"integrity:F002\\\"],\\\"summary\\\":\\\"The persisted object violates the exact field boundary by including extra_state.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.\\\",\\\"pathspec\\\":\\\"repository/tests/**/*.py\\\",\\\"pattern\\\":\\\"For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"The plan requires an acceptance test that invokes critique_branch through the public import seam.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The supplied test calls only the serialization helper and never invokes the public entry point or inspects a persisted artifact.\\\"}],\\\"id\\\":\\\"census:GF-003\\\",\\\"remedy\\\":\\\"Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-003\\\",\\\"execution:F3\\\",\\\"integrity:F003",
+          "raw_sha256": "1795f40cf5f5061300255b36e0aa25bd85b4efc33ba4bfe77cda4aa6c57c76a6",
           "requested_timeout_sec": 1200,
-          "response_excerpt": "{\"class_actions\":{},\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"kind\":\"one_off\",\"reason\":\"This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class.\"},\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"These lines prescribe fidelity.json as the required output artifact.\"},{\"anchor\":\"repository/reviewer.py:6-7\",\"rationale\":\"These lines show the public entry point selecting result.json instead of the required filename.\"}],\"id\":\"census:F001\",\"remedy\":\"Change the public entry point to write Path(\\\"fidelity.json\\\") and assert that exact filename through the public entry point.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F001\",\"execution:F1\",\"integrity:F1\"],\"summary\":\"The public entry point writes result.json instead of the required fidelity.json artifact.\"},{\"classification\":{\"definition\":{\"invariant\":\"A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"Persisted JSON objects containing fields prohibited by the governing contract.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"These lines restrict the persisted object to branch_contract only.\"},{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"These lines show extra_state being included in the serialized object.\"}],\"id\":\"census:F002\",\"remedy\":\"Remove extra_state and serialize exactly {\\\"branch_contract\\\": contract}; add an exact decoded-object assertion that rejects additional keys.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F002\",\"execution:F2\",\"integrity:F2\"],\"summary\":\"The persisted JSON object contains the contract-forbidden extra_state field.\"},{\"classification\":{\"definition\":{\"invariant\":\"An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.\",\"procedure\":\"For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"These lines require acceptance through the public entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"These lines show a helper-only test that never invokes critique_branch or checks its produced artifact.\"}],\"id\":\"census:F003\",\"remedy\":\"Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F003\",\"execution:F3\",\"integrity:F3\"],\"summary\":\"The acceptance test bypasses the contracted public production entry point.\"},{\"classification\":{\"definition\":{\"invariant\":\"Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.\",\"pathspec\":\"repository/README.md\",\"pattern\":\"Implementation-status claims contradicted by the current implementation.\",\"severity\":\"MINOR\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"This line characterizes the implementation as a placeholder.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"These lines contain a substantive implementation, contradicting the placeholder characterization.\"}],\"id\":\"census:F004\",\"remedy\":\"Update the README to describe the actual nonconformance, or describe completion after the implementation is corrected.\",\"severity\":\"MINOR\",\"source_ids\":[\"execution:F4\"],\"summary\":\"The README inaccurately characterizes the current implementation as a placeholder.\"}],\"role\":\"census\"}",
-          "response_sha256": "5b0e5cedf5ac4696da7c1e8905f4e5954971e6704248b160dd579186fc6c1726",
+          "response_excerpt": "{\"class_actions\":{},\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"definition\":{\"invariant\":\"A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The plan requires the serialized contract artifact to be written to fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The public entry point instead targets result.json, so the required artifact is not emitted.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"These lines show the persistence operation completing against the incorrectly named artifact.\"}],\"id\":\"census:GF-001\",\"remedy\":\"Change the public entry point to write the serialized contract artifact to fidelity.json.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-001\",\"execution:F1\",\"integrity:F001\"],\"summary\":\"The public entry point emits result.json instead of the contract-required fidelity.json.\"},{\"classification\":{\"definition\":{\"invariant\":\"A persisted object governed by an exact-field contract must contain all and only the permitted fields.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan requires the persisted object to contain exactly branch_contract and forbids extra fields.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The constructed output object adds extra_state alongside branch_contract.\"},{\"anchor\":\"repository/reviewer.py:8\",\"rationale\":\"This line identifies the forbidden extra_state field in the object that is persisted.\"}],\"id\":\"census:GF-002\",\"remedy\":\"Remove extra_state and persist an object whose sole field is branch_contract.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-002\",\"execution:F2\",\"integrity:F002\"],\"summary\":\"The persisted object violates the exact field boundary by including extra_state.\"},{\"classification\":{\"definition\":{\"invariant\":\"Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.\",\"pathspec\":\"repository/tests/**/*.py\",\"pattern\":\"For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The plan requires an acceptance test that invokes critique_branch through the public import seam.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The supplied test calls only the serialization helper and never invokes the public entry point or inspects a persisted artifact.\"}],\"id\":\"census:GF-003\",\"remedy\":\"Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-003\",\"execution:F3\",\"integrity:F003\"],\"summary\":\"Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation.\"}],\"role\":\"census\"}",
+          "response_sha256": "09885537e4ee09b8797c028c6c6f8d2a37732aa244265ebb50d978b41826b160",
           "returncode": 0,
           "role": "consolidation",
           "sequence": 4,
-          "session_ref": "01a02ad3-c5c9-7651-9c16-3f0b59296a8f",
-          "stderr_excerpt": "2026-08-22T18:55:16.543716Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:45.214389Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "4d2251859f767b082d4ac76ec4a29da6ffd8cbd24d25562c28beb2ab8fe4d526",
+          "session_ref": "01a02fe4-82a6-7151-b034-6b767de2c23f",
+          "stderr_excerpt": "2026-08-23T18:31:39.480351Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:32:06.356479Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+          "stderr_sha256": "a7ccfa9cf4c3035da699afcd8d5c77f89973343a7eb9cbb9d121809ba60ac73c",
           "usage": {
-            "cached_input_tokens": 0,
-            "input_tokens": 17245,
-            "output_tokens": 1123,
-            "reasoning_output_tokens": 348
+            "cached_input_tokens": 11008,
+            "input_tokens": 17205,
+            "output_tokens": 950,
+            "reasoning_output_tokens": 185
           },
           "validation_issue": null,
           "validation_pointer": null
@@ -174,128 +154,129 @@
         "already_raised": [],
         "attempt_ledger": [
           {
-            "duration_ms": 86005,
+            "duration_ms": 73294,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-68b8-7080-96fa-117a6f2dacea\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files | sort; git log --oneline --all -- reviewer.py; git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files | sort; git log --oneline --all -- reviewer.py; git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n13b5dc3 separate negative fidelity failures\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --all --oneline --decorate --graph; git show --stat --oneline 9819227; git show 9819227:reviewer.py; git show 9819227:tests/test_fidelity.py; git show 95a9c63:reviewer.py; git show 95a9c63:tests/test_fidelity.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --all --oneline --decorate --graph; git show --stat --oneline 9819227; git show 9819227:reviewer.py; git show 9819227:tests/test_fidelity.py; git show 95a9c63:reviewer.py; git show 95a9c63:tests/test_fidelity.py'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n* 13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n* 649f94c nonconforming\\n| * 95a9c63 (conforming) preserve public return contract\\n| * 9819227 conform\\n|/  \\n* 521b4a1 (main) initial\\n9819227 conform\\n reviewer.py            | 14 ++++++++++++--\\n tests/test_fidelity.py | 12 ++++++++++++\\n 2 files changed, 24 insertions(+), 2 deletions(-)\\nimport json\\nfrom pathlib import Path\\n\\n\\ndef critique_branch(contract: str) -> Path:\\n    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n    output = Path(\\\"fidelity.json\\\")\\n    output.write_text(\\n        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n        encoding=\\\"utf-8\\\",\\n    )\\n    return output\\nimport json\\n\\nfrom reviewer import critique_branch\\n\\n\\ndef test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\\n    monkeypatch.chdir(tmp_path)\\n    output = critique_branch(\\\"frozen\\\")\\n    assert output.name == \\\"fidelity.json\\\"\\n    assert json.loads(output.read_text(encoding=\\\"utf-8\\\")) == {\\n        \\\"branch_contract\\\": \\\"frozen\\\",\\n    }\\nimport json\\nfrom pathlib import Path\\n\\n\\ndef critique_branch(contract: str) -> None:\\n    \\\"\\\"\\\"Emit ",
-            "raw_sha256": "7e028804aca548d13f63728a63b773e5dde6dc33e9a2f57485a497c1de4b5714",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-657a-72a1-a2a7-4a4a99ca631f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking the repository context and history against all three obligations before issuing findings.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Repository premises are being verified.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted transformation behavior is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Public-entry-point consumers are being traced.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Failure behavior is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance coverage is being traced through the required entry point.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Operational artifacts are being checked within the stated acceptance scope.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Plan, implementation, and public behavior consistency are being compared.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Review scope is calibrated to the three tiny-branch obligations and recoverable blocking stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"behaviour\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-3u1xehgj/tree\\n7ec163a Add nonconforming fidelity fixture\\n4afe149 Base fidelity fixture\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def crit",
+            "raw_sha256": "c1a92063d592bc7280221ac4b65b7a31fb7eaea313fd0f0ed0d73eb3ded34cba",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract requires a specifically named artifact, an exact persisted shape, and acceptance through the public entry point.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation writes the wrong artifact name and an additional persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a local helper unrelated to the contracted behavior.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three implementation-contract obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The established public entry point and None return contract remain intact, while the implementation explicitly describes itself as a negative fixture.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository documentation acknowledges that the feature branch remains incomplete.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The public function signature is preserved and the repository itself does not substantiate a fidelity-complete premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-9\",\"rationale\":\"The persistence transformation selects result.json and serializes extra_state alongside branch_contract.\"},{\"anchor\":\"plan:2\",\"rationale\":\"The required transformation target is fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The permitted persisted addition is limited to branch_contract.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The output destination and serialized object shape both contradict the contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"Consumers are entitled to locate fidelity.json and observe only branch_contract through critique_branch.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"Calling the public entry point instead produces a differently named and differently shaped artifact.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"A contract-compliant consumer cannot find or validate the produced artifact.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission, entry-point coverage, and persisted shape but no recovery behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery obligation is in scope, and the stated stakes exclude corrupt-state recovery.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test invokes only helper_that_does_not_invoke_the_public_entry_point and asserts a constant truthy string, so it exercises neither critique_branch nor either persisted-output requirement.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The acceptance test cannot detect either production defect because it never reaches the public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README warns that the branch's completeness claim is not realized rather than advertising the artifact as complete.\"},{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains no deployment or operational-documentation requirement.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation does not falsely clear the incomplete branch, and no operational procedure is required.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persisted contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The public persisted shape permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-9\",\"rationale\":\"Runtime behavior silently substitutes result.json and adds extra_state.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Persisted ",
-            "response_sha256": "d7bdcf6043865dffb888fcddf45265ff398f46fcb56eae40086435fbc0114ca8",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract has three obligations, and the implementation violates each through the wrong output path, an additional persisted field, and acceptance coverage that bypasses the public entry point.\"},{\"anchor\":\"repository/reviewer.py:4-10\",\"rationale\":\"The sole public implementation writes result.json with both branch_contract and extra_state.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a standalone helper rather than critique_branch.\"}],\"finding_ids\":[\"BHV-001\",\"BHV-002\",\"BHV-003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen-contract obligations is faithfully completed.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:4-10\",\"rationale\":\"The repository's public behavior is directly visible in the small implementation: critique_branch persists one JSON object to a fixed relative path.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The repository's only supplied test surface contains no call to the production entry point.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The relevant production and test premises are explicit and require no unsupported runtime assumptions.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted transformation must limit additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The generated object also contains extra_state, changing the required persisted shape.\"}],\"finding_ids\":[\"BHV-002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The JSON transformation introduces state expressly excluded by the contract.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test consumes only a test-local helper and never reaches critique_branch or its artifact.\"}],\"finding_ids\":[\"BHV-003\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer is disconnected from the public production behavior.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:6-10\",\"rationale\":\"The implementation performs one sequential filesystem write and allows write or serialization failures to propagate; the contract states no recovery behavior and the calibrated stakes accept recoverable blocking.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"No additional recovery mechanism is required under the stated contract and stakes.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion requires O1 to be exercised through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test calls helper_that_does_not_invoke_the_public_entry_point, so it cannot detect either the wrong artifact name or production write failures.\"}],\"finding_ids\":[\"BHV-003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The required public-entry-point acceptance path is untested.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README mismatch is explicit negative-fixture context and documentation accuracy is excluded from this acceptance by the supplied stakes.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is intentionally outside the three-obligation acceptance scope.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public artifact contract names fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The implementation silently chooses result.json instead.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The implementation persists the contradictory extra_state field.\"}],\"finding_ids\":[\"BHV-001\",\"BHV-002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The public persisted behavior contradicts both the required a",
+            "response_sha256": "61a8ea5f8f1d8821037f0f6ed302772697ab6f369d6015cbacf915ae19677804",
             "returncode": 0,
             "role": "census-behaviour",
             "sequence": 1,
-            "session_ref": "01a02ad2-68b8-7080-96fa-117a6f2dacea",
-            "stderr_excerpt": "2026-08-22T18:53:47.100868Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:53:58.661527Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:02.093996Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:07.987728Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:16.575742Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:12.109413Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-22T18:55:12.114538Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02ad2-68b8-7080-96fa-117a6f2dacea.1787424827600622627.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
-            "stderr_sha256": "6f10c2aa4bf68aa233222923e46158d61e5498d317d07d9e3be6abffa0148cf4",
+            "session_ref": "01a02fe3-657a-72a1-a2a7-4a4a99ca631f",
+            "stderr_excerpt": "2026-08-23T18:30:26.325443Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:27.984438Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-6484-7663-b6e1-d9434ba52f98.1787509826716329233.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-23T18:30:29.630010Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:46.363017Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:52.003980Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:38.614268Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+            "stderr_sha256": "2558c4e9c8406fb74c9f831cf85e4e8a42bda939a0bcbae16ecfc409d24eb040",
             "usage": {
-              "cached_input_tokens": 68608,
-              "input_tokens": 90199,
-              "output_tokens": 3212,
-              "reasoning_output_tokens": 1327
+              "cached_input_tokens": 46336,
+              "input_tokens": 54715,
+              "output_tokens": 3121,
+              "reasoning_output_tokens": 1061
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 89524,
+            "duration_ms": 63892,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-68ac-78f1-aa22-7d3772cb350b\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --all --decorate -12 && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --all --decorate -12 && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-_n4x4bny/tree\\n13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n95a9c63 (conforming) preserve public return contract\\n649f94c nonconforming\\n9819227 conform\\n521b4a1 (main) initial\\ncommit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && git ls-tree -r --name-only HEAD && git log --all --oneline --stat --decorate\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && git ls-tree -r --name-only HEAD && git log --all --oneline --stat --decorate\\\"\",\"aggregated_output\":\"\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git ls-tree -r --name-only HEAD; git log --all --oneline --stat --decorate'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git ls-tree -r --name-only HEAD; git log --all --oneline --stat --decorate'\",\"aggregated_output\":\"README.md\\nreviewer.py\\ntests/test_fidelity.py\\n13b5dc3 (HEAD, nonconforming) separate negative fidelity failures\\n reviewer.py            | 10 +++++++++-\\n tests/test_fidelity.py |  6 ++++++\\n 2 files changed, 15 insertions(+), 1 deletion(-)\\n95a9c63 (conforming) preserve public return contract\\n reviewer.py            | 3 +-",
-            "raw_sha256": "4aed7ddfc9e09cfebae5b7be5b9c25633d68bf158dbb71d453e7dad0f18b7113",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-64a5-7911-a6bc-01161a81e8b9\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . ; git log --oneline --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . ; git log --oneline --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-3u1xehgj/tree\\n7ec163a Add nonconforming fidelity fixture\\n4afe149 Base fidelity fixture\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'; find .. -name AGENTS.md -o -name CLAUDE.md; git log --follow --format=fuller --stat -- reviewer.py; git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'; find .. -name AGENTS.md -o -name CLAUDE.md; git log --follow --format=fuller --stat -- reviewer.py; git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor:     Codex Acceptance <acceptance@example.invalid>\\nAuthorDate: Sun Aug 23 19:22:41 2026 +0100\\nCommit:     Codex Acceptance <acceptance@example.invalid>\\nCommitDate: Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\n reviewer.py | 10 +++++++++-\\n 1 file changed, 9 insertions(+), 1 deletion(-)\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor:     Codex Acceptance <acceptance@example.invalid>\\nAuthorDate: Sun Aug 23 19:22:10 2026 +0100\\nCommit:     Codex Acceptance <acceptance@example.invalid>\\nCommitDate: Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\n reviewer.py | 2 ++\\n 1 file changed, 2 insertions(+)\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The contract contains three concrete obligations: the output filename, public-entry-point acceptance coverage, and the persisted-field restriction.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-9\\\",\\\"rationale\\\":\\\"The implementation writes a differently named artifact with an additional persisted field.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The only test bypasses the production entry point and artifact behavior.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\",\\\"F2\\\",\\\"F3\\\"],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"None of the three frozen contract obligations is fully satisfied.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-9\\\",\\\"rationale\\\":\\\"The implementation explicitly describes and implements a deliberately nonconforming negative fixture, so its beh",
+            "raw_sha256": "d856027935795fa8be27ed456385e0d3977bc6450664d55809544a728f384b5c",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains three obligations: the output filename, the required public-entry-point acceptance path, and the persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The only implementation writes a differently named artifact containing an additional field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a local helper rather than the required public entry point.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the contract's three independently stated obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The public entry point and its None-returning signature remain present, but its behavior is deliberately nonconforming.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository's own description says a placeholder remains, which does not match the implemented writer.\"}],\"finding_ids\":[\"F4\"],\"id\":\"repository-premises\",\"status\":\"finding\",\"summary\":\"The public API premise is preserved, but the README inaccurately characterizes the current implementation.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:8\",\"rationale\":\"The contract argument is preserved under branch_contract, but the serialized object also introduces extra_state.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The contract limits persisted additions to branch_contract.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The input value is serialized faithfully, but the persisted object shape violates the explicit field restriction.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"This snapshot defines only the artifact producer.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test does not read or otherwise consume either the required or actual artifact.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"not_applicable\",\"summary\":\"The repository contains no downstream artifact consumer; filename and shape fidelity are assessed directly against the frozen contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission and acceptance behavior but no recovery semantics.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The implementation is a single local write, and the stated stakes exclude corrupt-state recovery and data-loss consequences.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required at the calibrated stakes.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance criterion A1 explicitly requires exercising O1 through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The sole test invokes only helper_that_does_not_invoke_the_public_entry_point and makes no artifact assertion.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The named acceptance criterion is not exercised through its required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The README says a placeholder remains.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The entry point is no longer a placeholder; it performs a concrete, intentionally incorrect write.\"}],\"finding_ids\":[\"F4\"],\"id\":\"docs-operations\",\"status\":\"finding\",\"summary\":\"The repository documentation is stale or misleading about the implementation state.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public artifact contract names fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"Runtime behavior instead persists result.json with an additional field.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F4\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Runtime persistence and repository documentation contradict the frozen pu",
-            "response_sha256": "b736b8dc1dbc9bd23cf923393028efb5913f8a373ca0592a330e63bbd5f92737",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains three concrete obligations: the output filename, public-entry-point acceptance coverage, and the persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation writes a differently named artifact with an additional persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test bypasses the production entry point and artifact behavior.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen contract obligations is fully satisfied.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-9\",\"rationale\":\"The implementation explicitly describes and implements a deliberately nonconforming negative fixture, so its behavior is established directly rather than resting on an unverified runtime premise.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The complete test artifact plainly exercises only its local helper.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The tiny repository contains direct evidence of the implementation and test seams; no unsupported runtime premise is needed.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"The contract string is serialized under branch_contract, but the transformation also introduces extra_state.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted representation is restricted to branch_contract.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"Serialization preserves the supplied contract but produces a forbidden extra field.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must consume O1 through the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The sole test consumes only a local helper and never calls critique_branch.\"}],\"finding_ids\":[\"F3\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer bypasses the production API entirely.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract defines no recovery, retry, cleanup, or atomicity obligation.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"Write failures naturally propagate to the trusted sequential caller, consistent with the stated acceptance of recoverable blocking.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required for this fixture.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion requires exercising artifact emission through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test merely checks that a constant nonempty string is truthy and cannot detect either artifact defect.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The test does not exercise the named public entry point or any persisted output.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The accepted implementation contract contains no documentation or operational-runbook obligation.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The README openly identifies the branch as an intentionally incomplete negative fixture, which is outside the stated three-obligation acceptance scope.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is expressly outside this acceptance contract.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persisted-artifact contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The public persisted shape permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"Runtime behavior silently substitutes result.json and adds extra_state.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"Both the artifact name and persisted shape contradict the frozen contract",
+            "response_sha256": "7ab24c74bcc1626a52d6f7840ccb3ed3ba82ba67547af65f1d7bf6e84b015e5d",
             "returncode": 0,
             "role": "census-execution",
             "sequence": 2,
-            "session_ref": "01a02ad2-68ac-78f1-aa22-7d3772cb350b",
-            "stderr_excerpt": "2026-08-22T18:53:47.081775Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:01.075901Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:04.482336Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:15.642621Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "64dd43c987843955c8cb20b0c3c8f0c0b0901d8659b3f0d3ca22c1361f0f8422",
+            "session_ref": "01a02fe3-64a5-7911-a6bc-01161a81e8b9",
+            "stderr_excerpt": "2026-08-23T18:30:26.308043Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:29.461841Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:36.464964Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:43.317963Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:29.223695Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:31:29.229527Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-64a5-7911-a6bc-01161a81e8b9.1787509827674279073.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+            "stderr_sha256": "4db8cc35c9a8e2931a84655c511999f2fbac76bb04c247cfa81ae97832b6b480",
             "usage": {
-              "cached_input_tokens": 51456,
-              "input_tokens": 72044,
-              "output_tokens": 3945,
-              "reasoning_output_tokens": 2165
+              "cached_input_tokens": 17152,
+              "input_tokens": 53380,
+              "output_tokens": 2712,
+              "reasoning_output_tokens": 1174
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 67657,
+            "duration_ms": 68663,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad2-6913-7663-9e58-ecb59fb203eb\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-_n4x4bny/tree\\n\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follow -- reviewer.py'\",\"aggregated_output\":\"13b5dc3 separate negative fidelity failures\\n521b4a1 initial\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log -p --follow -- reviewer.py'\",\"aggregated_output\":\"commit 13b5dc35d0db36dbbc529da5a579ce08323f31a6\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:53:23 2026 +0100\\n\\n    separate negative fidelity failures\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,10 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Persist the deliberately wrong artifact shape for the negative fixture.\\\"\\\"\\\"\\n+    Path(\\\"result.json\\\").write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract, \\\"extra_state\\\": True}) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_3\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_3\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files'\",\"aggregated_output\":\"reviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_4\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|result\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' -g '\\\"'!README.md'\\\"' .\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"i",
-            "raw_sha256": "c503e41b75e154787c71add2e8f416caff006c9ed56132904763d3ce359f9487",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe3-6484-7663-b6e1-d9434ba52f98\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m tracing the three contract obligations against the production entry point, consumers, and history before assigning findings.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied production entry point is the starting point for repository-premise validation.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied serialization transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Public-entry-point consumers and acceptance coverage are being traced.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"Write failure and recovery behavior are being assessed proportionally to the stated fixture stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The supplied test seam is being compared with the named acceptance criterion.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/README.md:1-3\\\",\\\"rationale\\\":\\\"The intentional negative-fixture documentation context is noted.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted shape consistency is being checked.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The review is bounded to the three small fixture obligations and stated recoverability.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"integrity\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files; rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' .; git log --follow --format='%H %s' -- reviewer.py; git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files; rg -n \\\\\\\"critique_branch|result\\\\\\\\.json|fidelity\\\\\\\\.json|branch_contract|extra_state\\\\\\\" -g '\\\"'!README.md'\\\"' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' .; git log --follow --format='%H %s' -- reviewer.py; git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nreviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n7ec163a68fc158d349118694b41f4796ec336353 Add nonconforming fidelity fixture\\n4afe14967bd0ef81ab2a68d8c3abe6a3d372f209 Base fidelity fixture\\ncommit 7ec163a68fc158d349118694b41f4796ec336353\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:41 2026 +0100\\n\\n    Add nonconforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..f5be692 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py",
+            "raw_sha256": "a85e02bdee91d75424a93724f2e1ea9ef43d480bc8a5a859e5ccb060af637976",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract requires a specific artifact name, acceptance through the public entry point, and an exact persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:6-9\",\"rationale\":\"The implementation writes the wrong filename and adds prohibited persisted state.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a helper rather than the required public entry point.\"}],\"finding_ids\":[\"F1\",\"F2\",\"F3\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the contract's three substantive obligations is fully implemented and verified.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository itself acknowledges that the claimed contract completion is false.\"},{\"anchor\":\"repository/reviewer.py:5-8\",\"rationale\":\"The public entry point explicitly documents and produces a deliberately incorrect artifact.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"repository-premises\",\"status\":\"finding\",\"summary\":\"Repository evidence directly disproves the premise that the frozen contract is complete.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted transformation is restricted to the branch_contract field.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"Serialization transforms the input into an object containing both branch_contract and extra_state.\"}],\"finding_ids\":[\"F2\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The serialization transformation introduces state expressly excluded by the contract.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The declared persisted artifact consumed downstream is fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The production entry point instead writes result.json, leaving the contracted artifact absent.\"}],\"finding_ids\":[\"F1\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"Consumers looking for the contracted fidelity.json artifact cannot find the implementation's output.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies output, acceptance seam, and persisted shape but no failure or recovery behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required by this narrowly scoped contract.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance criterion A1 requires exercising O1 through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test calls only a local helper and neither invokes critique_branch nor observes its persisted output.\"}],\"finding_ids\":[\"F3\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The named acceptance criterion is not exercised through its required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The documentation accurately warns that the branch's completeness claim is not realized.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"The README communicates the incomplete state; the contract imposes no additional operational-documentation obligation.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The contract names fidelity.json as the public persisted artifact.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The contract limits persisted additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:6-8\",\"rationale\":\"Runtime behavior contradicts both contracts by naming result.json and persisting extra_state.\"}],\"finding_ids\":[\"F1\",\"F2\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The persisted filename and schema silently contradict the frozen contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"Each defect maps directly to one of the four-line contract's explicit obligations and has a bounded local repair.\"}],\"finding_ids\":[],\"id\":\"proportionality\",\"status\":\"covered\",\"summary\":\"The findings and remedies are limited to the tiny branch's explicit fidelity obligations.\"}],\"findings\":[{\"evidence\":[{\"",
-            "response_sha256": "31c52dc77eb78732864be2bc863adf91cfee87c4079bc15a5e54369b33e2e97d",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains three obligations: output filename, public-entry-point acceptance coverage, and persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The implementation violates the filename and persisted-shape obligations.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The only test exercises a helper instead of the required public entry point.\"}],\"finding_ids\":[\"F001\",\"F002\",\"F003\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"None of the three frozen-contract obligations is fully implemented and verified.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The repository's sole production entry point and its complete persistence path are visible here.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The repository's only consumer-like test does not import or call the production entry point.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The tiny repository has no additional consumers, configuration, or production counterpart that alters the observed contract violations.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Serialization preserves the required branch_contract value, but directs it to the wrong artifact and adds a prohibited field.\"},{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the required artifact name and the complete allowed persisted shape.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The persistence transformation produces the wrong named artifact with an over-broad object shape.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"Acceptance must exercise output generation through critique_branch.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test consumes only its local helper and never reaches critique_branch.\"}],\"finding_ids\":[\"F003\"],\"id\":\"consumers\",\"status\":\"finding\",\"summary\":\"The acceptance consumer bypasses the public production seam.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Write and serialization errors propagate to the trusted sequential caller; under the stated recoverable-blocking stakes, no additional recovery mechanism is required.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Fail-fast behavior is proportionate for this single-operator negative fixture.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named acceptance criterion explicitly requires the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The test asserts only that a constant nonempty string is truthy and neither invokes critique_branch nor inspects a persisted artifact.\"}],\"finding_ids\":[\"F003\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The required public-entry-point acceptance behavior is entirely untested.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The README explicitly describes the branch as a deliberately incomplete fixture, matching the stated intentional negative-fixture context.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is explicitly outside this acceptance's three-obligation scope.\"},{\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The public persistence contract names fidelity.json.\"},{\"anchor\":\"plan:4\",\"rationale\":\"The persisted object contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The implementation silently writes result.json and includes extra_state alongside branch_contract.\"}],\"finding_ids\":[\"F001\",\"F002\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The persisted filename and object shape contradict the frozen public contract.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The findings are limited to the three explicit obligations in this tiny branch.\"},{\"anchor\":\"rep",
+            "response_sha256": "78953df859d9de386a80516439404123a13a59cf78109bd87c0a2258ce7a7d5a",
             "returncode": 0,
             "role": "census-integrity",
             "sequence": 3,
-            "session_ref": "01a02ad2-6913-7663-9e58-ecb59fb203eb",
-            "stderr_excerpt": "2026-08-22T18:53:47.092946Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:53:48.691335Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02ad2-68b8-7080-96fa-117a6f2dacea.1787424827600622627.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-22T18:54:00.852413Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:09.346099Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:54:53.685038Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "435a56aec8fcc99a558e1a99c375e0a7f2678c79deb123dc63959dfb502158bf",
+            "session_ref": "01a02fe3-6484-7663-b6e1-d9434ba52f98",
+            "stderr_excerpt": "2026-08-23T18:30:26.332136Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:30.643595Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:47.115847Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:30:53.237130Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:31:33.871337Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:31:33.876855Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe3-6484-7663-b6e1-d9434ba52f98.1787509826716329233.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+            "stderr_sha256": "593f896bbe58ed04813440fb8729f8cae3512ea27a4b8911b149a4c8ac1ea9c7",
             "usage": {
-              "cached_input_tokens": 34304,
-              "input_tokens": 53557,
-              "output_tokens": 2794,
-              "reasoning_output_tokens": 1159
+              "cached_input_tokens": 33280,
+              "input_tokens": 53865,
+              "output_tokens": 2966,
+              "reasoning_output_tokens": 876
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 29316,
+            "duration_ms": 27535,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02ad3-c5c9-7651-9c16-3f0b59296a8f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[{\\\"classification\\\":{\\\"kind\\\":\\\"one_off\\\",\\\"reason\\\":\\\"This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class.\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"These lines prescribe fidelity.json as the required output artifact.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:6-7\\\",\\\"rationale\\\":\\\"These lines show the public entry point selecting result.json instead of the required filename.\\\"}],\\\"id\\\":\\\"census:F001\\\",\\\"remedy\\\":\\\"Change the public entry point to write Path(\\\\\\\"fidelity.json\\\\\\\") and assert that exact filename through the public entry point.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F001\\\",\\\"execution:F1\\\",\\\"integrity:F1\\\"],\\\"summary\\\":\\\"The public entry point writes result.json instead of the required fidelity.json artifact.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"Persisted JSON objects containing fields prohibited by the governing contract.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"These lines restrict the persisted object to branch_contract only.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7-8\\\",\\\"rationale\\\":\\\"These lines show extra_state being included in the serialized object.\\\"}],\\\"id\\\":\\\"census:F002\\\",\\\"remedy\\\":\\\"Remove extra_state and serialize exactly {\\\\\\\"branch_contract\\\\\\\": contract}; add an exact decoded-object assertion that rejects additional keys.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F002\\\",\\\"execution:F2\\\",\\\"integrity:F2\\\"],\\\"summary\\\":\\\"The persisted JSON object contains the contract-forbidden extra_state field.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.\\\",\\\"procedure\\\":\\\"For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"These lines require acceptance through the public entry point.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"These lines show a helper-only test that never invokes critique_branch or checks its produced artifact.\\\"}],\\\"id\\\":\\\"census:F003\\\",\\\"remedy\\\":\\\"Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:F003\\\",\\\"execution:F3\\\",\\\"integrity:F3\\\"],\\\"summary\\\":\\\"The acceptance test bypasses the contracted public production entry point.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.\\\",\\\"pathspec\\\":\\\"repository/README.md\\\",\\\"pattern\\\":\\\"Implementation-status claims contradicted by the current implementation.\\\",\\\"severity\\\":\\\"MINOR\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/README.md:3\\\",\\\"rationale\\\":\\\"This line characterizes the implementation as a placeholder.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"These lines contain a substantive implementation, contradicting the placeholder characterization.\\\"}],\\\"id\\\":\\\"census:F004\\\",\\\"remedy\\\":\\\"Update the README to describe the actual",
-            "raw_sha256": "27f047cded722bbea7ef4b1f1a016821da114080ebf0cb1505a831e851873854",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe4-82a6-7151-b034-6b767de2c23f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"The plan requires the serialized contract artifact to be written to fidelity.json.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:6\\\",\\\"rationale\\\":\\\"The public entry point instead targets result.json, so the required artifact is not emitted.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"These lines show the persistence operation completing against the incorrectly named artifact.\\\"}],\\\"id\\\":\\\"census:GF-001\\\",\\\"remedy\\\":\\\"Change the public entry point to write the serialized contract artifact to fidelity.json.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-001\\\",\\\"execution:F1\\\",\\\"integrity:F001\\\"],\\\"summary\\\":\\\"The public entry point emits result.json instead of the contract-required fidelity.json.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"A persisted object governed by an exact-field contract must contain all and only the permitted fields.\\\",\\\"pathspec\\\":\\\"repository/**/*.py\\\",\\\"pattern\\\":\\\"For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The plan requires the persisted object to contain exactly branch_contract and forbids extra fields.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:7\\\",\\\"rationale\\\":\\\"The constructed output object adds extra_state alongside branch_contract.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:8\\\",\\\"rationale\\\":\\\"This line identifies the forbidden extra_state field in the object that is persisted.\\\"}],\\\"id\\\":\\\"census:GF-002\\\",\\\"remedy\\\":\\\"Remove extra_state and persist an object whose sole field is branch_contract.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-002\\\",\\\"execution:F2\\\",\\\"integrity:F002\\\"],\\\"summary\\\":\\\"The persisted object violates the exact field boundary by including extra_state.\\\"},{\\\"classification\\\":{\\\"definition\\\":{\\\"invariant\\\":\\\"Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.\\\",\\\"pathspec\\\":\\\"repository/tests/**/*.py\\\",\\\"pattern\\\":\\\"For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.\\\",\\\"severity\\\":\\\"BLOCKER\\\"},\\\"kind\\\":\\\"new_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"The plan requires an acceptance test that invokes critique_branch through the public import seam.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:1-6\\\",\\\"rationale\\\":\\\"The supplied test calls only the serialization helper and never invokes the public entry point or inspects a persisted artifact.\\\"}],\\\"id\\\":\\\"census:GF-003\\\",\\\"remedy\\\":\\\"Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.\\\",\\\"severity\\\":\\\"BLOCKER\\\",\\\"source_ids\\\":[\\\"behaviour:BHV-003\\\",\\\"execution:F3\\\",\\\"integrity:F003",
+            "raw_sha256": "1795f40cf5f5061300255b36e0aa25bd85b4efc33ba4bfe77cda4aa6c57c76a6",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1200,
-            "response_excerpt": "{\"class_actions\":{},\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"kind\":\"one_off\",\"reason\":\"This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class.\"},\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"These lines prescribe fidelity.json as the required output artifact.\"},{\"anchor\":\"repository/reviewer.py:6-7\",\"rationale\":\"These lines show the public entry point selecting result.json instead of the required filename.\"}],\"id\":\"census:F001\",\"remedy\":\"Change the public entry point to write Path(\\\"fidelity.json\\\") and assert that exact filename through the public entry point.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F001\",\"execution:F1\",\"integrity:F1\"],\"summary\":\"The public entry point writes result.json instead of the required fidelity.json artifact.\"},{\"classification\":{\"definition\":{\"invariant\":\"A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"Persisted JSON objects containing fields prohibited by the governing contract.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"These lines restrict the persisted object to branch_contract only.\"},{\"anchor\":\"repository/reviewer.py:7-8\",\"rationale\":\"These lines show extra_state being included in the serialized object.\"}],\"id\":\"census:F002\",\"remedy\":\"Remove extra_state and serialize exactly {\\\"branch_contract\\\": contract}; add an exact decoded-object assertion that rejects additional keys.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F002\",\"execution:F2\",\"integrity:F2\"],\"summary\":\"The persisted JSON object contains the contract-forbidden extra_state field.\"},{\"classification\":{\"definition\":{\"invariant\":\"An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.\",\"procedure\":\"For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"These lines require acceptance through the public entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"These lines show a helper-only test that never invokes critique_branch or checks its produced artifact.\"}],\"id\":\"census:F003\",\"remedy\":\"Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:F003\",\"execution:F3\",\"integrity:F3\"],\"summary\":\"The acceptance test bypasses the contracted public production entry point.\"},{\"classification\":{\"definition\":{\"invariant\":\"Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.\",\"pathspec\":\"repository/README.md\",\"pattern\":\"Implementation-status claims contradicted by the current implementation.\",\"severity\":\"MINOR\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"This line characterizes the implementation as a placeholder.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"These lines contain a substantive implementation, contradicting the placeholder characterization.\"}],\"id\":\"census:F004\",\"remedy\":\"Update the README to describe the actual nonconformance, or describe completion after the implementation is corrected.\",\"severity\":\"MINOR\",\"source_ids\":[\"execution:F4\"],\"summary\":\"The README inaccurately characterizes the current implementation as a placeholder.\"}],\"role\":\"census\"}",
-            "response_sha256": "5b0e5cedf5ac4696da7c1e8905f4e5954971e6704248b160dd579186fc6c1726",
+            "response_excerpt": "{\"class_actions\":{},\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"definition\":{\"invariant\":\"A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:2\",\"rationale\":\"The plan requires the serialized contract artifact to be written to fidelity.json.\"},{\"anchor\":\"repository/reviewer.py:6\",\"rationale\":\"The public entry point instead targets result.json, so the required artifact is not emitted.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"These lines show the persistence operation completing against the incorrectly named artifact.\"}],\"id\":\"census:GF-001\",\"remedy\":\"Change the public entry point to write the serialized contract artifact to fidelity.json.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-001\",\"execution:F1\",\"integrity:F001\"],\"summary\":\"The public entry point emits result.json instead of the contract-required fidelity.json.\"},{\"classification\":{\"definition\":{\"invariant\":\"A persisted object governed by an exact-field contract must contain all and only the permitted fields.\",\"pathspec\":\"repository/**/*.py\",\"pattern\":\"For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan requires the persisted object to contain exactly branch_contract and forbids extra fields.\"},{\"anchor\":\"repository/reviewer.py:7\",\"rationale\":\"The constructed output object adds extra_state alongside branch_contract.\"},{\"anchor\":\"repository/reviewer.py:8\",\"rationale\":\"This line identifies the forbidden extra_state field in the object that is persisted.\"}],\"id\":\"census:GF-002\",\"remedy\":\"Remove extra_state and persist an object whose sole field is branch_contract.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-002\",\"execution:F2\",\"integrity:F002\"],\"summary\":\"The persisted object violates the exact field boundary by including extra_state.\"},{\"classification\":{\"definition\":{\"invariant\":\"Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.\",\"pathspec\":\"repository/tests/**/*.py\",\"pattern\":\"For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.\",\"severity\":\"BLOCKER\"},\"kind\":\"new_class\"},\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The plan requires an acceptance test that invokes critique_branch through the public import seam.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-6\",\"rationale\":\"The supplied test calls only the serialization helper and never invokes the public entry point or inspects a persisted artifact.\"}],\"id\":\"census:GF-003\",\"remedy\":\"Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.\",\"severity\":\"BLOCKER\",\"source_ids\":[\"behaviour:BHV-003\",\"execution:F3\",\"integrity:F003\"],\"summary\":\"Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation.\"}],\"role\":\"census\"}",
+            "response_sha256": "09885537e4ee09b8797c028c6c6f8d2a37732aa244265ebb50d978b41826b160",
             "returncode": 0,
             "role": "consolidation",
             "sequence": 4,
-            "session_ref": "01a02ad3-c5c9-7651-9c16-3f0b59296a8f",
-            "stderr_excerpt": "2026-08-22T18:55:16.543716Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:55:45.214389Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "4d2251859f767b082d4ac76ec4a29da6ffd8cbd24d25562c28beb2ab8fe4d526",
+            "session_ref": "01a02fe4-82a6-7151-b034-6b767de2c23f",
+            "stderr_excerpt": "2026-08-23T18:31:39.480351Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:32:06.356479Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+            "stderr_sha256": "a7ccfa9cf4c3035da699afcd8d5c77f89973343a7eb9cbb9d121809ba60ac73c",
             "usage": {
-              "cached_input_tokens": 0,
-              "input_tokens": 17245,
-              "output_tokens": 1123,
-              "reasoning_output_tokens": 348
+              "cached_input_tokens": 11008,
+              "input_tokens": 17205,
+              "output_tokens": 950,
+              "reasoning_output_tokens": 185
             },
             "validation_issue": null,
             "validation_pointer": null
           }
         ],
-        "base_id": "521b4a12adc83156e5380153f51a5ca1a7c60f66",
-        "duration_ms": 29316,
+        "base_id": "4afe14967bd0ef81ab2a68d8c3abe6a3d372f209",
+        "correction_gates": [],
+        "duration_ms": 27535,
         "engine": "codex",
         "error": false,
-        "head_id": "13b5dc35d0db36dbbc529da5a579ce08323f31a6",
-        "lineage": "issue-63-exact-nonconforming-v3",
+        "head_id": "7ec163a68fc158d349118694b41f4796ec336353",
+        "lineage": "issue-68-plan-digest-nonconforming-v3",
         "mode": "converge-packet",
         "model": "gpt-5.6-sol",
         "plan_contract_reused": false,
@@ -304,10 +285,11 @@
         "plan_path": null,
         "plan_text": "# Fidelity contract\nO1: emit fidelity.json\nA1: exercise O1 through the public critique_branch entry point\nP1: persisted additions are limited to branch_contract",
         "rejected_payloads": [],
+        "rendered_trailer": "LINEAGE: issue-68-plan-digest-nonconforming-v3 (rounds recorded: 1)\nPLAN-DIGEST: ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5\nCLASS-REGISTER: staged census parsed — NEW 65ca4cb6, NEW f0b7b837, NEW 84d94124\nCLASS-CLOSURE: 0 open, 3 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nCLASS-CLOSURE-WARNING: 65ca4cb6 closed in the round it was registered — verify its predicate actually matches the violation it describes (A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.); f0b7b837 closed in the round it was registered — verify its predicate actually matches the violation it describes (A persisted object governed by an exact-field contract must contain all and only the permitted fields.); 84d94124 closed in the round it was registered — verify its predicate actually matches the violation it describes (Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.)\nSTRUCTURAL-PHASE: correction\nSTRUCTURAL-DEBT: 3 blocking open\nCONVERGENCE: BLOCKED — staged structural debt remains open.\nSTAGED-ATTEMPTS: total=4 validation-retries=0 validation-invalid=0 execution-failed=0",
         "retry_register": null,
         "returncode": 0,
         "round": 1,
-        "session_ref": "01a02ad3-c5c9-7651-9c16-3f0b59296a8f",
+        "session_ref": "01a02fe4-82a6-7151-b034-6b767de2c23f",
         "staged_manifests": [
           {
             "class_assessments": [],
@@ -315,63 +297,39 @@
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:5-9",
+                  "repository/reviewer.py:4-10",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [
-                  "behaviour:F001",
-                  "behaviour:F002",
-                  "behaviour:F003"
+                  "behaviour:BHV-001",
+                  "behaviour:BHV-002",
+                  "behaviour:BHV-003"
                 ],
                 "id": "artifact-complete",
                 "status": "finding",
-                "summary": "None of the three implementation-contract obligations is fully satisfied."
+                "summary": "None of the three frozen-contract obligations is faithfully completed."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:5-9",
-                  "repository/README.md:1-3"
+                  "repository/reviewer.py:4-10",
+                  "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [],
                 "id": "repository-premises",
                 "status": "covered",
-                "summary": "The public function signature is preserved and the repository itself does not substantiate a fidelity-complete premise."
+                "summary": "The relevant production and test premises are explicit and require no unsupported runtime assumptions."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:7-9",
-                  "plan:2",
-                  "plan:4"
+                  "plan:4",
+                  "repository/reviewer.py:7"
                 ],
                 "finding_ids": [
-                  "behaviour:F001",
-                  "behaviour:F002"
+                  "behaviour:BHV-002"
                 ],
                 "id": "transformations",
                 "status": "finding",
-                "summary": "The output destination and serialized object shape both contradict the contract."
-              },
-              {
-                "evidence": [
-                  "plan:2-4",
-                  "repository/reviewer.py:5-9"
-                ],
-                "finding_ids": [
-                  "behaviour:F001",
-                  "behaviour:F002"
-                ],
-                "id": "consumers",
-                "status": "finding",
-                "summary": "A contract-compliant consumer cannot find or validate the produced artifact."
-              },
-              {
-                "evidence": [
-                  "plan:2-4"
-                ],
-                "finding_ids": [],
-                "id": "failure-recovery",
-                "status": "not_applicable",
-                "summary": "No failure-recovery obligation is in scope, and the stated stakes exclude corrupt-state recovery."
+                "summary": "The JSON transformation introduces state expressly excluded by the contract."
               },
               {
                 "evidence": [
@@ -379,80 +337,97 @@
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [
-                  "behaviour:F001",
-                  "behaviour:F002",
-                  "behaviour:F003"
+                  "behaviour:BHV-003"
                 ],
-                "id": "tests-acceptance",
+                "id": "consumers",
                 "status": "finding",
-                "summary": "The acceptance test cannot detect either production defect because it never reaches the public entry point."
+                "summary": "The acceptance consumer is disconnected from the public production behavior."
               },
               {
                 "evidence": [
-                  "repository/README.md:1-3",
-                  "plan:2-4"
+                  "repository/reviewer.py:6-10"
+                ],
+                "finding_ids": [],
+                "id": "failure-recovery",
+                "status": "covered",
+                "summary": "No additional recovery mechanism is required under the stated contract and stakes."
+              },
+              {
+                "evidence": [
+                  "plan:3",
+                  "repository/tests/test_fidelity.py:1-6"
+                ],
+                "finding_ids": [
+                  "behaviour:BHV-003"
+                ],
+                "id": "tests-acceptance",
+                "status": "finding",
+                "summary": "The required public-entry-point acceptance path is untested."
+              },
+              {
+                "evidence": [
+                  "repository/README.md:1-3"
                 ],
                 "finding_ids": [],
                 "id": "docs-operations",
-                "status": "covered",
-                "summary": "Documentation does not falsely clear the incomplete branch, and no operational procedure is required."
+                "status": "not_applicable",
+                "summary": "Documentation accuracy is intentionally outside the three-obligation acceptance scope."
               },
               {
                 "evidence": [
                   "plan:2",
+                  "repository/reviewer.py:6",
                   "plan:4",
-                  "repository/reviewer.py:7-9"
+                  "repository/reviewer.py:7"
                 ],
                 "finding_ids": [
-                  "behaviour:F001",
-                  "behaviour:F002"
+                  "behaviour:BHV-001",
+                  "behaviour:BHV-002"
                 ],
                 "id": "consistency",
                 "status": "finding",
-                "summary": "Persisted runtime behavior contradicts both declared output contracts."
+                "summary": "The public persisted behavior contradicts both the required artifact identity and shape."
               },
               {
                 "evidence": [
-                  "plan:2-4",
-                  "repository/reviewer.py:5-9",
-                  "repository/tests/test_fidelity.py:1-6"
+                  "plan:2-4"
                 ],
                 "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The findings and remedies are limited to explicit correctness obligations under the modest stated stakes."
+                "summary": "The findings are confined to direct fidelity failures at the stated high-impact acceptance boundary."
               }
             ],
             "findings": [
               {
                 "evidence": [
                   "plan:2",
-                  "repository/reviewer.py:7"
+                  "repository/reviewer.py:6"
                 ],
-                "id": "behaviour:F001",
-                "remedy": "Change the output path in critique_branch to Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
-                "severity": "MAJOR",
-                "summary": "critique_branch emits result.json instead of the required fidelity.json."
+                "id": "behaviour:BHV-001",
+                "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
+                "severity": "BLOCKER",
+                "summary": "The required fidelity.json artifact is never emitted."
               },
               {
                 "evidence": [
                   "plan:4",
-                  "repository/reviewer.py:8"
+                  "repository/reviewer.py:7"
                 ],
-                "id": "behaviour:F002",
-                "remedy": "Serialize only {\"branch_contract\": contract} and add an exact decoded-object assertion that rejects additional keys.",
-                "severity": "MAJOR",
-                "summary": "The persisted artifact contains the forbidden extra_state field."
+                "id": "behaviour:BHV-002",
+                "remedy": "Persist an object containing exactly the branch_contract field and remove extra_state.",
+                "severity": "BLOCKER",
+                "summary": "The persisted artifact violates the required exact field boundary."
               },
               {
                 "evidence": [
                   "plan:3",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
-                "id": "behaviour:F003",
-                "remedy": "Replace the helper-only test with one that changes to a temporary directory, calls critique_branch, and verifies fidelity.json and its exact JSON object.",
-                "severity": "MAJOR",
-                "summary": "The acceptance test does not invoke the contracted public entry point."
+                "id": "behaviour:BHV-003",
+                "remedy": "Replace the helper-only test with one that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with the contract-required content.",
+                "severity": "BLOCKER",
+                "summary": "Acceptance tests bypass the required public production seam."
               }
             ],
             "lane": "behaviour"
@@ -463,7 +438,7 @@
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:5-10",
+                  "repository/reviewer.py:5-9",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [
@@ -473,23 +448,21 @@
                 ],
                 "id": "artifact-complete",
                 "status": "finding",
-                "summary": "None of the contract's three independently stated obligations is fully satisfied."
+                "summary": "None of the three frozen contract obligations is fully satisfied."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:5-10",
-                  "repository/README.md:3"
+                  "repository/reviewer.py:5-9",
+                  "repository/tests/test_fidelity.py:1-6"
                 ],
-                "finding_ids": [
-                  "execution:F4"
-                ],
+                "finding_ids": [],
                 "id": "repository-premises",
-                "status": "finding",
-                "summary": "The public API premise is preserved, but the README inaccurately characterizes the current implementation."
+                "status": "covered",
+                "summary": "The tiny repository contains direct evidence of the implementation and test seams; no unsupported runtime premise is needed."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:8",
+                  "repository/reviewer.py:7-8",
                   "plan:4"
                 ],
                 "finding_ids": [
@@ -497,27 +470,29 @@
                 ],
                 "id": "transformations",
                 "status": "finding",
-                "summary": "The input value is serialized faithfully, but the persisted object shape violates the explicit field restriction."
+                "summary": "Serialization preserves the supplied contract but produces a forbidden extra field."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:5-10",
+                  "plan:3",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
-                "finding_ids": [],
+                "finding_ids": [
+                  "execution:F3"
+                ],
                 "id": "consumers",
-                "status": "not_applicable",
-                "summary": "The repository contains no downstream artifact consumer; filename and shape fidelity are assessed directly against the frozen contract."
+                "status": "finding",
+                "summary": "The acceptance consumer bypasses the production API entirely."
               },
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:7-10"
+                  "repository/reviewer.py:6-9"
                 ],
                 "finding_ids": [],
                 "id": "failure-recovery",
                 "status": "not_applicable",
-                "summary": "No failure-recovery behavior is required at the calibrated stakes."
+                "summary": "No failure-recovery behavior is required for this fixture."
               },
               {
                 "evidence": [
@@ -529,66 +504,62 @@
                 ],
                 "id": "tests-acceptance",
                 "status": "finding",
-                "summary": "The named acceptance criterion is not exercised through its required public entry point."
-              },
-              {
-                "evidence": [
-                  "repository/README.md:3",
-                  "repository/reviewer.py:5-10"
-                ],
-                "finding_ids": [
-                  "execution:F4"
-                ],
-                "id": "docs-operations",
-                "status": "finding",
-                "summary": "The repository documentation is stale or misleading about the implementation state."
-              },
-              {
-                "evidence": [
-                  "plan:2",
-                  "repository/reviewer.py:7-8",
-                  "plan:4"
-                ],
-                "finding_ids": [
-                  "execution:F1",
-                  "execution:F2",
-                  "execution:F4"
-                ],
-                "id": "consistency",
-                "status": "finding",
-                "summary": "Runtime persistence and repository documentation contradict the frozen public contract and the actual implementation, respectively."
+                "summary": "The test does not exercise the named public entry point or any persisted output."
               },
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:7-10"
+                  "repository/README.md:3"
+                ],
+                "finding_ids": [],
+                "id": "docs-operations",
+                "status": "not_applicable",
+                "summary": "Documentation accuracy is expressly outside this acceptance contract."
+              },
+              {
+                "evidence": [
+                  "plan:2",
+                  "plan:4",
+                  "repository/reviewer.py:6-9"
+                ],
+                "finding_ids": [
+                  "execution:F1",
+                  "execution:F2"
+                ],
+                "id": "consistency",
+                "status": "finding",
+                "summary": "Both the artifact name and persisted shape contradict the frozen contract."
+              },
+              {
+                "evidence": [
+                  "plan:2-4"
                 ],
                 "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The findings are limited to direct fidelity defects and one concrete documentation mismatch; no excluded threat or scale assumptions are introduced."
+                "summary": "The review is bounded to the high-impact fidelity failures in the three explicit obligations."
               }
             ],
             "findings": [
               {
                 "evidence": [
                   "plan:2",
-                  "repository/reviewer.py:7"
+                  "repository/reviewer.py:6"
                 ],
                 "id": "execution:F1",
-                "remedy": "Change the output path from result.json to fidelity.json.",
+                "remedy": "Change the public entry point to write `fidelity.json` instead of `result.json`.",
                 "severity": "BLOCKER",
-                "summary": "The required fidelity.json artifact is not produced."
+                "summary": "The required fidelity.json artifact is not emitted."
               },
               {
                 "evidence": [
                   "plan:4",
-                  "repository/reviewer.py:8"
+                  "repository/reviewer.py:7"
                 ],
                 "id": "execution:F2",
-                "remedy": "Remove extra_state so the persisted object contains only branch_contract.",
+                "remedy": "Persist an object containing only `branch_contract`.",
                 "severity": "BLOCKER",
-                "summary": "The persisted JSON shape contains a contract-forbidden field."
+                "summary": "The persisted artifact contains a forbidden extra_state field."
               },
               {
                 "evidence": [
@@ -596,19 +567,9 @@
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "id": "execution:F3",
-                "remedy": "Replace the wrong-seam test with one that invokes critique_branch in an isolated working directory and asserts the filename and exact JSON object required by O1 and P1.",
+                "remedy": "Replace the helper-only test with one that invokes `critique_branch` in an isolated temporary working directory and asserts the name and exact JSON contents of `fidelity.json`.",
                 "severity": "BLOCKER",
-                "summary": "Acceptance testing bypasses the required public production entry point."
-              },
-              {
-                "evidence": [
-                  "repository/README.md:3",
-                  "repository/reviewer.py:5-10"
-                ],
-                "id": "execution:F4",
-                "remedy": "Update the README to describe the actual nonconformance, or describe completion once the implementation is corrected.",
-                "severity": "MINOR",
-                "summary": "The README inaccurately says the implementation is still a placeholder."
+                "summary": "Acceptance coverage bypasses the public production entry point."
               }
             ],
             "lane": "execution"
@@ -619,63 +580,40 @@
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:6-9",
+                  "repository/reviewer.py:5-10",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [
-                  "integrity:F1",
-                  "integrity:F2",
-                  "integrity:F3"
+                  "integrity:F001",
+                  "integrity:F002",
+                  "integrity:F003"
                 ],
                 "id": "artifact-complete",
                 "status": "finding",
-                "summary": "None of the contract's three substantive obligations is fully implemented and verified."
+                "summary": "None of the three frozen-contract obligations is fully implemented and verified."
               },
               {
                 "evidence": [
-                  "repository/README.md:3",
-                  "repository/reviewer.py:5-8"
+                  "repository/reviewer.py:5-10",
+                  "repository/tests/test_fidelity.py:1-6"
                 ],
-                "finding_ids": [
-                  "integrity:F1",
-                  "integrity:F2"
-                ],
+                "finding_ids": [],
                 "id": "repository-premises",
-                "status": "finding",
-                "summary": "Repository evidence directly disproves the premise that the frozen contract is complete."
+                "status": "covered",
+                "summary": "The tiny repository has no additional consumers, configuration, or production counterpart that alters the observed contract violations."
               },
               {
                 "evidence": [
-                  "plan:4",
-                  "repository/reviewer.py:7"
+                  "repository/reviewer.py:7-10",
+                  "plan:2-4"
                 ],
                 "finding_ids": [
-                  "integrity:F2"
+                  "integrity:F001",
+                  "integrity:F002"
                 ],
                 "id": "transformations",
                 "status": "finding",
-                "summary": "The serialization transformation introduces state expressly excluded by the contract."
-              },
-              {
-                "evidence": [
-                  "plan:2",
-                  "repository/reviewer.py:6"
-                ],
-                "finding_ids": [
-                  "integrity:F1"
-                ],
-                "id": "consumers",
-                "status": "finding",
-                "summary": "Consumers looking for the contracted fidelity.json artifact cannot find the implementation's output."
-              },
-              {
-                "evidence": [
-                  "plan:2-4"
-                ],
-                "finding_ids": [],
-                "id": "failure-recovery",
-                "status": "not_applicable",
-                "summary": "No failure-recovery behavior is required by this narrowly scoped contract."
+                "summary": "The persistence transformation produces the wrong named artifact with an over-broad object shape."
               },
               {
                 "evidence": [
@@ -683,11 +621,32 @@
                   "repository/tests/test_fidelity.py:1-6"
                 ],
                 "finding_ids": [
-                  "integrity:F3"
+                  "integrity:F003"
+                ],
+                "id": "consumers",
+                "status": "finding",
+                "summary": "The acceptance consumer bypasses the public production seam."
+              },
+              {
+                "evidence": [
+                  "repository/reviewer.py:7-10"
+                ],
+                "finding_ids": [],
+                "id": "failure-recovery",
+                "status": "covered",
+                "summary": "Fail-fast behavior is proportionate for this single-operator negative fixture."
+              },
+              {
+                "evidence": [
+                  "plan:3",
+                  "repository/tests/test_fidelity.py:1-6"
+                ],
+                "finding_ids": [
+                  "integrity:F003"
                 ],
                 "id": "tests-acceptance",
                 "status": "finding",
-                "summary": "The named acceptance criterion is not exercised through its required public entry point."
+                "summary": "The required public-entry-point acceptance behavior is entirely untested."
               },
               {
                 "evidence": [
@@ -695,63 +654,64 @@
                 ],
                 "finding_ids": [],
                 "id": "docs-operations",
-                "status": "covered",
-                "summary": "The README communicates the incomplete state; the contract imposes no additional operational-documentation obligation."
+                "status": "not_applicable",
+                "summary": "Documentation accuracy is explicitly outside this acceptance's three-obligation scope."
               },
               {
                 "evidence": [
                   "plan:2",
                   "plan:4",
-                  "repository/reviewer.py:6-8"
+                  "repository/reviewer.py:7-10"
                 ],
                 "finding_ids": [
-                  "integrity:F1",
-                  "integrity:F2"
+                  "integrity:F001",
+                  "integrity:F002"
                 ],
                 "id": "consistency",
                 "status": "finding",
-                "summary": "The persisted filename and schema silently contradict the frozen contract."
+                "summary": "The persisted filename and object shape contradict the frozen public contract."
               },
               {
                 "evidence": [
-                  "plan:2-4"
+                  "plan:2-4",
+                  "repository/reviewer.py:5-10"
                 ],
                 "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The findings and remedies are limited to the tiny branch's explicit fidelity obligations."
+                "summary": "The review remains bounded to the stated high-impact fidelity obligations and trusted single-operator stakes."
               }
             ],
             "findings": [
               {
                 "evidence": [
                   "plan:2",
-                  "repository/reviewer.py:6"
+                  "repository/reviewer.py:7-10"
                 ],
-                "id": "integrity:F1",
-                "remedy": "Change the public entry point to write fidelity.json.",
+                "id": "integrity:F001",
+                "remedy": "Change the production entry point to write the serialized contract artifact to fidelity.json.",
                 "severity": "BLOCKER",
-                "summary": "The public entry point emits the wrong artifact filename."
+                "summary": "The implementation emits result.json instead of the required fidelity.json."
               },
               {
                 "evidence": [
                   "plan:4",
-                  "repository/reviewer.py:7"
+                  "repository/reviewer.py:8"
                 ],
-                "id": "integrity:F2",
-                "remedy": "Remove extra_state and serialize an object containing only branch_contract.",
+                "id": "integrity:F002",
+                "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
                 "severity": "BLOCKER",
-                "summary": "The persisted artifact contains a prohibited extra field."
+                "summary": "The persisted artifact contains a field expressly prohibited by the contract."
               },
               {
                 "evidence": [
                   "plan:3",
                   "repository/tests/test_fidelity.py:1-6"
                 ],
-                "id": "integrity:F3",
-                "remedy": "Replace the helper-only test with one that calls critique_branch and verifies fidelity.json and its exact JSON shape.",
+                "id": "integrity:F003",
+                "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch through its public import and verifies the resulting fidelity.json filename and exact branch_contract-only content.",
                 "severity": "BLOCKER",
-                "summary": "Acceptance testing bypasses the required public entry point."
+                "summary": "The acceptance test exercises the wrong seam and cannot detect either production contract violation."
               }
             ],
             "lane": "integrity"
@@ -759,98 +719,95 @@
         ],
         "staged_settlement": {
           "_class_record_pointers": [
+            "/governing_findings/0/classification/definition",
             "/governing_findings/1/classification/definition",
-            "/governing_findings/2/classification/definition",
-            "/governing_findings/3/classification/definition"
+            "/governing_findings/2/classification/definition"
           ],
           "_finding_class_refs": {
-            "census:F001": null,
-            "census:F002": "record:0",
-            "census:F003": "record:1",
-            "census:F004": "record:2"
+            "census:GF-001": "record:0",
+            "census:GF-002": "record:1",
+            "census:GF-003": "record:2"
           },
           "assessment_dispositions": [],
           "class_assessments": [],
           "class_dispositions": [
             {
-              "finding_id": "census:F001",
-              "kind": "one_off",
-              "reason": "This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class."
-            },
-            {
-              "finding_id": "census:F002",
+              "finding_id": "census:GF-001",
               "kind": "new_class",
               "record_index": 0
             },
             {
-              "finding_id": "census:F003",
+              "finding_id": "census:GF-002",
               "kind": "new_class",
               "record_index": 1
             },
             {
-              "finding_id": "census:F004",
+              "finding_id": "census:GF-003",
               "kind": "new_class",
               "record_index": 2
             }
           ],
           "class_records": [
             {
-              "invariant": "A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.",
+              "invariant": "A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.",
               "op": "new",
               "pathspec": "repository/**/*.py",
-              "pattern": "Persisted JSON objects containing fields prohibited by the governing contract.",
+              "pattern": "For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.",
               "severity": "BLOCKER"
             },
             {
-              "invariant": "An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.",
+              "invariant": "A persisted object governed by an exact-field contract must contain all and only the permitted fields.",
               "op": "new",
-              "procedure": "For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.",
+              "pathspec": "repository/**/*.py",
+              "pattern": "For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.",
               "severity": "BLOCKER"
             },
             {
-              "invariant": "Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.",
+              "invariant": "Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.",
               "op": "new",
-              "pathspec": "repository/README.md",
-              "pattern": "Implementation-status claims contradicted by the current implementation.",
-              "severity": "MINOR"
+              "pathspec": "repository/tests/**/*.py",
+              "pattern": "For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.",
+              "severity": "BLOCKER"
             }
           ],
           "debt": [
             {
               "evidence": [
                 "plan:2",
-                "repository/reviewer.py:6-7"
+                "repository/reviewer.py:6",
+                "repository/reviewer.py:7-10"
               ],
-              "finding_id": "census:F001",
+              "finding_id": "census:GF-001",
               "id": "D1",
-              "remedy": "Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
+              "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
               "severity": "BLOCKER",
               "status": "open",
-              "summary": "The public entry point writes result.json instead of the required fidelity.json artifact."
+              "summary": "The public entry point emits result.json instead of the contract-required fidelity.json."
             },
             {
               "evidence": [
                 "plan:4",
-                "repository/reviewer.py:7-8"
+                "repository/reviewer.py:7",
+                "repository/reviewer.py:8"
               ],
-              "finding_id": "census:F002",
+              "finding_id": "census:GF-002",
               "id": "D2",
-              "remedy": "Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.",
+              "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
               "severity": "BLOCKER",
               "status": "open",
-              "summary": "The persisted JSON object contains the contract-forbidden extra_state field."
+              "summary": "The persisted object violates the exact field boundary by including extra_state."
             },
             {
               "evidence": [
                 "plan:3",
                 "repository/tests/test_fidelity.py:1-6"
               ],
-              "finding_id": "census:F003",
+              "finding_id": "census:GF-003",
               "id": "D3",
-              "remedy": "Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.",
+              "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
               "severity": "BLOCKER",
               "status": "open",
-              "summary": "The acceptance test bypasses the contracted public production entry point."
+              "summary": "Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation."
             }
           ],
           "debt_updates": [],
@@ -858,106 +815,94 @@
             {
               "evidence": [
                 "plan:2",
-                "repository/reviewer.py:6-7"
+                "repository/reviewer.py:6",
+                "repository/reviewer.py:7-10"
               ],
-              "id": "census:F001",
-              "remedy": "Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
+              "id": "census:GF-001",
+              "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
               "severity": "BLOCKER",
-              "summary": "The public entry point writes result.json instead of the required fidelity.json artifact."
+              "summary": "The public entry point emits result.json instead of the contract-required fidelity.json."
             },
             {
               "evidence": [
                 "plan:4",
-                "repository/reviewer.py:7-8"
+                "repository/reviewer.py:7",
+                "repository/reviewer.py:8"
               ],
-              "id": "census:F002",
-              "remedy": "Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.",
+              "id": "census:GF-002",
+              "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
               "severity": "BLOCKER",
-              "summary": "The persisted JSON object contains the contract-forbidden extra_state field."
+              "summary": "The persisted object violates the exact field boundary by including extra_state."
             },
             {
               "evidence": [
                 "plan:3",
                 "repository/tests/test_fidelity.py:1-6"
               ],
-              "id": "census:F003",
-              "remedy": "Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.",
+              "id": "census:GF-003",
+              "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
               "severity": "BLOCKER",
-              "summary": "The acceptance test bypasses the contracted public production entry point."
-            },
-            {
-              "evidence": [
-                "repository/README.md:3",
-                "repository/reviewer.py:5-10"
-              ],
-              "id": "census:F004",
-              "remedy": "Update the README to describe the actual nonconformance, or describe completion after the implementation is corrected.",
-              "severity": "MINOR",
-              "summary": "The README inaccurately characterizes the current implementation as a placeholder."
+              "summary": "Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation."
             }
           ],
           "role": "census",
           "source_dispositions": [
             {
-              "governing_id": "census:F001",
-              "source_id": "behaviour:F001"
+              "governing_id": "census:GF-001",
+              "source_id": "behaviour:BHV-001"
             },
             {
-              "governing_id": "census:F001",
+              "governing_id": "census:GF-001",
               "source_id": "execution:F1"
             },
             {
-              "governing_id": "census:F001",
-              "source_id": "integrity:F1"
+              "governing_id": "census:GF-001",
+              "source_id": "integrity:F001"
             },
             {
-              "governing_id": "census:F002",
-              "source_id": "behaviour:F002"
+              "governing_id": "census:GF-002",
+              "source_id": "behaviour:BHV-002"
             },
             {
-              "governing_id": "census:F002",
+              "governing_id": "census:GF-002",
               "source_id": "execution:F2"
             },
             {
-              "governing_id": "census:F002",
-              "source_id": "integrity:F2"
+              "governing_id": "census:GF-002",
+              "source_id": "integrity:F002"
             },
             {
-              "governing_id": "census:F003",
-              "source_id": "behaviour:F003"
+              "governing_id": "census:GF-003",
+              "source_id": "behaviour:BHV-003"
             },
             {
-              "governing_id": "census:F003",
+              "governing_id": "census:GF-003",
               "source_id": "execution:F3"
             },
             {
-              "governing_id": "census:F003",
-              "source_id": "integrity:F3"
-            },
-            {
-              "governing_id": "census:F004",
-              "source_id": "execution:F4"
+              "governing_id": "census:GF-003",
+              "source_id": "integrity:F003"
             }
           ]
         },
-        "structural_snapshot": "cb51b82884416e87077302875fc3137737a4c74ede7c520def24fa33166e87b8",
-        "target": "committed diff main...nonconforming in issue63-exact-fixture",
-        "text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\n- [BLOCKER] The public entry point writes result.json instead of the required fidelity.json artifact. (plan:2, repository/reviewer.py:6-7)\n- [BLOCKER] The persisted JSON object contains the contract-forbidden extra_state field. [classes: d2cb55d1] (plan:4, repository/reviewer.py:7-8)\n- [BLOCKER] The acceptance test bypasses the contracted public production entry point. [classes: 671d42a4] (plan:3, repository/tests/test_fidelity.py:1-6)\n- [MINOR] The README inaccurately characterizes the current implementation as a placeholder. (repository/README.md:3, repository/reviewer.py:5-10)\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\n- [BLOCKER] Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.\n- [BLOCKER] Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.\n- [BLOCKER] Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.\n- [MINOR] Update the README to describe the actual nonconformance, or describe completion after the implementation is corrected.",
-        "timestamp": "ISSUE63-EXACT-NONCONFORMING",
+        "structural_snapshot": "fa367e0441b4ba6cd7751f88830d512bfa94a2dfdcc175217c5cc237854016ed",
+        "target": "committed diff main...nonconforming in issue68-fidelity-fixture",
+        "text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\n- [BLOCKER] The public entry point emits result.json instead of the contract-required fidelity.json. [classes: 65ca4cb6] (plan:2, repository/reviewer.py:6, repository/reviewer.py:7-10)\n- [BLOCKER] The persisted object violates the exact field boundary by including extra_state. [classes: f0b7b837] (plan:4, repository/reviewer.py:7, repository/reviewer.py:8)\n- [BLOCKER] Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation. [classes: 84d94124] (plan:3, repository/tests/test_fidelity.py:1-6)\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\n- [BLOCKER] Change the public entry point to write the serialized contract artifact to fidelity.json.\n- [BLOCKER] Remove extra_state and persist an object whose sole field is branch_contract.\n- [BLOCKER] Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
+        "timestamp": "20260823T193206",
         "tool": "critique_branch",
         "usage": {
-          "cached_input_tokens": 0,
-          "input_tokens": 17245,
-          "output_tokens": 1123,
-          "reasoning_output_tokens": 348
+          "cached_input_tokens": 11008,
+          "input_tokens": 17205,
+          "output_tokens": 950,
+          "reasoning_output_tokens": 185
         }
       },
-      "audit_canonical_sha256": "f3dffedfb9ea572a73697fc552eb5eb213e6d4cce03062063f9668ee82057fbb",
-      "base_id": "521b4a12adc83156e5380153f51a5ca1a7c60f66",
+      "audit_canonical_sha256": "d4c7cfbab07ebd7334598014b1a7dfb18a0d855b02ed775aecef2544c66af370",
+      "base_id": "4afe14967bd0ef81ab2a68d8c3abe6a3d372f209",
       "engine": "codex",
       "expected": "nonconforming",
-      "head_id": "13b5dc35d0db36dbbc529da5a579ce08323f31a6",
-      "lineage": "issue-63-exact-nonconforming-v3",
+      "head_id": "7ec163a68fc158d349118694b41f4796ec336353",
+      "lineage": "issue-68-plan-digest-nonconforming-v3",
       "lineage_state": {
         "branch_contract": {
           "digest": "ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5",
@@ -969,32 +914,33 @@
         "claim_state": {},
         "classes": [
           {
-            "class_id": "d2cb55d1",
+            "class_id": "65ca4cb6",
             "first_round": 1,
-            "invariant": "A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.",
+            "invariant": "A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.",
             "matches": [],
             "pathspec": "repository/**/*.py",
-            "pattern": "Persisted JSON objects containing fields prohibited by the governing contract.",
+            "pattern": "For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.",
             "severity": "BLOCKER",
             "status": "closed"
           },
           {
-            "class_id": "671d42a4",
+            "class_id": "f0b7b837",
             "first_round": 1,
-            "invariant": "An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.",
+            "invariant": "A persisted object governed by an exact-field contract must contain all and only the permitted fields.",
             "matches": [],
-            "procedure": "For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.",
+            "pathspec": "repository/**/*.py",
+            "pattern": "For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.",
             "severity": "BLOCKER",
-            "status": "open"
+            "status": "closed"
           },
           {
-            "class_id": "6e0d9bf4",
+            "class_id": "84d94124",
             "first_round": 1,
-            "invariant": "Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.",
+            "invariant": "Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.",
             "matches": [],
-            "pathspec": "repository/README.md",
-            "pattern": "Implementation-status claims contradicted by the current implementation.",
-            "severity": "MINOR",
+            "pathspec": "repository/tests/**/*.py",
+            "pattern": "For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.",
+            "severity": "BLOCKER",
             "status": "closed"
           }
         ],
@@ -1003,183 +949,205 @@
         "mode": "branch",
         "next_seq": 4,
         "review_state": {
+          "correction_control": {
+            "classes": {
+              "65ca4cb6": {
+                "last_session_ref": null,
+                "reopen_count": 0,
+                "reset_round": null
+              },
+              "84d94124": {
+                "last_session_ref": null,
+                "reopen_count": 0,
+                "reset_round": null
+              },
+              "f0b7b837": {
+                "last_session_ref": null,
+                "reopen_count": 0,
+                "reset_round": null
+              }
+            },
+            "version": 1
+          },
           "debt": [
             {
-              "class_ids": [],
+              "class_ids": [
+                "65ca4cb6"
+              ],
               "evidence": [
                 "plan:2",
-                "repository/reviewer.py:6-7"
+                "repository/reviewer.py:6",
+                "repository/reviewer.py:7-10"
               ],
-              "finding_id": "census:F001",
+              "finding_id": "census:GF-001",
               "first_round": 1,
               "id": "D1",
               "last_round": 1,
-              "remedy": "Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
+              "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
               "severity": "BLOCKER",
               "source_ids": [
-                "behaviour:F001",
+                "behaviour:BHV-001",
                 "execution:F1",
-                "integrity:F1"
+                "integrity:F001"
               ],
               "status": "open",
-              "summary": "The public entry point writes result.json instead of the required fidelity.json artifact."
+              "summary": "The public entry point emits result.json instead of the contract-required fidelity.json."
             },
             {
               "class_ids": [
-                "d2cb55d1"
+                "f0b7b837"
               ],
               "evidence": [
                 "plan:4",
-                "repository/reviewer.py:7-8"
+                "repository/reviewer.py:7",
+                "repository/reviewer.py:8"
               ],
-              "finding_id": "census:F002",
+              "finding_id": "census:GF-002",
               "first_round": 1,
               "id": "D2",
               "last_round": 1,
-              "remedy": "Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.",
+              "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
               "severity": "BLOCKER",
               "source_ids": [
-                "behaviour:F002",
+                "behaviour:BHV-002",
                 "execution:F2",
-                "integrity:F2"
+                "integrity:F002"
               ],
               "status": "open",
-              "summary": "The persisted JSON object contains the contract-forbidden extra_state field."
+              "summary": "The persisted object violates the exact field boundary by including extra_state."
             },
             {
               "class_ids": [
-                "671d42a4"
+                "84d94124"
               ],
               "evidence": [
                 "plan:3",
                 "repository/tests/test_fidelity.py:1-6"
               ],
-              "finding_id": "census:F003",
+              "finding_id": "census:GF-003",
               "first_round": 1,
               "id": "D3",
               "last_round": 1,
-              "remedy": "Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.",
+              "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
               "severity": "BLOCKER",
               "source_ids": [
-                "behaviour:F003",
+                "behaviour:BHV-003",
                 "execution:F3",
-                "integrity:F3"
+                "integrity:F003"
               ],
               "status": "open",
-              "summary": "The acceptance test bypasses the contracted public production entry point."
+              "summary": "Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation."
             }
           ],
           "last_round": 1,
           "phase": "correction",
-          "snapshot_digest": "cb51b82884416e87077302875fc3137737a4c74ede7c520def24fa33166e87b8",
-          "stakes": "Trusted single operator and OS; Codex is a trusted reviewer; repository, contract, and model output are untrusted data; no hostile local race or repository execution; one tiny branch and one four-line immutable contract; false fidelity clear is high impact and recoverable blocking is acceptable. This fixture has no release, data-loss, or external-action consequence; each omission is an independent recoverable merge defect. Exclude multi-tenancy, compromised OS/provider, formal proof, hostile web content, and corrupt-state recovery. Correctness and bugs only.",
-          "stakes_digest": "e2d95660ab9ffc954b7ed36d2dddd7b868a0f6bbd1791016f730649124fa38ba",
+          "snapshot_digest": "fa367e0441b4ba6cd7751f88830d512bfa94a2dfdcc175217c5cc237854016ed",
+          "stakes": "Trusted single operator and OS; fixture, plan, and model output are untrusted static data; sequential execution with no hostile local race or repository execution; one tiny branch and three plan obligations; false fidelity clearance is high impact and recoverable blocking is acceptable. The README mismatch is intentional negative-fixture context; documentation accuracy is outside this acceptance, which assesses only the three supplied plan obligations.",
+          "stakes_digest": "abda01be96a27bb50b6af4b44fc5068804d6a22491e3764546d7e6d9d2e5ba0c",
           "version": 1
         },
         "rounds": 1
       },
-      "lineage_state_canonical_sha256": "2970b5bd1decc5b0965c7b389f475ff2dcde8e5e205ccd4113a040da5f81ada9",
+      "lineage_state_canonical_sha256": "47c4cab7d658749d955b3b420c2819d6aa768ca1ce3754499638460623826170",
       "model": "gpt-5.6-sol",
-      "packet": "=== UNDER REVIEW ===\nworking-tree snapshot 521b4a12adc8..13b5dc35d0db in issue63-exact-fixture\n\n=== DIFFSTAT ===\nREADME.md              |  2 +-\n reviewer.py            | 10 +++++++++-\n tests/test_fidelity.py |  6 ++++++\n 3 files changed, 16 insertions(+), 2 deletions(-)\n\n=== DIFF (git diff 521b4a12adc8..13b5dc35d0db) ===\ndiff --git a/README.md b/README.md\nindex e796c7a..18e94ee 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,3 +1,3 @@\n # Fidelity fixture\n \n-The feature branch must implement the frozen contract supplied by the reviewer.\n+The feature branch claims the frozen contract is complete, but the placeholder remains.\ndiff --git a/reviewer.py b/reviewer.py\nindex 67cf633..f5be692 100644\n--- a/reviewer.py\n+++ b/reviewer.py\n@@ -1,2 +1,10 @@\n+import json\n+from pathlib import Path\n+\n+\n def critique_branch(contract: str) -> None:\n-    \"\"\"Placeholder public entry point.\"\"\"\n+    \"\"\"Persist the deliberately wrong artifact shape for the negative fixture.\"\"\"\n+    Path(\"result.json\").write_text(\n+        json.dumps({\"branch_contract\": contract, \"extra_state\": True}) + \"\\n\",\n+        encoding=\"utf-8\",\n+    )\ndiff --git a/tests/test_fidelity.py b/tests/test_fidelity.py\nnew file mode 100644\nindex 0000000..8a01f09\n--- /dev/null\n+++ b/tests/test_fidelity.py\n@@ -0,0 +1,6 @@\n+def helper_that_does_not_invoke_the_public_entry_point() -> str:\n+    return \"tested the wrong seam\"\n+\n+\n+def test_wrong_seam() -> None:\n+    assert helper_that_does_not_invoke_the_public_entry_point()\n\n\n=== FILE README.md [M] ===\n# Fidelity fixture\n\nThe feature branch claims the frozen contract is complete, but the placeholder remains.\n\n\n=== FILE reviewer.py [M] ===\nimport json\nfrom pathlib import Path\n\n\ndef critique_branch(contract: str) -> None:\n    \"\"\"Persist the deliberately wrong artifact shape for the negative fixture.\"\"\"\n    Path(\"result.json\").write_text(\n        json.dumps({\"branch_contract\": contract, \"extra_state\": True}) + \"\\n\",\n        encoding=\"utf-8\",\n    )\n\n\n=== FILE tests/test_fidelity.py [A] ===\ndef helper_that_does_not_invoke_the_public_entry_point() -> str:\n    return \"tested the wrong seam\"\n\n\ndef test_wrong_seam() -> None:\n    assert helper_that_does_not_invoke_the_public_entry_point()\n",
-      "packet_sha256": "8c9955a308c311d848b3c393200c55da4d40add9bc0f2417ea8a6c0893619c6b",
+      "packet": "=== UNDER REVIEW ===\nworking-tree snapshot 4afe14967bd0..7ec163a68fc1 in issue68-fidelity-fixture\n\n=== DIFFSTAT ===\nREADME.md              |  2 +-\n reviewer.py            | 10 +++++++++-\n tests/test_fidelity.py |  6 ++++++\n 3 files changed, 16 insertions(+), 2 deletions(-)\n\n=== DIFF (git diff 4afe14967bd0..7ec163a68fc1) ===\ndiff --git a/README.md b/README.md\nindex e796c7a..18e94ee 100644\n--- a/README.md\n+++ b/README.md\n@@ -1,3 +1,3 @@\n # Fidelity fixture\n \n-The feature branch must implement the frozen contract supplied by the reviewer.\n+The feature branch claims the frozen contract is complete, but the placeholder remains.\ndiff --git a/reviewer.py b/reviewer.py\nindex 67cf633..f5be692 100644\n--- a/reviewer.py\n+++ b/reviewer.py\n@@ -1,2 +1,10 @@\n+import json\n+from pathlib import Path\n+\n+\n def critique_branch(contract: str) -> None:\n-    \"\"\"Placeholder public entry point.\"\"\"\n+    \"\"\"Persist the deliberately wrong artifact shape for the negative fixture.\"\"\"\n+    Path(\"result.json\").write_text(\n+        json.dumps({\"branch_contract\": contract, \"extra_state\": True}) + \"\\n\",\n+        encoding=\"utf-8\",\n+    )\ndiff --git a/tests/test_fidelity.py b/tests/test_fidelity.py\nnew file mode 100644\nindex 0000000..8a01f09\n--- /dev/null\n+++ b/tests/test_fidelity.py\n@@ -0,0 +1,6 @@\n+def helper_that_does_not_invoke_the_public_entry_point() -> str:\n+    return \"tested the wrong seam\"\n+\n+\n+def test_wrong_seam() -> None:\n+    assert helper_that_does_not_invoke_the_public_entry_point()\n\n\n=== FILE README.md [M] ===\n# Fidelity fixture\n\nThe feature branch claims the frozen contract is complete, but the placeholder remains.\n\n\n=== FILE reviewer.py [M] ===\nimport json\nfrom pathlib import Path\n\n\ndef critique_branch(contract: str) -> None:\n    \"\"\"Persist the deliberately wrong artifact shape for the negative fixture.\"\"\"\n    Path(\"result.json\").write_text(\n        json.dumps({\"branch_contract\": contract, \"extra_state\": True}) + \"\\n\",\n        encoding=\"utf-8\",\n    )\n\n\n=== FILE tests/test_fidelity.py [A] ===\ndef helper_that_does_not_invoke_the_public_entry_point() -> str:\n    return \"tested the wrong seam\"\n\n\ndef test_wrong_seam() -> None:\n    assert helper_that_does_not_invoke_the_public_entry_point()\n",
+      "packet_sha256": "4e6e7732af3e0ad20f003d4840fc5d29f35e08125a49a6f64020a35b6bd4ee32",
       "plan_contract_reused": false,
       "plan_digest": "ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5",
+      "rendered_trailer": "LINEAGE: issue-68-plan-digest-nonconforming-v3 (rounds recorded: 1)\nPLAN-DIGEST: ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5\nCLASS-REGISTER: staged census parsed — NEW 65ca4cb6, NEW f0b7b837, NEW 84d94124\nCLASS-CLOSURE: 0 open, 3 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nCLASS-CLOSURE-WARNING: 65ca4cb6 closed in the round it was registered — verify its predicate actually matches the violation it describes (A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.); f0b7b837 closed in the round it was registered — verify its predicate actually matches the violation it describes (A persisted object governed by an exact-field contract must contain all and only the permitted fields.); 84d94124 closed in the round it was registered — verify its predicate actually matches the violation it describes (Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.)\nSTRUCTURAL-PHASE: correction\nSTRUCTURAL-DEBT: 3 blocking open\nCONVERGENCE: BLOCKED — staged structural debt remains open.\nSTAGED-ATTEMPTS: total=4 validation-retries=0 validation-invalid=0 execution-failed=0",
       "round": 1,
-      "session_ref": "01a02ad3-c5c9-7651-9c16-3f0b59296a8f",
+      "session_ref": "01a02fe4-82a6-7151-b034-6b767de2c23f",
       "settlement": {
         "_class_record_pointers": [
+          "/governing_findings/0/classification/definition",
           "/governing_findings/1/classification/definition",
-          "/governing_findings/2/classification/definition",
-          "/governing_findings/3/classification/definition"
+          "/governing_findings/2/classification/definition"
         ],
         "_finding_class_refs": {
-          "census:F001": null,
-          "census:F002": "record:0",
-          "census:F003": "record:1",
-          "census:F004": "record:2"
+          "census:GF-001": "record:0",
+          "census:GF-002": "record:1",
+          "census:GF-003": "record:2"
         },
         "assessment_dispositions": [],
         "class_assessments": [],
         "class_dispositions": [
           {
-            "finding_id": "census:F001",
-            "kind": "one_off",
-            "reason": "This violation is tied to the immutable contract's uniquely prescribed fidelity.json filename; recurrence would constitute a different contract instance rather than the same reusable defect class."
-          },
-          {
-            "finding_id": "census:F002",
+            "finding_id": "census:GF-001",
             "kind": "new_class",
             "record_index": 0
           },
           {
-            "finding_id": "census:F003",
+            "finding_id": "census:GF-002",
             "kind": "new_class",
             "record_index": 1
           },
           {
-            "finding_id": "census:F004",
+            "finding_id": "census:GF-003",
             "kind": "new_class",
             "record_index": 2
           }
         ],
         "class_records": [
           {
-            "invariant": "A persisted JSON artifact must contain exactly the fields permitted by its governing contract and no additional state.",
+            "invariant": "A public entry point that promises a named persisted artifact must emit that artifact under the exact contract-required filename.",
             "op": "new",
             "pathspec": "repository/**/*.py",
-            "pattern": "Persisted JSON objects containing fields prohibited by the governing contract.",
+            "pattern": "For each public persistence contract, compare the required output filename with the filename opened or written by the public entry point; report a violation when they differ.",
             "severity": "BLOCKER"
           },
           {
-            "invariant": "An acceptance test for a public entry point must invoke that entry point and verify every artifact property named by the acceptance contract.",
+            "invariant": "A persisted object governed by an exact-field contract must contain all and only the permitted fields.",
             "op": "new",
-            "procedure": "For each acceptance criterion, trace the test invocation to the required public entry point and verify exact assertions for the prescribed filename and decoded object shape.",
+            "pathspec": "repository/**/*.py",
+            "pattern": "For each exact-shape persistence contract, compare the complete set of serialized object keys with the permitted key set; report a violation for every missing or additional key.",
             "severity": "BLOCKER"
           },
           {
-            "invariant": "Repository documentation describing implementation status must agree with the implementation state evidenced by the documented code.",
+            "invariant": "Acceptance coverage for a public persisted-output contract must invoke the public production entry point and verify the resulting artifact's name and exact content.",
             "op": "new",
-            "pathspec": "repository/README.md",
-            "pattern": "Implementation-status claims contradicted by the current implementation.",
-            "severity": "MINOR"
+            "pathspec": "repository/tests/**/*.py",
+            "pattern": "For each public persisted-output obligation, require an acceptance test that calls the named public entry point in an isolated working directory and asserts both the output filename and complete serialized value; report a violation when tests exercise only a helper or substitute seam.",
+            "severity": "BLOCKER"
           }
         ],
         "debt": [
           {
             "evidence": [
               "plan:2",
-              "repository/reviewer.py:6-7"
+              "repository/reviewer.py:6",
+              "repository/reviewer.py:7-10"
             ],
-            "finding_id": "census:F001",
+            "finding_id": "census:GF-001",
             "id": "D1",
-            "remedy": "Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
+            "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
             "severity": "BLOCKER",
             "status": "open",
-            "summary": "The public entry point writes result.json instead of the required fidelity.json artifact."
+            "summary": "The public entry point emits result.json instead of the contract-required fidelity.json."
           },
           {
             "evidence": [
               "plan:4",
-              "repository/reviewer.py:7-8"
+              "repository/reviewer.py:7",
+              "repository/reviewer.py:8"
             ],
-            "finding_id": "census:F002",
+            "finding_id": "census:GF-002",
             "id": "D2",
-            "remedy": "Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.",
+            "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
             "severity": "BLOCKER",
             "status": "open",
-            "summary": "The persisted JSON object contains the contract-forbidden extra_state field."
+            "summary": "The persisted object violates the exact field boundary by including extra_state."
           },
           {
             "evidence": [
               "plan:3",
               "repository/tests/test_fidelity.py:1-6"
             ],
-            "finding_id": "census:F003",
+            "finding_id": "census:GF-003",
             "id": "D3",
-            "remedy": "Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.",
+            "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
             "severity": "BLOCKER",
             "status": "open",
-            "summary": "The acceptance test bypasses the contracted public production entry point."
+            "summary": "Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation."
           }
         ],
         "debt_updates": [],
@@ -1187,202 +1155,189 @@
           {
             "evidence": [
               "plan:2",
-              "repository/reviewer.py:6-7"
+              "repository/reviewer.py:6",
+              "repository/reviewer.py:7-10"
             ],
-            "id": "census:F001",
-            "remedy": "Change the public entry point to write Path(\"fidelity.json\") and assert that exact filename through the public entry point.",
+            "id": "census:GF-001",
+            "remedy": "Change the public entry point to write the serialized contract artifact to fidelity.json.",
             "severity": "BLOCKER",
-            "summary": "The public entry point writes result.json instead of the required fidelity.json artifact."
+            "summary": "The public entry point emits result.json instead of the contract-required fidelity.json."
           },
           {
             "evidence": [
               "plan:4",
-              "repository/reviewer.py:7-8"
+              "repository/reviewer.py:7",
+              "repository/reviewer.py:8"
             ],
-            "id": "census:F002",
-            "remedy": "Remove extra_state and serialize exactly {\"branch_contract\": contract}; add an exact decoded-object assertion that rejects additional keys.",
+            "id": "census:GF-002",
+            "remedy": "Remove extra_state and persist an object whose sole field is branch_contract.",
             "severity": "BLOCKER",
-            "summary": "The persisted JSON object contains the contract-forbidden extra_state field."
+            "summary": "The persisted object violates the exact field boundary by including extra_state."
           },
           {
             "evidence": [
               "plan:3",
               "repository/tests/test_fidelity.py:1-6"
             ],
-            "id": "census:F003",
-            "remedy": "Replace the helper-only test with one that changes to an isolated temporary directory, invokes critique_branch, and verifies fidelity.json and its exact JSON object.",
+            "id": "census:GF-003",
+            "remedy": "Replace the helper-only test with an acceptance test that invokes critique_branch in an isolated working directory and verifies that fidelity.json is created with exactly the branch_contract field and value.",
             "severity": "BLOCKER",
-            "summary": "The acceptance test bypasses the contracted public production entry point."
-          },
-          {
-            "evidence": [
-              "repository/README.md:3",
-              "repository/reviewer.py:5-10"
-            ],
-            "id": "census:F004",
-            "remedy": "Update the README to describe the actual nonconformance, or describe completion after the implementation is corrected.",
-            "severity": "MINOR",
-            "summary": "The README inaccurately characterizes the current implementation as a placeholder."
+            "summary": "Acceptance coverage bypasses the public production seam and cannot detect either persisted-output contract violation."
           }
         ],
         "role": "census",
         "source_dispositions": [
           {
-            "governing_id": "census:F001",
-            "source_id": "behaviour:F001"
+            "governing_id": "census:GF-001",
+            "source_id": "behaviour:BHV-001"
           },
           {
-            "governing_id": "census:F001",
+            "governing_id": "census:GF-001",
             "source_id": "execution:F1"
           },
           {
-            "governing_id": "census:F001",
-            "source_id": "integrity:F1"
+            "governing_id": "census:GF-001",
+            "source_id": "integrity:F001"
           },
           {
-            "governing_id": "census:F002",
-            "source_id": "behaviour:F002"
+            "governing_id": "census:GF-002",
+            "source_id": "behaviour:BHV-002"
           },
           {
-            "governing_id": "census:F002",
+            "governing_id": "census:GF-002",
             "source_id": "execution:F2"
           },
           {
-            "governing_id": "census:F002",
-            "source_id": "integrity:F2"
+            "governing_id": "census:GF-002",
+            "source_id": "integrity:F002"
           },
           {
-            "governing_id": "census:F003",
-            "source_id": "behaviour:F003"
+            "governing_id": "census:GF-003",
+            "source_id": "behaviour:BHV-003"
           },
           {
-            "governing_id": "census:F003",
+            "governing_id": "census:GF-003",
             "source_id": "execution:F3"
           },
           {
-            "governing_id": "census:F003",
-            "source_id": "integrity:F3"
-          },
-          {
-            "governing_id": "census:F004",
-            "source_id": "execution:F4"
+            "governing_id": "census:GF-003",
+            "source_id": "integrity:F003"
           }
         ]
       },
-      "structural_snapshot": "cb51b82884416e87077302875fc3137737a4c74ede7c520def24fa33166e87b8"
+      "structural_snapshot": "fa367e0441b4ba6cd7751f88830d512bfa94a2dfdcc175217c5cc237854016ed"
     },
     {
       "accepted_plan_anchors": [
         "plan:1-4",
         "plan:2-4",
-        "plan:3",
         "plan:4"
       ],
       "attempt_ledger": [
         {
-          "duration_ms": 67479,
+          "duration_ms": 57739,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5062-7ac2-8eb8-d87f65e63333\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking the implementation against each frozen obligation, then following the public entry point’s repository call sites and history before deciding whether any finding is warranted.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress; repository context is being investigated.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The supplied public entry point is the blast-radius root for repository investigation.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress; call sites, instructions, and history are being checked.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-11\\\",\\\"rationale\\\":\\\"The contract-to-JSON transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:4-12\\\",\\\"rationale\\\":\\\"The supplied acceptance test is one known consumer of the public entry point.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-11\\\",\\\"rationale\\\":\\\"Filesystem failure behavior is under review within the stated trusted single-operator stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The named output, entry point, and persisted-field acceptance obligations are being mapped to tests.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:6-6\\\",\\\"rationale\\\":\\\"The public entry point documentation is being checked against operational behavior.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The persisted schema constraint is being checked for consistency with code and tests.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The small implementation is being assessed proportionally to the tiny trusted-operator branch stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"behaviour\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-suney073/tree\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance ",
-          "raw_sha256": "90b9376871d512b2626de6ad6e99950fbc59be5692f0f831a3bce0311d751ffc",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-191c-7c70-a1c6-97b6317c6475\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-oo7o5ch1/tree\\n8f8e424 Add conforming fidelity fixture\\n4afe149 Base fidelity fixture\\ncommit 8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:23:07 2026 +0100\\n\\n    Add conforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,11 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' | sort && git status --short && git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' | sort && git status --short && git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nREADME.md\\n M README.md\\n M reviewer.py\\n M tests/test_fidelity.py\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md && git log -p --follow -- README.md && git diff -- README.md'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md && git log -p --follow -- README.md && git diff -- README.md'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n     1\\t# Fidelity fixture\\n     2\\t\\n     3\\tThe feature branch must implement the frozen contract supplied by the reviewer.\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acce",
+          "raw_sha256": "f1823d14e2ad23c8ee921ddc53b527d683d172b4f91ea6c1c6d51d1ca584c948",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires the named artifact, invocation through the public entry point, and exactly one persisted field.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation writes fidelity.json from critique_branch and serializes only branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the resulting artifact and exact object contents.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"Every frozen implementation obligation is present.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The established public signature continues to return None while gaining the required filesystem side effect.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository describes the feature branch as implementing the reviewer-supplied frozen contract.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation fits the repository's small fixture and preserves the pre-existing public return contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"The input contract is transformed directly into a JSON object containing only branch_contract, with deterministic key ordering and UTF-8 output.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-JSON transformation matches the persisted schema.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:4-12\",\"rationale\":\"The known consumer imports critique_branch, invokes it from a controlled working directory, and reads the documented fidelity.json output.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public entry point and artifact are consumed consistently.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Filesystem failures naturally propagate from write_text, preventing the caller from receiving a false success; no additional recovery behavior is required by the contract.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Fail-fast write behavior is proportionate to the trusted single-operator stakes, where recoverable blocking is acceptable.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The acceptance obligations cover artifact creation, public-entry-point exercise, and the restricted persisted schema.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch itself and validates both the filename and exact decoded JSON object.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"All named acceptance criteria are exercised through the required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:6-6\",\"rationale\":\"The public function docstring accurately describes its artifact-emission behavior.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"Repository-level documentation identifies this as the frozen-contract fidelity fixture; the contract supplies the exact operational requirements.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation is sufficient for this deliberately tiny fixture.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The frozen persisted contract limits additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:9-9\",\"rationale\":\"The emitted JSON object contains exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"The test's exact dictionary equality detects extra persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on the persisted contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation uses a single direct write with no speculative abstraction or configurability.\"},{\"anchor\":\"repository/tes",
-          "response_sha256": "b2adf0745a9a4d93882dc474426493a3886fb1f45f4737ef48fdb437d5384781",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires fidelity.json, public-entry-point exercise, and no persisted field beyond branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public function writes fidelity.json containing exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public function and verifies the emitted artifact and field set.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen contract obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository identifies the supplied frozen contract as the feature-branch authority.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation remains a small public entry point consistent with this fixture repository.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's fixture purpose and public API premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is placed directly into a one-field mapping and serialized as JSON without semantic alteration.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract value is transformed into the required JSON artifact without introducing additional persisted data.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:3-12\",\"rationale\":\"The sole demonstrated consumer imports and invokes critique_branch directly, then reads the documented artifact.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public consumer path observes the intended artifact and schema.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Serialization and filesystem failures are not swallowed, so callers receive a blocking failure instead of false success; recoverable blocking is acceptable under the stated stakes.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failure behavior is explicit propagation and is proportionate to this recoverable fixture workflow.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the artifact, required public entry point, and permitted persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch, reads fidelity.json, and asserts that its complete decoded object contains only branch_contract with the supplied value.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The named acceptance path verifies every frozen obligation through the production entry point.\"},{\"evidence\":[{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract contains no documentation or operational procedure obligation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is explicitly outside this acceptance and the contract introduces no operational requirements.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The persisted contract permits only branch_contract and requires emission through critique_branch.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation's public behavior and persisted schema exactly match those requirements.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test independently confirms the public behavior and complete decoded field set.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on filename, entry point, value, and persisted schema.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:1-11\",\"rationale\":\"The implementation uses only standard-library serialization and a direct file write, with no unnecessary abstraction or configurability.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-12\",\"rationale\":\"One focused test cover",
+          "response_sha256": "98998efbb0e8cda747003ffca799144bda52eb179ac824d6a9591ddd67ac778e",
           "returncode": 0,
           "role": "census-behaviour",
           "sequence": 1,
-          "session_ref": "01a02abd-5062-7ac2-8eb8-d87f65e63333",
-          "stderr_excerpt": "2026-08-22T18:30:44.578401Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:31:51.043260Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "5b214e117d5cc2ce003c5a5775815e802a4943bce3d23269f7e9e3211669b869",
+          "session_ref": "01a02fe6-191c-7c70-a1c6-97b6317c6475",
+          "stderr_excerpt": "2026-08-23T18:33:23.603972Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:35.163096Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:39.174492Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:43.460550Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:20.272106Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:34:20.277030Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe6-191c-7c70-a1c6-97b6317c6475.1787510004018409790.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+          "stderr_sha256": "64717017ba3c3102fa2acba2695d98438224816505ed2fd76bb5749fc24f6129",
           "usage": {
-            "cached_input_tokens": 34304,
-            "input_tokens": 73266,
-            "output_tokens": 2698,
-            "reasoning_output_tokens": 872
+            "cached_input_tokens": 50432,
+            "input_tokens": 71512,
+            "output_tokens": 2173,
+            "reasoning_output_tokens": 914
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 77953,
+          "duration_ms": 63125,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5014-7410-b94e-a546ebbda0a4\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m tracing the contract obligations through repository call sites, history, and project instructions before assessing implementation fidelity.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1\\\",\\\"rationale\\\":\\\"Repository premise checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Transformation checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Consumer checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Failure and recovery checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance coverage checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1-4\\\",\\\"rationale\\\":\\\"Operational documentation checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted contract consistency checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1-4\\\",\\\"rationale\\\":\\\"Scope proportionality checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"execution\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract|Fidelity contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract|Fidelity contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-suney073/tree\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:30:22 2026 +0100\\n\\n    preserve public return contract\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex a243eaa..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -2,11 +2,10 @@ import json\\n from pathlib import Path\\n \\n \\n-def critique_branch(contract: str) -> Path:\\n+def critique_branch(contract: str) -> None:\\n     \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n     output = Path(\\\"fidelity.json\\\")\\n     output.write_",
-          "raw_sha256": "45b969061091ba66ceb9b896104c13d47ca82d61bc17c6e4dfe19ceaf1c2f2e5",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-191c-7862-bcb7-0a37edaae248\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking each of the three frozen obligations against the implementation, public entry point, and persisted shape.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress across the supplied contract and repository context.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied implementation is the starting point for tracing repository-level assumptions and consumers.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigating repository instructions, call sites, and history.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"The serialization transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigating exact persisted representation.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:6-12\\\",\\\"rationale\\\":\\\"The supplied test is a known consumer and acceptance exercise.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Tracing all consumers beyond the supplied touched files.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"The write path and its failure semantics are under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Assessing failure and recovery within the stated stakes.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance requires exercising O1 through critique_branch.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Checking the test against the named public entry point.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Operational and documentation implications are bounded by the stated three obligations.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Reviewing only in-scope operational implications.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The persisted public contract is checked for exact consistency.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Checking whether persistence silently adds or changes fields.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The change is being calibrated to a tiny trusted single-operator fixture.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Avoiding concerns outside the stated stakes.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"execution\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-oo7o5ch1/tree\\n\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follo",
+          "raw_sha256": "39696b05199a3bd4689ec785416218174f4b410c85524bdf897a8ecf04791232",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires fidelity.json, invocation through critique_branch, and no persisted field besides branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point writes fidelity.json containing exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the complete decoded artifact.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All frozen contract obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a focused fidelity fixture governed by the supplied frozen contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation preserves the established None-returning public signature while adding the required artifact emission.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's narrowly stated purpose and public entry-point premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The input contract is transformed directly into a JSON object with one branch_contract member and UTF-8 serialization.\"},{\"anchor\":\"repository/tests/test_fidelity.py:10-12\",\"rationale\":\"Decoding the emitted JSON must reproduce the exact expected mapping, covering serialization round-trip behavior.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract value is serialized without introducing additional persisted fields.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named consumer-facing acceptance requirement is specifically the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:3-9\",\"rationale\":\"The test imports and invokes that public entry point, then consumes the artifact at its expected path.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The named public consumer path is used directly and observes the expected artifact.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Filesystem and serialization failures are not swallowed, so a failed emission cannot be reported as a successful call.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failures propagate to the caller; no additional recovery behavior is required by the contract or stated stakes.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define every named output, entry-point, and persisted-content acceptance obligation.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch, confirms fidelity.json exists by reading it, and asserts its entire decoded object contains only branch_contract.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The focused acceptance test covers every named criterion through the production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"Repository documentation identifies the fixture and the frozen contract as its governing source.\"},{\"anchor\":\"plan:1-4\",\"rationale\":\"The small contract fully states the required artifact, invocation path, and persistence boundary; no further operational procedure is introduced.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation is proportionate to this tiny contract-driven fixture.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted public contract limits additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation retains the None return contract and persists a JSON object whose sole member is branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:10-12\",\"rationale\":\"The complete decoded object is compared for equality, preventing silent extra persisted fields",
-          "response_sha256": "004df68e2cad0d73f42d2a466a4e172cf8f8eb2a4353118f20f77a3325d41edd",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains exactly three obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The public entry point writes fidelity.json containing exactly the contracted branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the emitted object and its sole field.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen plan obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The implementation preserves the existing public function signature and introduces no dependencies beyond the standard library.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a small fidelity fixture governed by the frozen contract, matching the implementation's narrow purpose.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation fits the repository's minimal fixture structure and public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed directly into a JSON object under branch_contract, with JSON escaping handled by json.dumps and a deterministic trailing newline.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The serialization transformation preserves the supplied string and introduces no additional persisted data.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The known consumer reads fidelity.json as UTF-8 JSON and observes exactly the object emitted by critique_branch.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The emitted artifact satisfies the repository's exercised consumer contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Filesystem and serialization failures propagate to the caller instead of producing a false successful return; recoverable blocking is acceptable under the stated stakes.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failure behavior is appropriately fail-closed for this fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The test-relevant obligations require artifact emission through critique_branch and restriction of persisted additions to branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test calls critique_branch, confirms fidelity.json exists by reading it, and compares the complete decoded object with the sole permitted field.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The named public entry point exercises every supplied acceptance obligation.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The docstring accurately states the entry point's operational behavior, and the artifact location and encoding are explicit in the implementation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"No additional documentation or operational machinery is required for the three in-scope obligations.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The serialized mapping contains exactly branch_contract and no metadata or auxiliary fields.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"The complete decoded persisted object is asserted to contain only branch_contract.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on the persisted public shape.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:1-10\",\"rationale\":\"The implementation uses a direct standard-library write with no abstr",
+          "response_sha256": "d646ec6915afb86f512e553a990456082738f387491340ff6c76652bada99826",
           "returncode": 0,
           "role": "census-execution",
           "sequence": 2,
-          "session_ref": "01a02abd-5014-7410-b94e-a546ebbda0a4",
-          "stderr_excerpt": "2026-08-22T18:30:44.561402Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:32:01.517465Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "06bb8d447b7dfe4bfc41c62fa03bc07a775984a993062140d85d16048b8a824f",
+          "session_ref": "01a02fe6-191c-7862-bcb7-0a37edaae248",
+          "stderr_excerpt": "2026-08-23T18:33:23.635147Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:42.152404Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:52.657566Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:56.422720Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:25.718421Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+          "stderr_sha256": "cc376cf0a789bc65cb62e0bb731844cd50d6079f148a0bb74ccc41bf41567521",
           "usage": {
             "cached_input_tokens": 52480,
-            "input_tokens": 73245,
-            "output_tokens": 3023,
-            "reasoning_output_tokens": 1182
+            "input_tokens": 73665,
+            "output_tokens": 2617,
+            "reasoning_output_tokens": 655
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 54828,
+          "duration_ms": 40920,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5022-7fa1-b917-ef6dab8ad873\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files | sed -n '1,160p'\\nrg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true\\ngit log --oneline --follow -- reviewer.py\\ngit log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files | sed -n '1,160p'\\nrg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true\\ngit log --oneline --follow -- reviewer.py\\ngit log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"reviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:30:22 2026 +0100\\n\\n    preserve public return contract\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex a243eaa..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -2,11 +2,10 @@ import json\\n from pathlib import Path\\n \\n \\n-def critique_branch(contract: str) -> Path:\\n+def critique_branch(contract: str) -> None:\\n     \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n     output = Path(\\\"fidelity.json\\\")\\n     output.write_text(\\n         json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n         encoding=\\\"utf-8\\\",\\n     )\\n-    return output\\n\\ncommit 9819227fa3babee75392c8dec11fc8faf0db9053\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:36 2026 +0100\\n\\n    conform\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..a243eaa 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,12 @@\\n-def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+import json\\n+from pathlib import Path\\n+\\n+\\n+def critique_branch(contract: str) -> Path:\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n+    return output\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md\\ngit log -p --all -- README.md tests/",
-          "raw_sha256": "610c571f16ef9f28f005853f660dde9f383b558c58c44f939a2d9d7c96323cc2",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-1979-7763-8913-dc74b9d7e3d8\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"commit 8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:23:07 2026 +0100\\n\\n    Add conforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,11 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && for f in \\\"'$(rg --files -g '\\\"'\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'); do case \\\\\\\"\\\"'$f\\\" in *.pyc|*.png|*.jpg|*.gif) ;; *) nl -ba \\\"$f\\\";; esac; done'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && for f in \\\"'$(rg --files -g '\\\"'\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'); do case \\\\\\\"\\\"'$f\\\" in *.pyc|*.png|*.jpg|*.gif) ;; *) nl -ba \\\"$f\\\";; esac; done'\",\"aggregated_output\":\"README.md\\n     1\\t# Fidelity fixture\\n     2\\t\\n     3\\tThe feature branch must implement the frozen contract supplied by the reviewer.\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The frozen contract contains exactly three implementation obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The public entry point writes fidelity.json containing a single branch_contract field.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:6-12\\\",\\\"rationale\\\":\\\"The acceptance test invokes the public entry point and verifies the required file and exact persisted object.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"All three frozen-plan obligations are implemented and exercised.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The existing critique_branch pub",
+          "raw_sha256": "d209870badf33509d3dd926fb8688a8193f5638553661dacd3a935ccc170ff94",
           "requested_timeout_sec": 1800,
-          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The complete frozen contract contains one output obligation, one public-entry-point acceptance criterion, and one persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation writes fidelity.json through critique_branch and persists only branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test exercises the public entry point and verifies the required artifact and payload.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All frozen contract obligations are implemented without an undeclared deferral.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a focused fidelity fixture governed by the supplied frozen contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The changed implementation preserves the existing public function shape while replacing its placeholder behavior.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's narrow fixture purpose and public entry-point premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed directly into a JSON object with exactly the branch_contract field, then serialized as UTF-8.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-artifact transformation is direct and preserves the supplied value.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The repository's consumer reads fidelity.json as UTF-8 JSON and verifies the exact expected object.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The exercised consumer observes the artifact in the format produced by the implementation.\"},{\"evidence\":[{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract specifies no failure or recovery behavior beyond emitting the artifact and limiting its persisted payload.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required for this narrowly scoped fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the output, public-entry-point, and persisted-field acceptance requirements.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test invokes critique_branch, locates fidelity.json, parses it, and checks that branch_contract is the sole persisted field.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"Every named acceptance criterion is exercised through the required public production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository documentation already states the fixture's operational purpose and governing contract.\"},{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract introduces no deployment, configuration, migration, or operator-documentation obligation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"No additional operational documentation is required by this self-contained fixture change.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The emitted JSON contains exactly one key named branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Object equality verifies that the public artifact exposes no additional persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"The persisted schema, implementation behavior, and acceptance test agree exactly.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"A small public function and direct serialization implement the tiny immutable contract without speculative abstractions or configuration.\"},{\"anchor\":\"repository/tests/te",
-          "response_sha256": "d8c53cb1882c57414e79cb2fc47b6a45ea178fcaf04d11552e0d5ccae12be5be",
+          "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains exactly three implementation obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point writes fidelity.json containing a single branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the required file and exact persisted object.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen-plan obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The existing critique_branch public entry point remains the implementation boundary and now emits the artifact directly.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository describes this branch as a fidelity fixture governed by the supplied frozen contract, consistent with the reviewed implementation.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The change fits the repository's small fixture structure and preserves its public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed into a JSON object with exactly branch_contract, deterministically serialized, newline-terminated, and UTF-8 encoded.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Parsing the emitted JSON recovers exactly the expected branch_contract mapping.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-JSON transformation preserves the supplied value and introduces no additional persisted fields.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:3-10\",\"rationale\":\"The sole demonstrated consumer uses the public critique_branch entry point and reads the artifact at the contracted fidelity.json path.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public caller and artifact consumer agree with the implemented path and data shape.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission, public-entry-point exercise, and persisted shape, but no recovery or failure-handling behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery obligation exists for this trusted, sequential fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the named output, required public entry point, and exact persisted addition.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch itself, checks fidelity.json at the runtime working directory, and asserts the parsed object has only branch_contract.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The acceptance test covers every named criterion through the required public production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point's docstring and implementation directly describe and perform the contracted artifact emission without introducing operational configuration.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"No documentation or operational change is required by the three scoped obligations.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only the branch_contract addition.\"},{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The serialized object contains exactly the permitted branch_contract key.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Exact parsed-object equality detects missing, renamed, or additional persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"The plan, implementation, and acceptance assertion agree on the persi",
+          "response_sha256": "c43d1ce2f4e6b4befcd8a2841c199446dd6e51d504a8e74fc210fcb819e92570",
           "returncode": 0,
           "role": "census-integrity",
           "sequence": 3,
-          "session_ref": "01a02abd-5022-7fa1-b917-ef6dab8ad873",
-          "stderr_excerpt": "2026-08-22T18:30:44.553506Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:31:38.310426Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-          "stderr_sha256": "026d8d44c93689b0a349e0ad93599f3860555993de7b4010bdbbaa79e79ab9c4",
+          "session_ref": "01a02fe6-1979-7763-8913-dc74b9d7e3d8",
+          "stderr_excerpt": "2026-08-23T18:33:23.615556Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:25.117190Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe6-191c-7c70-a1c6-97b6317c6475.1787510004018409790.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-23T18:33:32.444625Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:37.970791Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:03.454110Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+          "stderr_sha256": "3fb1ebce27c6aa9066a13094cfcc68a4b9a1a1a9e5d11c8190da9cc9999bce76",
           "usage": {
-            "cached_input_tokens": 50432,
-            "input_tokens": 71320,
-            "output_tokens": 2135,
-            "reasoning_output_tokens": 854
+            "cached_input_tokens": 34304,
+            "input_tokens": 53420,
+            "output_tokens": 1687,
+            "reasoning_output_tokens": 450
           },
           "validation_issue": null,
           "validation_pointer": null
         },
         {
-          "duration_ms": 9221,
+          "duration_ms": 10074,
           "engine": "codex",
           "failure_detail_excerpt": "",
           "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
           "outcome": "completed",
           "provider_duration_ms": null,
-          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abe-8315-7fe1-b3c1-27bc953cfbc1\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"census\\\"}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":16202,\"cached_input_tokens\":0,\"output_tokens\":88,\"reasoning_output_tokens\":52}}\n",
-          "raw_sha256": "71d3de80675111166708e34e83843327444ac079fd61908c31c3a4f25ad33d6a",
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe7-0ef1-7b53-a9f3-cb054ff119a6\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"census\\\"}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":16309,\"cached_input_tokens\":0,\"output_tokens\":103,\"reasoning_output_tokens\":67}}\n",
+          "raw_sha256": "18815383aa4b34c71e541319f77aa1934568f204f72337a83b4b7a105e3ed002",
           "requested_timeout_sec": 1200,
           "response_excerpt": "{\"class_actions\":{},\"debt_outcomes\":[],\"governing_findings\":[],\"role\":\"census\"}",
           "response_sha256": "3b1988d93c3179fc33da38912cfae9f15135f85e0e867a8173285943d21e796e",
           "returncode": 0,
           "role": "consolidation",
           "sequence": 4,
-          "session_ref": "01a02abe-8315-7fe1-b3c1-27bc953cfbc1",
-          "stderr_excerpt": "2026-08-22T18:32:03.368710Z  WARN sqlx::query: slow statement: execution time exceeded alert threshold summary=\"SELECT MAX(threads.updated_at_ms), MAX(threads.recency_at_ms) FROM …\" db.statement=\"\\n\\nSELECT MAX(threads.updated_at_ms), MAX(threads.recency_at_ms) FROM threads\\n\" rows_affected=0 rows_returned=1 elapsed=1.21511241s elapsed_secs=1.21511241 slow_threshold=1s\n2026-08-22T18:32:10.844908Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-22T18:32:11.086750Z  WARN codex_core_plugins::manager: failed to warm remote plugin catalog cache error=failed to send remote plugin catalog request to https://chatgpt.com/backend-api/ps/plugins/list: error sending request for url (https://chatgpt.com/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=eyJzY29wZSI6IkdMT0JBTCIsIndvcmtzcGFjZV9pZCI6bnVsbCwiY3JlYXRvcl9hY2NvdW50X3VzZXJfaWQiOm51bGwsImNvbGxlY3Rpb24iOm51bGwsImluY2x1ZGVfcmVzdHJpY3RlZF9wbHVnaW5zIjp0cnVlLCJpbmNsdWRlX3VubGlzdGVkX2dsb2JhbF9wbHVnaW5zIjp0cnVlLCJlbGlnaWJsZV9wbGFuX3R5cGUiOiJwcm8iLCJlbmZvcmNlX3BsYW5fZWxpZ2liaWxpdHkiOmZhbHNlLCJyYW5rX2J5X3BvcHVsYXJpdHkiOnRydWUsImNvbnRpbnVhdGlvbiI6eyJkZXBsb3ltZW50X3R5cGUiOiJwcmltYXJ5IiwicXVlcnlfaWQiOiJyczQ6ZjhjMTIyZWMtYzRlMS00ZTIzLWE3NWUtMzFiYzM5M2NjYTVkOnMwUTcwS3c6MDpsZWFmLTY4OGZjZjczLTk4NjQtNDczYy05Mjc0LWQyZTYxYTk5YzZmYSIsImN1cnNvciI6IlpINjlkWEM0Z0x2dmVITHBoSlVLNmZqaTJOR2pQTlMwR3NWQ3BKVlpnX3ZVTmVFRmNaNWNkalM0Q0pncFJaWmd3TFRSVk1CQkpPMVdpYVFYVnkwdFZjSTNLcGhIaFZJQXE2Y1ZmOGFZSl8wQjNLQlg3QWJSZGZvZUtkelhoNXV1WEluc3ZUN3F0TmFQN1JwRnJHNzlTVmNiX1V3MU9DbDdPUHFzbFRIOVQxYWhmQ0Z3MkZfWkxTbjNPR2tBbHlRTzhvRUdnZEp3U2VnPSJ9fQ)\n",
-          "stderr_sha256": "dc365fe0cbd0d354335b1cd0e1680fdd3547e0bac0e0d153ee87424da0f820dd",
+          "session_ref": "01a02fe7-0ef1-7b53-a9f3-cb054ff119a6",
+          "stderr_excerpt": "2026-08-23T18:34:26.583527Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:35.973819Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:34:36.137112Z  WARN codex_core_plugins::manager: failed to warm remote plugin catalog cache error=failed to send remote plugin catalog request to https://chatgpt.com/backend-api/ps/plugins/list: error sending request for url (https://chatgpt.com/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=eyJzY29wZSI6IkdMT0JBTCIsIndvcmtzcGFjZV9pZCI6bnVsbCwiY3JlYXRvcl9hY2NvdW50X3VzZXJfaWQiOm51bGwsImNvbGxlY3Rpb24iOm51bGwsImluY2x1ZGVfcmVzdHJpY3RlZF9wbHVnaW5zIjp0cnVlLCJpbmNsdWRlX3VubGlzdGVkX2dsb2JhbF9wbHVnaW5zIjp0cnVlLCJlbGlnaWJsZV9wbGFuX3R5cGUiOiJwcm8iLCJlbmZvcmNlX3BsYW5fZWxpZ2liaWxpdHkiOmZhbHNlLCJyYW5rX2J5X3BvcHVsYXJpdHkiOnRydWUsImNvbnRpbnVhdGlvbiI6eyJkZXBsb3ltZW50X3R5cGUiOiJwcmltYXJ5IiwicXVlcnlfaWQiOiJyczQ6OTFjMGEzMmYtMjVhNS00NDNhLTgwMmItNTIzZDE3YzIwNjI4OmFXdXk2aVA6MDpsZWFmLTNiOGNkNmNjLTQ1MGMtNGJiZS1iNzQwLTI5ZDRlNjg3ZjZkYyIsImN1cnNvciI6IlpINjlkWEM0Z0x2dmVITHBoSlVLNmZqaTJOR2pQTlMwR3NWQ3BKVlpnX3ZVTmVFRmNaNWNkalM0Q0pncFJaWmdrX3JjcDhHMjhkeVUyblVDQURMeEtmRGoySWpWaklBT1ZFNUJaYklWNHhFZWczUnhEYkdkbTNNcDJtMkdmS3FNLWhIV3NrOUUxRkJXM3EzalRmNjVpM1dvQTc5VXZXU3VMOEdSN25aR3lqZU5aN2ctYk9lZ2RGWnA2M1pNU0JtcGxNUmFna3E2amR3PSJ9fQ)\n",
+          "stderr_sha256": "541e1219ed3498622d9a5b0e41d307465e53a905c0e00e133a916b4cb62a379a",
           "usage": {
             "cached_input_tokens": 0,
-            "input_tokens": 16202,
-            "output_tokens": 88,
-            "reasoning_output_tokens": 52
+            "input_tokens": 16309,
+            "output_tokens": 103,
+            "reasoning_output_tokens": 67
           },
           "validation_issue": null,
           "validation_pointer": null
@@ -1392,101 +1347,101 @@
         "already_raised": [],
         "attempt_ledger": [
           {
-            "duration_ms": 67479,
+            "duration_ms": 57739,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5062-7ac2-8eb8-d87f65e63333\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking the implementation against each frozen obligation, then following the public entry point’s repository call sites and history before deciding whether any finding is warranted.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress; repository context is being investigated.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The supplied public entry point is the blast-radius root for repository investigation.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress; call sites, instructions, and history are being checked.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-11\\\",\\\"rationale\\\":\\\"The contract-to-JSON transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:4-12\\\",\\\"rationale\\\":\\\"The supplied acceptance test is one known consumer of the public entry point.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-11\\\",\\\"rationale\\\":\\\"Filesystem failure behavior is under review within the stated trusted single-operator stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The named output, entry point, and persisted-field acceptance obligations are being mapped to tests.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:6-6\\\",\\\"rationale\\\":\\\"The public entry point documentation is being checked against operational behavior.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The persisted schema constraint is being checked for consistency with code and tests.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The small implementation is being assessed proportionally to the tiny trusted-operator branch stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"behaviour\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-suney073/tree\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance ",
-            "raw_sha256": "90b9376871d512b2626de6ad6e99950fbc59be5692f0f831a3bce0311d751ffc",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-191c-7c70-a1c6-97b6317c6475\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-oo7o5ch1/tree\\n8f8e424 Add conforming fidelity fixture\\n4afe149 Base fidelity fixture\\ncommit 8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:23:07 2026 +0100\\n\\n    Add conforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,11 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' | sort && git status --short && git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' | sort && git status --short && git ls-tree -r --name-only HEAD\\\"\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\nREADME.md\\n M README.md\\n M reviewer.py\\n M tests/test_fidelity.py\\nREADME.md\\nreviewer.py\\ntests/test_fidelity.py\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md && git log -p --follow -- README.md && git diff -- README.md'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md && git log -p --follow -- README.md && git diff -- README.md'\",\"aggregated_output\":\"/usr/bin/keychain: 362: cannot create /home/andy/.keychain/ANDY-lockf.8: Read-only file system\\n     1\\t# Fidelity fixture\\n     2\\t\\n     3\\tThe feature branch must implement the frozen contract supplied by the reviewer.\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acce",
+            "raw_sha256": "f1823d14e2ad23c8ee921ddc53b527d683d172b4f91ea6c1c6d51d1ca584c948",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires the named artifact, invocation through the public entry point, and exactly one persisted field.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation writes fidelity.json from critique_branch and serializes only branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the resulting artifact and exact object contents.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"Every frozen implementation obligation is present.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The established public signature continues to return None while gaining the required filesystem side effect.\"},{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository describes the feature branch as implementing the reviewer-supplied frozen contract.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation fits the repository's small fixture and preserves the pre-existing public return contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"The input contract is transformed directly into a JSON object containing only branch_contract, with deterministic key ordering and UTF-8 output.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-JSON transformation matches the persisted schema.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:4-12\",\"rationale\":\"The known consumer imports critique_branch, invokes it from a controlled working directory, and reads the documented fidelity.json output.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public entry point and artifact are consumed consistently.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Filesystem failures naturally propagate from write_text, preventing the caller from receiving a false success; no additional recovery behavior is required by the contract.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Fail-fast write behavior is proportionate to the trusted single-operator stakes, where recoverable blocking is acceptable.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The acceptance obligations cover artifact creation, public-entry-point exercise, and the restricted persisted schema.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch itself and validates both the filename and exact decoded JSON object.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"All named acceptance criteria are exercised through the required public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:6-6\",\"rationale\":\"The public function docstring accurately describes its artifact-emission behavior.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"Repository-level documentation identifies this as the frozen-contract fidelity fixture; the contract supplies the exact operational requirements.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation is sufficient for this deliberately tiny fixture.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The frozen persisted contract limits additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:9-9\",\"rationale\":\"The emitted JSON object contains exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"The test's exact dictionary equality detects extra persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on the persisted contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation uses a single direct write with no speculative abstraction or configurability.\"},{\"anchor\":\"repository/tes",
-            "response_sha256": "b2adf0745a9a4d93882dc474426493a3886fb1f45f4737ef48fdb437d5384781",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires fidelity.json, public-entry-point exercise, and no persisted field beyond branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public function writes fidelity.json containing exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public function and verifies the emitted artifact and field set.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen contract obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:3\",\"rationale\":\"The repository identifies the supplied frozen contract as the feature-branch authority.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation remains a small public entry point consistent with this fixture repository.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's fixture purpose and public API premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is placed directly into a one-field mapping and serialized as JSON without semantic alteration.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract value is transformed into the required JSON artifact without introducing additional persisted data.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:3-12\",\"rationale\":\"The sole demonstrated consumer imports and invokes critique_branch directly, then reads the documented artifact.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public consumer path observes the intended artifact and schema.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Serialization and filesystem failures are not swallowed, so callers receive a blocking failure instead of false success; recoverable blocking is acceptable under the stated stakes.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failure behavior is explicit propagation and is proportionate to this recoverable fixture workflow.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the artifact, required public entry point, and permitted persisted field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch, reads fidelity.json, and asserts that its complete decoded object contains only branch_contract with the supplied value.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The named acceptance path verifies every frozen obligation through the production entry point.\"},{\"evidence\":[{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract contains no documentation or operational procedure obligation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"Documentation accuracy is explicitly outside this acceptance and the contract introduces no operational requirements.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The persisted contract permits only branch_contract and requires emission through critique_branch.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation's public behavior and persisted schema exactly match those requirements.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test independently confirms the public behavior and complete decoded field set.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on filename, entry point, value, and persisted schema.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:1-11\",\"rationale\":\"The implementation uses only standard-library serialization and a direct file write, with no unnecessary abstraction or configurability.\"},{\"anchor\":\"repository/tests/test_fidelity.py:1-12\",\"rationale\":\"One focused test cover",
+            "response_sha256": "98998efbb0e8cda747003ffca799144bda52eb179ac824d6a9591ddd67ac778e",
             "returncode": 0,
             "role": "census-behaviour",
             "sequence": 1,
-            "session_ref": "01a02abd-5062-7ac2-8eb8-d87f65e63333",
-            "stderr_excerpt": "2026-08-22T18:30:44.578401Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:31:51.043260Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "5b214e117d5cc2ce003c5a5775815e802a4943bce3d23269f7e9e3211669b869",
+            "session_ref": "01a02fe6-191c-7c70-a1c6-97b6317c6475",
+            "stderr_excerpt": "2026-08-23T18:33:23.603972Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:35.163096Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:39.174492Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:43.460550Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:20.272106Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:34:20.277030Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at AbsolutePathBuf(\"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe6-191c-7c70-a1c6-97b6317c6475.1787510004018409790.sh\"): Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n",
+            "stderr_sha256": "64717017ba3c3102fa2acba2695d98438224816505ed2fd76bb5749fc24f6129",
             "usage": {
-              "cached_input_tokens": 34304,
-              "input_tokens": 73266,
-              "output_tokens": 2698,
-              "reasoning_output_tokens": 872
+              "cached_input_tokens": 50432,
+              "input_tokens": 71512,
+              "output_tokens": 2173,
+              "reasoning_output_tokens": 914
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 77953,
+            "duration_ms": 63125,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5014-7410-b94e-a546ebbda0a4\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m tracing the contract obligations through repository call sites, history, and project instructions before assessing implementation fidelity.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1\\\",\\\"rationale\\\":\\\"Repository premise checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Transformation checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Consumer checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2\\\",\\\"rationale\\\":\\\"Failure and recovery checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance coverage checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1-4\\\",\\\"rationale\\\":\\\"Operational documentation checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"Persisted contract consistency checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:1-4\\\",\\\"rationale\\\":\\\"Scope proportionality checks are in progress.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigation in progress.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"execution\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract|Fidelity contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract|Fidelity contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-suney073/tree\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:30:22 2026 +0100\\n\\n    preserve public return contract\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex a243eaa..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -2,11 +2,10 @@ import json\\n from pathlib import Path\\n \\n \\n-def critique_branch(contract: str) -> Path:\\n+def critique_branch(contract: str) -> None:\\n     \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n     output = Path(\\\"fidelity.json\\\")\\n     output.write_",
-            "raw_sha256": "45b969061091ba66ceb9b896104c13d47ca82d61bc17c6e4dfe19ceaf1c2f2e5",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-191c-7862-bcb7-0a37edaae248\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"I’m checking each of the three frozen obligations against the implementation, public entry point, and persisted shape.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Review in progress across the supplied contract and repository context.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-10\\\",\\\"rationale\\\":\\\"The supplied implementation is the starting point for tracing repository-level assumptions and consumers.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigating repository instructions, call sites, and history.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"The serialization transformation is under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Investigating exact persisted representation.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:6-12\\\",\\\"rationale\\\":\\\"The supplied test is a known consumer and acceptance exercise.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Tracing all consumers beyond the supplied touched files.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:7-10\\\",\\\"rationale\\\":\\\"The write path and its failure semantics are under review.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Assessing failure and recovery within the stated stakes.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:3\\\",\\\"rationale\\\":\\\"Acceptance requires exercising O1 through critique_branch.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Checking the test against the named public entry point.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"Operational and documentation implications are bounded by the stated three obligations.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Reviewing only in-scope operational implications.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The persisted public contract is checked for exact consistency.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Checking whether persistence silently adds or changes fields.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The change is being calibrated to a tiny trusted single-operator fixture.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Avoiding concerns outside the stated stakes.\\\"}],\\\"findings\\\":[],\\\"lane\\\":\\\"execution\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"pwd && rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"/mnt/c/Users/andy/AppData/Local/Temp/paranoia-wt-oo7o5ch1/tree\\n\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'git log --oneline --follo",
+            "raw_sha256": "39696b05199a3bd4689ec785416218174f4b410c85524bdf897a8ecf04791232",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract requires fidelity.json, invocation through critique_branch, and no persisted field besides branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point writes fidelity.json containing exactly the branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the complete decoded artifact.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All frozen contract obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a focused fidelity fixture governed by the supplied frozen contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation preserves the established None-returning public signature while adding the required artifact emission.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's narrowly stated purpose and public entry-point premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The input contract is transformed directly into a JSON object with one branch_contract member and UTF-8 serialization.\"},{\"anchor\":\"repository/tests/test_fidelity.py:10-12\",\"rationale\":\"Decoding the emitted JSON must reproduce the exact expected mapping, covering serialization round-trip behavior.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract value is serialized without introducing additional persisted fields.\"},{\"evidence\":[{\"anchor\":\"plan:3\",\"rationale\":\"The named consumer-facing acceptance requirement is specifically the public critique_branch entry point.\"},{\"anchor\":\"repository/tests/test_fidelity.py:3-9\",\"rationale\":\"The test imports and invokes that public entry point, then consumes the artifact at its expected path.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The named public consumer path is used directly and observes the expected artifact.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-11\",\"rationale\":\"Filesystem and serialization failures are not swallowed, so a failed emission cannot be reported as a successful call.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failures propagate to the caller; no additional recovery behavior is required by the contract or stated stakes.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define every named output, entry-point, and persisted-content acceptance obligation.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch, confirms fidelity.json exists by reading it, and asserts its entire decoded object contains only branch_contract.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The focused acceptance test covers every named criterion through the production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"Repository documentation identifies the fixture and the frozen contract as its governing source.\"},{\"anchor\":\"plan:1-4\",\"rationale\":\"The small contract fully states the required artifact, invocation path, and persistence boundary; no further operational procedure is introduced.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"Documentation is proportionate to this tiny contract-driven fixture.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted public contract limits additions to branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation retains the None return contract and persists a JSON object whose sole member is branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:10-12\",\"rationale\":\"The complete decoded object is compared for equality, preventing silent extra persisted fields",
-            "response_sha256": "004df68e2cad0d73f42d2a466a4e172cf8f8eb2a4353118f20f77a3325d41edd",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The contract contains exactly three obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The public entry point writes fidelity.json containing exactly the contracted branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the emitted object and its sole field.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen plan obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The implementation preserves the existing public function signature and introduces no dependencies beyond the standard library.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a small fidelity fixture governed by the frozen contract, matching the implementation's narrow purpose.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation fits the repository's minimal fixture structure and public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed directly into a JSON object under branch_contract, with JSON escaping handled by json.dumps and a deterministic trailing newline.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The serialization transformation preserves the supplied string and introduces no additional persisted data.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The known consumer reads fidelity.json as UTF-8 JSON and observes exactly the object emitted by critique_branch.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The emitted artifact satisfies the repository's exercised consumer contract.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"Filesystem and serialization failures propagate to the caller instead of producing a false successful return; recoverable blocking is acceptable under the stated stakes.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"covered\",\"summary\":\"Failure behavior is appropriately fail-closed for this fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The test-relevant obligations require artifact emission through critique_branch and restriction of persisted additions to branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test calls critique_branch, confirms fidelity.json exists by reading it, and compares the complete decoded object with the sole permitted field.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The named public entry point exercises every supplied acceptance obligation.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-10\",\"rationale\":\"The docstring accurately states the entry point's operational behavior, and the artifact location and encoding are explicit in the implementation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"covered\",\"summary\":\"No additional documentation or operational machinery is required for the three in-scope obligations.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The serialized mapping contains exactly branch_contract and no metadata or auxiliary fields.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"The complete decoded persisted object is asserted to contain only branch_contract.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"Plan, implementation, and acceptance test agree on the persisted public shape.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:1-10\",\"rationale\":\"The implementation uses a direct standard-library write with no abstr",
+            "response_sha256": "d646ec6915afb86f512e553a990456082738f387491340ff6c76652bada99826",
             "returncode": 0,
             "role": "census-execution",
             "sequence": 2,
-            "session_ref": "01a02abd-5014-7410-b94e-a546ebbda0a4",
-            "stderr_excerpt": "2026-08-22T18:30:44.561402Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:32:01.517465Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "06bb8d447b7dfe4bfc41c62fa03bc07a775984a993062140d85d16048b8a824f",
+            "session_ref": "01a02fe6-191c-7862-bcb7-0a37edaae248",
+            "stderr_excerpt": "2026-08-23T18:33:23.635147Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:42.152404Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:52.657566Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:56.422720Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:25.718421Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+            "stderr_sha256": "cc376cf0a789bc65cb62e0bb731844cd50d6079f148a0bb74ccc41bf41567521",
             "usage": {
               "cached_input_tokens": 52480,
-              "input_tokens": 73245,
-              "output_tokens": 3023,
-              "reasoning_output_tokens": 1182
+              "input_tokens": 73665,
+              "output_tokens": 2617,
+              "reasoning_output_tokens": 655
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 54828,
+            "duration_ms": 40920,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abd-5022-7fa1-b917-ef6dab8ad873\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . && git log --oneline --follow -- reviewer.py && git log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":1,\"status\":\"failed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files | sed -n '1,160p'\\nrg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true\\ngit log --oneline --follow -- reviewer.py\\ngit log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files | sed -n '1,160p'\\nrg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true\\ngit log --oneline --follow -- reviewer.py\\ngit log -p --follow -- reviewer.py\\\"\",\"aggregated_output\":\"reviewer.py\\nREADME.md\\ntests/test_fidelity.py\\n95a9c63 preserve public return contract\\n9819227 conform\\n521b4a1 initial\\ncommit 95a9c6370b1e4cd51222b44f7ede083be8e350b3\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:30:22 2026 +0100\\n\\n    preserve public return contract\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex a243eaa..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -2,11 +2,10 @@ import json\\n from pathlib import Path\\n \\n \\n-def critique_branch(contract: str) -> Path:\\n+def critique_branch(contract: str) -> None:\\n     \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n     output = Path(\\\"fidelity.json\\\")\\n     output.write_text(\\n         json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n         encoding=\\\"utf-8\\\",\\n     )\\n-    return output\\n\\ncommit 9819227fa3babee75392c8dec11fc8faf0db9053\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:36 2026 +0100\\n\\n    conform\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..a243eaa 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,12 @@\\n-def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+import json\\n+from pathlib import Path\\n+\\n+\\n+def critique_branch(contract: str) -> Path:\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n+    return output\\n\\ncommit 521b4a12adc83156e5380153f51a5ca1a7c60f66\\nAuthor: acceptance <acceptance@example.com>\\nDate:   Sat Aug 22 19:23:21 2026 +0100\\n\\n    initial\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_2\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'nl -ba README.md\\ngit log -p --all -- README.md tests/",
-            "raw_sha256": "610c571f16ef9f28f005853f660dde9f383b558c58c44f939a2d9d7c96323cc2",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe6-1979-7763-8913-dc74b9d7e3d8\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g 'AGENTS.md' -g 'CLAUDE.md' -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && rg -n \\\\\\\"critique_branch|fidelity\\\\\\\\.json|branch_contract\\\\\\\" -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' . || true && git log --follow -p -- reviewer.py\\\"\",\"aggregated_output\":\"commit 8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:23:07 2026 +0100\\n\\n    Add conforming fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nindex 67cf633..09baaf3 100644\\n--- a/reviewer.py\\n+++ b/reviewer.py\\n@@ -1,2 +1,11 @@\\n+import json\\n+from pathlib import Path\\n+\\n+\\n def critique_branch(contract: str) -> None:\\n-    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n+    \\\"\\\"\\\"Emit the contracted artifact through the public entry point.\\\"\\\"\\\"\\n+    output = Path(\\\"fidelity.json\\\")\\n+    output.write_text(\\n+        json.dumps({\\\"branch_contract\\\": contract}, sort_keys=True) + \\\"\\\\n\\\",\\n+        encoding=\\\"utf-8\\\",\\n+    )\\n\\ncommit 4afe14967bd0ef81ab2a68d8c3abe6a3d372f209\\nAuthor: Codex Acceptance <acceptance@example.invalid>\\nDate:   Sun Aug 23 19:22:10 2026 +0100\\n\\n    Base fidelity fixture\\n\\ndiff --git a/reviewer.py b/reviewer.py\\nnew file mode 100644\\nindex 0000000..67cf633\\n--- /dev/null\\n+++ b/reviewer.py\\n@@ -0,0 +1,2 @@\\n+def critique_branch(contract: str) -> None:\\n+    \\\"\\\"\\\"Placeholder public entry point.\\\"\\\"\\\"\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && for f in \\\"'$(rg --files -g '\\\"'\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'); do case \\\\\\\"\\\"'$f\\\" in *.pyc|*.png|*.jpg|*.gif) ;; *) nl -ba \\\"$f\\\";; esac; done'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc \\\"rg --files -g '\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"' && for f in \\\"'$(rg --files -g '\\\"'\\\"'!reviewer.py'\\\"' -g '\\\"'!tests/test_fidelity.py'\\\"'); do case \\\\\\\"\\\"'$f\\\" in *.pyc|*.png|*.jpg|*.gif) ;; *) nl -ba \\\"$f\\\";; esac; done'\",\"aggregated_output\":\"README.md\\n     1\\t# Fidelity fixture\\n     2\\t\\n     3\\tThe feature branch must implement the frozen contract supplied by the reviewer.\\n\",\"exit_code\":0,\"status\":\"completed\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_2\",\"type\":\"agent_message\",\"text\":\"{\\\"class_assessments\\\":[],\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:2-4\\\",\\\"rationale\\\":\\\"The frozen contract contains exactly three implementation obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\\\"},{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The public entry point writes fidelity.json containing a single branch_contract field.\\\"},{\\\"anchor\\\":\\\"repository/tests/test_fidelity.py:6-12\\\",\\\"rationale\\\":\\\"The acceptance test invokes the public entry point and verifies the required file and exact persisted object.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"All three frozen-plan obligations are implemented and exercised.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/reviewer.py:5-11\\\",\\\"rationale\\\":\\\"The existing critique_branch pub",
+            "raw_sha256": "d209870badf33509d3dd926fb8688a8193f5638553661dacd3a935ccc170ff94",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1800,
-            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The complete frozen contract contains one output obligation, one public-entry-point acceptance criterion, and one persisted-field restriction.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The implementation writes fidelity.json through critique_branch and persists only branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test exercises the public entry point and verifies the required artifact and payload.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All frozen contract obligations are implemented without an undeclared deferral.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository identifies itself as a focused fidelity fixture governed by the supplied frozen contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The changed implementation preserves the existing public function shape while replacing its placeholder behavior.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The implementation matches the repository's narrow fixture purpose and public entry-point premise.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed directly into a JSON object with exactly the branch_contract field, then serialized as UTF-8.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-artifact transformation is direct and preserves the supplied value.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The repository's consumer reads fidelity.json as UTF-8 JSON and verifies the exact expected object.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The exercised consumer observes the artifact in the format produced by the implementation.\"},{\"evidence\":[{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract specifies no failure or recovery behavior beyond emitting the artifact and limiting its persisted payload.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery behavior is required for this narrowly scoped fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the output, public-entry-point, and persisted-field acceptance requirements.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test invokes critique_branch, locates fidelity.json, parses it, and checks that branch_contract is the sole persisted field.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"Every named acceptance criterion is exercised through the required public production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository documentation already states the fixture's operational purpose and governing contract.\"},{\"anchor\":\"plan:1-4\",\"rationale\":\"The frozen contract introduces no deployment, configuration, migration, or operator-documentation obligation.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"No additional operational documentation is required by this self-contained fixture change.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The emitted JSON contains exactly one key named branch_contract.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Object equality verifies that the public artifact exposes no additional persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"The persisted schema, implementation behavior, and acceptance test agree exactly.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"A small public function and direct serialization implement the tiny immutable contract without speculative abstractions or configuration.\"},{\"anchor\":\"repository/tests/te",
-            "response_sha256": "d8c53cb1882c57414e79cb2fc47b6a45ea178fcaf04d11552e0d5ccae12be5be",
+            "response_excerpt": "{\"class_assessments\":[],\"coverage\":[{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract contains exactly three implementation obligations: emit fidelity.json, exercise emission through critique_branch, and persist only branch_contract.\"},{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point writes fidelity.json containing a single branch_contract field.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The acceptance test invokes the public entry point and verifies the required file and exact persisted object.\"}],\"finding_ids\":[],\"id\":\"artifact-complete\",\"status\":\"covered\",\"summary\":\"All three frozen-plan obligations are implemented and exercised.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The existing critique_branch public entry point remains the implementation boundary and now emits the artifact directly.\"},{\"anchor\":\"repository/README.md:1-3\",\"rationale\":\"The repository describes this branch as a fidelity fixture governed by the supplied frozen contract, consistent with the reviewed implementation.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The change fits the repository's small fixture structure and preserves its public entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:7-10\",\"rationale\":\"The input contract is transformed into a JSON object with exactly branch_contract, deterministically serialized, newline-terminated, and UTF-8 encoded.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Parsing the emitted JSON recovers exactly the expected branch_contract mapping.\"}],\"finding_ids\":[],\"id\":\"transformations\",\"status\":\"covered\",\"summary\":\"The contract-to-JSON transformation preserves the supplied value and introduces no additional persisted fields.\"},{\"evidence\":[{\"anchor\":\"repository/tests/test_fidelity.py:3-10\",\"rationale\":\"The sole demonstrated consumer uses the public critique_branch entry point and reads the artifact at the contracted fidelity.json path.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"covered\",\"summary\":\"The public caller and artifact consumer agree with the implemented path and data shape.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"The frozen contract specifies emission, public-entry-point exercise, and persisted shape, but no recovery or failure-handling behavior.\"}],\"finding_ids\":[],\"id\":\"failure-recovery\",\"status\":\"not_applicable\",\"summary\":\"No failure-recovery obligation exists for this trusted, sequential fixture.\"},{\"evidence\":[{\"anchor\":\"plan:2-4\",\"rationale\":\"These lines define the named output, required public entry point, and exact persisted addition.\"},{\"anchor\":\"repository/tests/test_fidelity.py:6-12\",\"rationale\":\"The test exercises critique_branch itself, checks fidelity.json at the runtime working directory, and asserts the parsed object has only branch_contract.\"}],\"finding_ids\":[],\"id\":\"tests-acceptance\",\"status\":\"covered\",\"summary\":\"The acceptance test covers every named criterion through the required public production entry point.\"},{\"evidence\":[{\"anchor\":\"repository/reviewer.py:5-11\",\"rationale\":\"The public entry point's docstring and implementation directly describe and perform the contracted artifact emission without introducing operational configuration.\"}],\"finding_ids\":[],\"id\":\"docs-operations\",\"status\":\"not_applicable\",\"summary\":\"No documentation or operational change is required by the three scoped obligations.\"},{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The persisted contract permits only the branch_contract addition.\"},{\"anchor\":\"repository/reviewer.py:8-10\",\"rationale\":\"The serialized object contains exactly the permitted branch_contract key.\"},{\"anchor\":\"repository/tests/test_fidelity.py:9-12\",\"rationale\":\"Exact parsed-object equality detects missing, renamed, or additional persisted fields.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"The plan, implementation, and acceptance assertion agree on the persi",
+            "response_sha256": "c43d1ce2f4e6b4befcd8a2841c199446dd6e51d504a8e74fc210fcb819e92570",
             "returncode": 0,
             "role": "census-integrity",
             "sequence": 3,
-            "session_ref": "01a02abd-5022-7fa1-b917-ef6dab8ad873",
-            "stderr_excerpt": "2026-08-22T18:30:44.553506Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-22T18:31:38.310426Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-            "stderr_sha256": "026d8d44c93689b0a349e0ad93599f3860555993de7b4010bdbbaa79e79ab9c4",
+            "session_ref": "01a02fe6-1979-7763-8913-dc74b9d7e3d8",
+            "stderr_excerpt": "2026-08-23T18:33:23.615556Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:25.117190Z  WARN codex_core::shell_snapshot: Failed to delete shell snapshot at \"/mnt/c/Users/andy/.codex/shell_snapshots/01a02fe6-191c-7c70-a1c6-97b6317c6475.1787510004018409790.sh\": Os { code: 2, kind: NotFound, message: \"No such file or directory\" }\n2026-08-23T18:33:32.444625Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:33:37.970791Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:03.454110Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+            "stderr_sha256": "3fb1ebce27c6aa9066a13094cfcc68a4b9a1a1a9e5d11c8190da9cc9999bce76",
             "usage": {
-              "cached_input_tokens": 50432,
-              "input_tokens": 71320,
-              "output_tokens": 2135,
-              "reasoning_output_tokens": 854
+              "cached_input_tokens": 34304,
+              "input_tokens": 53420,
+              "output_tokens": 1687,
+              "reasoning_output_tokens": 450
             },
             "validation_issue": null,
             "validation_pointer": null
           },
           {
-            "duration_ms": 9221,
+            "duration_ms": 10074,
             "engine": "codex",
             "failure_detail_excerpt": "",
             "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
             "outcome": "completed",
             "provider_duration_ms": null,
-            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02abe-8315-7fe1-b3c1-27bc953cfbc1\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"census\\\"}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":16202,\"cached_input_tokens\":0,\"output_tokens\":88,\"reasoning_output_tokens\":52}}\n",
-            "raw_sha256": "71d3de80675111166708e34e83843327444ac079fd61908c31c3a4f25ad33d6a",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02fe7-0ef1-7b53-a9f3-cb054ff119a6\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"census\\\"}\"}}\n{\"type\":\"turn.completed\",\"usage\":{\"input_tokens\":16309,\"cached_input_tokens\":0,\"output_tokens\":103,\"reasoning_output_tokens\":67}}\n",
+            "raw_sha256": "18815383aa4b34c71e541319f77aa1934568f204f72337a83b4b7a105e3ed002",
             "rejected_reply_excerpt": null,
             "rejected_reply_sha256": null,
             "requested_timeout_sec": 1200,
@@ -1495,25 +1450,26 @@
             "returncode": 0,
             "role": "consolidation",
             "sequence": 4,
-            "session_ref": "01a02abe-8315-7fe1-b3c1-27bc953cfbc1",
-            "stderr_excerpt": "2026-08-22T18:32:03.368710Z  WARN sqlx::query: slow statement: execution time exceeded alert threshold summary=\"SELECT MAX(threads.updated_at_ms), MAX(threads.recency_at_ms) FROM …\" db.statement=\"\\n\\nSELECT MAX(threads.updated_at_ms), MAX(threads.recency_at_ms) FROM threads\\n\" rows_affected=0 rows_returned=1 elapsed=1.21511241s elapsed_secs=1.21511241 slow_threshold=1s\n2026-08-22T18:32:10.844908Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-22T18:32:11.086750Z  WARN codex_core_plugins::manager: failed to warm remote plugin catalog cache error=failed to send remote plugin catalog request to https://chatgpt.com/backend-api/ps/plugins/list: error sending request for url (https://chatgpt.com/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=eyJzY29wZSI6IkdMT0JBTCIsIndvcmtzcGFjZV9pZCI6bnVsbCwiY3JlYXRvcl9hY2NvdW50X3VzZXJfaWQiOm51bGwsImNvbGxlY3Rpb24iOm51bGwsImluY2x1ZGVfcmVzdHJpY3RlZF9wbHVnaW5zIjp0cnVlLCJpbmNsdWRlX3VubGlzdGVkX2dsb2JhbF9wbHVnaW5zIjp0cnVlLCJlbGlnaWJsZV9wbGFuX3R5cGUiOiJwcm8iLCJlbmZvcmNlX3BsYW5fZWxpZ2liaWxpdHkiOmZhbHNlLCJyYW5rX2J5X3BvcHVsYXJpdHkiOnRydWUsImNvbnRpbnVhdGlvbiI6eyJkZXBsb3ltZW50X3R5cGUiOiJwcmltYXJ5IiwicXVlcnlfaWQiOiJyczQ6ZjhjMTIyZWMtYzRlMS00ZTIzLWE3NWUtMzFiYzM5M2NjYTVkOnMwUTcwS3c6MDpsZWFmLTY4OGZjZjczLTk4NjQtNDczYy05Mjc0LWQyZTYxYTk5YzZmYSIsImN1cnNvciI6IlpINjlkWEM0Z0x2dmVITHBoSlVLNmZqaTJOR2pQTlMwR3NWQ3BKVlpnX3ZVTmVFRmNaNWNkalM0Q0pncFJaWmd3TFRSVk1CQkpPMVdpYVFYVnkwdFZjSTNLcGhIaFZJQXE2Y1ZmOGFZSl8wQjNLQlg3QWJSZGZvZUtkelhoNXV1WEluc3ZUN3F0TmFQN1JwRnJHNzlTVmNiX1V3MU9DbDdPUHFzbFRIOVQxYWhmQ0Z3MkZfWkxTbjNPR2tBbHlRTzhvRUdnZEp3U2VnPSJ9fQ)\n",
-            "stderr_sha256": "dc365fe0cbd0d354335b1cd0e1680fdd3547e0bac0e0d153ee87424da0f820dd",
+            "session_ref": "01a02fe7-0ef1-7b53-a9f3-cb054ff119a6",
+            "stderr_excerpt": "2026-08-23T18:34:26.583527Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T18:34:35.973819Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n2026-08-23T18:34:36.137112Z  WARN codex_core_plugins::manager: failed to warm remote plugin catalog cache error=failed to send remote plugin catalog request to https://chatgpt.com/backend-api/ps/plugins/list: error sending request for url (https://chatgpt.com/backend-api/ps/plugins/list?scope=GLOBAL&limit=200&pageToken=eyJzY29wZSI6IkdMT0JBTCIsIndvcmtzcGFjZV9pZCI6bnVsbCwiY3JlYXRvcl9hY2NvdW50X3VzZXJfaWQiOm51bGwsImNvbGxlY3Rpb24iOm51bGwsImluY2x1ZGVfcmVzdHJpY3RlZF9wbHVnaW5zIjp0cnVlLCJpbmNsdWRlX3VubGlzdGVkX2dsb2JhbF9wbHVnaW5zIjp0cnVlLCJlbGlnaWJsZV9wbGFuX3R5cGUiOiJwcm8iLCJlbmZvcmNlX3BsYW5fZWxpZ2liaWxpdHkiOmZhbHNlLCJyYW5rX2J5X3BvcHVsYXJpdHkiOnRydWUsImNvbnRpbnVhdGlvbiI6eyJkZXBsb3ltZW50X3R5cGUiOiJwcmltYXJ5IiwicXVlcnlfaWQiOiJyczQ6OTFjMGEzMmYtMjVhNS00NDNhLTgwMmItNTIzZDE3YzIwNjI4OmFXdXk2aVA6MDpsZWFmLTNiOGNkNmNjLTQ1MGMtNGJiZS1iNzQwLTI5ZDRlNjg3ZjZkYyIsImN1cnNvciI6IlpINjlkWEM0Z0x2dmVITHBoSlVLNmZqaTJOR2pQTlMwR3NWQ3BKVlpnX3ZVTmVFRmNaNWNkalM0Q0pncFJaWmdrX3JjcDhHMjhkeVUyblVDQURMeEtmRGoySWpWaklBT1ZFNUJaYklWNHhFZWczUnhEYkdkbTNNcDJtMkdmS3FNLWhIV3NrOUUxRkJXM3EzalRmNjVpM1dvQTc5VXZXU3VMOEdSN25aR3lqZU5aN2ctYk9lZ2RGWnA2M1pNU0JtcGxNUmFna3E2amR3PSJ9fQ)\n",
+            "stderr_sha256": "541e1219ed3498622d9a5b0e41d307465e53a905c0e00e133a916b4cb62a379a",
             "usage": {
               "cached_input_tokens": 0,
-              "input_tokens": 16202,
-              "output_tokens": 88,
-              "reasoning_output_tokens": 52
+              "input_tokens": 16309,
+              "output_tokens": 103,
+              "reasoning_output_tokens": 67
             },
             "validation_issue": null,
             "validation_pointer": null
           }
         ],
-        "base_id": "521b4a12adc83156e5380153f51a5ca1a7c60f66",
-        "duration_ms": 9221,
+        "base_id": "4afe14967bd0ef81ab2a68d8c3abe6a3d372f209",
+        "correction_gates": [],
+        "duration_ms": 10074,
         "engine": "codex",
         "error": false,
-        "head_id": "95a9c6370b1e4cd51222b44f7ede083be8e350b3",
-        "lineage": "issue-63-exact-conforming-v2",
+        "head_id": "8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a",
+        "lineage": "issue-68-plan-digest-conforming-v3",
         "mode": "converge-packet",
         "model": "gpt-5.6-sol",
         "plan_contract_reused": false,
@@ -1522,10 +1478,11 @@
         "plan_path": null,
         "plan_text": "# Fidelity contract\nO1: emit fidelity.json\nA1: exercise O1 through the public critique_branch entry point\nP1: persisted additions are limited to branch_contract",
         "rejected_payloads": [],
+        "rendered_trailer": "LINEAGE: issue-68-plan-digest-conforming-v3 (rounds recorded: 1)\nPLAN-DIGEST: ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5\nCLASS-REGISTER: staged census parsed — NONE\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nSTRUCTURAL-PHASE: clear\nSTRUCTURAL-DEBT: 0 blocking open\nCONVERGENCE: NOT-BLOCKED — staged structural debt is clear.\nSTAGED-ATTEMPTS: total=4 validation-retries=0 validation-invalid=0 execution-failed=0",
         "retry_register": null,
         "returncode": 0,
         "round": 1,
-        "session_ref": "01a02abe-8315-7fe1-b3c1-27bc953cfbc1",
+        "session_ref": "01a02fe7-0ef1-7b53-a9f3-cb054ff119a6",
         "staged_manifests": [
           {
             "class_assessments": [],
@@ -1539,35 +1496,35 @@
                 "finding_ids": [],
                 "id": "artifact-complete",
                 "status": "covered",
-                "summary": "Every frozen implementation obligation is present."
+                "summary": "All three frozen contract obligations are implemented and exercised."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:5-11",
-                  "repository/README.md:3"
+                  "repository/README.md:3",
+                  "repository/reviewer.py:5-11"
                 ],
                 "finding_ids": [],
                 "id": "repository-premises",
                 "status": "covered",
-                "summary": "The implementation fits the repository's small fixture and preserves the pre-existing public return contract."
+                "summary": "The implementation matches the repository's fixture purpose and public API premise."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:7-11"
+                  "repository/reviewer.py:7-10"
                 ],
                 "finding_ids": [],
                 "id": "transformations",
                 "status": "covered",
-                "summary": "The contract-to-JSON transformation matches the persisted schema."
+                "summary": "The contract value is transformed into the required JSON artifact without introducing additional persisted data."
               },
               {
                 "evidence": [
-                  "repository/tests/test_fidelity.py:4-12"
+                  "repository/tests/test_fidelity.py:3-12"
                 ],
                 "finding_ids": [],
                 "id": "consumers",
                 "status": "covered",
-                "summary": "The public entry point and artifact are consumed consistently."
+                "summary": "The public consumer path observes the intended artifact and schema."
               },
               {
                 "evidence": [
@@ -1576,7 +1533,7 @@
                 "finding_ids": [],
                 "id": "failure-recovery",
                 "status": "covered",
-                "summary": "Fail-fast write behavior is proportionate to the trusted single-operator stakes, where recoverable blocking is acceptable."
+                "summary": "Failure behavior is explicit propagation and is proportionate to this recoverable fixture workflow."
               },
               {
                 "evidence": [
@@ -1586,38 +1543,37 @@
                 "finding_ids": [],
                 "id": "tests-acceptance",
                 "status": "covered",
-                "summary": "All named acceptance criteria are exercised through the required public entry point."
+                "summary": "The named acceptance path verifies every frozen obligation through the production entry point."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:6-6",
-                  "repository/README.md:1-3"
+                  "plan:1-4"
                 ],
                 "finding_ids": [],
                 "id": "docs-operations",
-                "status": "covered",
-                "summary": "Documentation is sufficient for this deliberately tiny fixture."
+                "status": "not_applicable",
+                "summary": "Documentation accuracy is explicitly outside this acceptance and the contract introduces no operational requirements."
               },
               {
                 "evidence": [
-                  "plan:4",
-                  "repository/reviewer.py:9-9",
-                  "repository/tests/test_fidelity.py:9-12"
-                ],
-                "finding_ids": [],
-                "id": "consistency",
-                "status": "covered",
-                "summary": "Plan, implementation, and acceptance test agree on the persisted contract."
-              },
-              {
-                "evidence": [
+                  "plan:2-4",
                   "repository/reviewer.py:5-11",
                   "repository/tests/test_fidelity.py:6-12"
                 ],
                 "finding_ids": [],
+                "id": "consistency",
+                "status": "covered",
+                "summary": "Plan, implementation, and acceptance test agree on filename, entry point, value, and persisted schema."
+              },
+              {
+                "evidence": [
+                  "repository/reviewer.py:1-11",
+                  "repository/tests/test_fidelity.py:1-12"
+                ],
+                "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The change is appropriately minimal for the stated trusted-operator fixture."
+                "summary": "The implementation and test are appropriately minimal for a trusted, sequential, single-operator fixture."
               }
             ],
             "findings": [],
@@ -1629,52 +1585,50 @@
               {
                 "evidence": [
                   "plan:2-4",
-                  "repository/reviewer.py:5-11",
+                  "repository/reviewer.py:5-10",
                   "repository/tests/test_fidelity.py:6-12"
                 ],
                 "finding_ids": [],
                 "id": "artifact-complete",
                 "status": "covered",
-                "summary": "All frozen contract obligations are implemented and exercised."
+                "summary": "All three frozen plan obligations are implemented and exercised."
               },
               {
                 "evidence": [
-                  "repository/README.md:1-3",
-                  "repository/reviewer.py:5-11"
+                  "repository/reviewer.py:5-10",
+                  "repository/README.md:1-3"
                 ],
                 "finding_ids": [],
                 "id": "repository-premises",
                 "status": "covered",
-                "summary": "The implementation matches the repository's narrowly stated purpose and public entry-point premise."
+                "summary": "The implementation fits the repository's minimal fixture structure and public entry point."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:8-10",
-                  "repository/tests/test_fidelity.py:10-12"
+                  "repository/reviewer.py:7-10"
                 ],
                 "finding_ids": [],
                 "id": "transformations",
                 "status": "covered",
-                "summary": "The contract value is serialized without introducing additional persisted fields."
+                "summary": "The serialization transformation preserves the supplied string and introduces no additional persisted data."
               },
               {
                 "evidence": [
-                  "plan:3",
-                  "repository/tests/test_fidelity.py:3-9"
+                  "repository/tests/test_fidelity.py:6-12"
                 ],
                 "finding_ids": [],
                 "id": "consumers",
                 "status": "covered",
-                "summary": "The named public consumer path is used directly and observes the expected artifact."
+                "summary": "The emitted artifact satisfies the repository's exercised consumer contract."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:7-11"
+                  "repository/reviewer.py:7-10"
                 ],
                 "finding_ids": [],
                 "id": "failure-recovery",
                 "status": "covered",
-                "summary": "Failures propagate to the caller; no additional recovery behavior is required by the contract or stated stakes."
+                "summary": "Failure behavior is appropriately fail-closed for this fixture."
               },
               {
                 "evidence": [
@@ -1684,38 +1638,37 @@
                 "finding_ids": [],
                 "id": "tests-acceptance",
                 "status": "covered",
-                "summary": "The focused acceptance test covers every named criterion through the production entry point."
+                "summary": "The named public entry point exercises every supplied acceptance obligation."
               },
               {
                 "evidence": [
-                  "repository/README.md:1-3",
-                  "plan:1-4"
+                  "repository/reviewer.py:5-10"
                 ],
                 "finding_ids": [],
                 "id": "docs-operations",
                 "status": "covered",
-                "summary": "Documentation is proportionate to this tiny contract-driven fixture."
+                "summary": "No additional documentation or operational machinery is required for the three in-scope obligations."
               },
               {
                 "evidence": [
                   "plan:4",
-                  "repository/reviewer.py:5-11",
-                  "repository/tests/test_fidelity.py:10-12"
+                  "repository/reviewer.py:8-10",
+                  "repository/tests/test_fidelity.py:9-12"
                 ],
                 "finding_ids": [],
                 "id": "consistency",
                 "status": "covered",
-                "summary": "The implementation and acceptance test consistently enforce the declared persisted and public contracts."
+                "summary": "Plan, implementation, and acceptance test agree on the persisted public shape."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:1-11",
+                  "repository/reviewer.py:1-10",
                   "repository/tests/test_fidelity.py:1-12"
                 ],
                 "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The change is minimal and appropriately scoped for a trusted single-operator fidelity fixture."
+                "summary": "The change is appropriately minimal for a trusted, sequential, single-operator fidelity fixture."
               }
             ],
             "findings": [],
@@ -1733,44 +1686,45 @@
                 "finding_ids": [],
                 "id": "artifact-complete",
                 "status": "covered",
-                "summary": "All frozen contract obligations are implemented without an undeclared deferral."
+                "summary": "All three frozen-plan obligations are implemented and exercised."
               },
               {
                 "evidence": [
-                  "repository/README.md:1-3",
-                  "repository/reviewer.py:5-11"
+                  "repository/reviewer.py:5-11",
+                  "repository/README.md:1-3"
                 ],
                 "finding_ids": [],
                 "id": "repository-premises",
                 "status": "covered",
-                "summary": "The implementation matches the repository's narrow fixture purpose and public entry-point premise."
+                "summary": "The change fits the repository's small fixture structure and preserves its public entry point."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:7-10"
+                  "repository/reviewer.py:7-10",
+                  "repository/tests/test_fidelity.py:9-12"
                 ],
                 "finding_ids": [],
                 "id": "transformations",
                 "status": "covered",
-                "summary": "The contract-to-artifact transformation is direct and preserves the supplied value."
+                "summary": "The contract-to-JSON transformation preserves the supplied value and introduces no additional persisted fields."
               },
               {
                 "evidence": [
-                  "repository/tests/test_fidelity.py:6-12"
+                  "repository/tests/test_fidelity.py:3-10"
                 ],
                 "finding_ids": [],
                 "id": "consumers",
                 "status": "covered",
-                "summary": "The exercised consumer observes the artifact in the format produced by the implementation."
+                "summary": "The public caller and artifact consumer agree with the implemented path and data shape."
               },
               {
                 "evidence": [
-                  "plan:1-4"
+                  "plan:2-4"
                 ],
                 "finding_ids": [],
                 "id": "failure-recovery",
                 "status": "not_applicable",
-                "summary": "No failure-recovery behavior is required for this narrowly scoped fixture."
+                "summary": "No failure-recovery obligation exists for this trusted, sequential fixture."
               },
               {
                 "evidence": [
@@ -1780,38 +1734,37 @@
                 "finding_ids": [],
                 "id": "tests-acceptance",
                 "status": "covered",
-                "summary": "Every named acceptance criterion is exercised through the required public production entry point."
+                "summary": "The acceptance test covers every named criterion through the required public production entry point."
               },
               {
                 "evidence": [
-                  "repository/README.md:1-3",
-                  "plan:1-4"
+                  "repository/reviewer.py:5-11"
                 ],
                 "finding_ids": [],
                 "id": "docs-operations",
                 "status": "not_applicable",
-                "summary": "No additional operational documentation is required by this self-contained fixture change."
+                "summary": "No documentation or operational change is required by the three scoped obligations."
               },
               {
                 "evidence": [
                   "plan:4",
-                  "repository/reviewer.py:7-10",
+                  "repository/reviewer.py:8-10",
                   "repository/tests/test_fidelity.py:9-12"
                 ],
                 "finding_ids": [],
                 "id": "consistency",
                 "status": "covered",
-                "summary": "The persisted schema, implementation behavior, and acceptance test agree exactly."
+                "summary": "The plan, implementation, and acceptance assertion agree on the persisted schema."
               },
               {
                 "evidence": [
-                  "repository/reviewer.py:5-11",
+                  "repository/reviewer.py:1-11",
                   "repository/tests/test_fidelity.py:6-12"
                 ],
                 "finding_ids": [],
                 "id": "proportionality",
                 "status": "covered",
-                "summary": "The implementation and test are proportionate to the single-operator, tiny-fixture stakes."
+                "summary": "The implementation and test are appropriately minimal for the stated trusted single-operator fixture."
               }
             ],
             "findings": [],
@@ -1831,24 +1784,24 @@
           "role": "census",
           "source_dispositions": []
         },
-        "structural_snapshot": "320b6f674b3824a3ed358aac8c7be8d2068f6144a3b7aff4b2b3ca5615939cf8",
-        "target": "committed diff main...conforming in issue63-exact-fixture",
+        "structural_snapshot": "c85ae95b4e4ecde1907cec58914b6fa1b77e99b3eb74d5a017b6e817cd1e70d8",
+        "target": "committed diff main...conforming in issue68-fidelity-fixture",
         "text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\nNothing notable.\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\nNothing notable.",
-        "timestamp": "ISSUE63-EXACT-CONFORMING",
+        "timestamp": "20260823T193436",
         "tool": "critique_branch",
         "usage": {
           "cached_input_tokens": 0,
-          "input_tokens": 16202,
-          "output_tokens": 88,
-          "reasoning_output_tokens": 52
+          "input_tokens": 16309,
+          "output_tokens": 103,
+          "reasoning_output_tokens": 67
         }
       },
-      "audit_canonical_sha256": "5525c1960ccf2da38a578f0129ea27781836983f02add7ad109dd8eebc5b7dab",
-      "base_id": "521b4a12adc83156e5380153f51a5ca1a7c60f66",
+      "audit_canonical_sha256": "d526ad49746459ed6e539c615f727d9849b2021da67810d5dfaeb9fd1e41d848",
+      "base_id": "4afe14967bd0ef81ab2a68d8c3abe6a3d372f209",
       "engine": "codex",
       "expected": "conforming",
-      "head_id": "95a9c6370b1e4cd51222b44f7ede083be8e350b3",
-      "lineage": "issue-63-exact-conforming-v2",
+      "head_id": "8f8e424d734743f58ab8ee0624d5cb93f8fe7b6a",
+      "lineage": "issue-68-plan-digest-conforming-v3",
       "lineage_state": {
         "branch_contract": {
           "digest": "ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5",
@@ -1864,24 +1817,29 @@
         "mode": "branch",
         "next_seq": 1,
         "review_state": {
+          "correction_control": {
+            "classes": {},
+            "version": 1
+          },
           "debt": [],
           "last_round": 1,
           "phase": "clear",
-          "snapshot_digest": "320b6f674b3824a3ed358aac8c7be8d2068f6144a3b7aff4b2b3ca5615939cf8",
-          "stakes": "Trusted single operator and OS; Codex is a trusted reviewer; repository, contract, and model output are untrusted data; no hostile local race or repository execution; one tiny branch and one four-line immutable contract; false fidelity clear is high impact and recoverable blocking is acceptable; exclude multi-tenancy, compromised OS/provider, formal proof, hostile web content, and corrupt-state recovery. Correctness and bugs only.",
-          "stakes_digest": "8b23d3e439222f2cc3fd3e002b775befe504d60e0ec921b6233bab5dac937570",
+          "snapshot_digest": "c85ae95b4e4ecde1907cec58914b6fa1b77e99b3eb74d5a017b6e817cd1e70d8",
+          "stakes": "Trusted single operator and OS; fixture, plan, and model output are untrusted static data; sequential execution with no hostile local race or repository execution; one tiny branch and three plan obligations; false fidelity clearance is high impact and recoverable blocking is acceptable. The README mismatch is intentional negative-fixture context; documentation accuracy is outside this acceptance, which assesses only the three supplied plan obligations.",
+          "stakes_digest": "abda01be96a27bb50b6af4b44fc5068804d6a22491e3764546d7e6d9d2e5ba0c",
           "version": 1
         },
         "rounds": 1
       },
-      "lineage_state_canonical_sha256": "cf1cf9845a0f5d777fd3c565c364a486d48e71290ef60c3637d97f842caf7299",
+      "lineage_state_canonical_sha256": "b4f04b2375da3419560e875f0eb05691d5aabf8c897836d69c172d0164a5bad3",
       "model": "gpt-5.6-sol",
-      "packet": "=== UNDER REVIEW ===\nworking-tree snapshot 521b4a12adc8..95a9c6370b1e in issue63-exact-fixture\n\n=== DIFFSTAT ===\nreviewer.py            | 11 ++++++++++-\n tests/test_fidelity.py | 12 ++++++++++++\n 2 files changed, 22 insertions(+), 1 deletion(-)\n\n=== DIFF (git diff 521b4a12adc8..95a9c6370b1e) ===\ndiff --git a/reviewer.py b/reviewer.py\nindex 67cf633..09baaf3 100644\n--- a/reviewer.py\n+++ b/reviewer.py\n@@ -1,2 +1,11 @@\n+import json\n+from pathlib import Path\n+\n+\n def critique_branch(contract: str) -> None:\n-    \"\"\"Placeholder public entry point.\"\"\"\n+    \"\"\"Emit the contracted artifact through the public entry point.\"\"\"\n+    output = Path(\"fidelity.json\")\n+    output.write_text(\n+        json.dumps({\"branch_contract\": contract}, sort_keys=True) + \"\\n\",\n+        encoding=\"utf-8\",\n+    )\ndiff --git a/tests/test_fidelity.py b/tests/test_fidelity.py\nnew file mode 100644\nindex 0000000..9afaee3\n--- /dev/null\n+++ b/tests/test_fidelity.py\n@@ -0,0 +1,12 @@\n+import json\n+\n+from reviewer import critique_branch\n+\n+\n+def test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\n+    monkeypatch.chdir(tmp_path)\n+    critique_branch(\"frozen\")\n+    output = tmp_path / \"fidelity.json\"\n+    assert json.loads(output.read_text(encoding=\"utf-8\")) == {\n+        \"branch_contract\": \"frozen\",\n+    }\n\n\n=== FILE reviewer.py [M] ===\nimport json\nfrom pathlib import Path\n\n\ndef critique_branch(contract: str) -> None:\n    \"\"\"Emit the contracted artifact through the public entry point.\"\"\"\n    output = Path(\"fidelity.json\")\n    output.write_text(\n        json.dumps({\"branch_contract\": contract}, sort_keys=True) + \"\\n\",\n        encoding=\"utf-8\",\n    )\n\n\n=== FILE tests/test_fidelity.py [A] ===\nimport json\n\nfrom reviewer import critique_branch\n\n\ndef test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\n    monkeypatch.chdir(tmp_path)\n    critique_branch(\"frozen\")\n    output = tmp_path / \"fidelity.json\"\n    assert json.loads(output.read_text(encoding=\"utf-8\")) == {\n        \"branch_contract\": \"frozen\",\n    }\n",
-      "packet_sha256": "874f8aa3bfc455c229b3a96038f621e645cc2236f02d2a1d1e7e57ee5257d31c",
+      "packet": "=== UNDER REVIEW ===\nworking-tree snapshot 4afe14967bd0..8f8e424d7347 in issue68-fidelity-fixture\n\n=== DIFFSTAT ===\nreviewer.py            | 11 ++++++++++-\n tests/test_fidelity.py | 12 ++++++++++++\n 2 files changed, 22 insertions(+), 1 deletion(-)\n\n=== DIFF (git diff 4afe14967bd0..8f8e424d7347) ===\ndiff --git a/reviewer.py b/reviewer.py\nindex 67cf633..09baaf3 100644\n--- a/reviewer.py\n+++ b/reviewer.py\n@@ -1,2 +1,11 @@\n+import json\n+from pathlib import Path\n+\n+\n def critique_branch(contract: str) -> None:\n-    \"\"\"Placeholder public entry point.\"\"\"\n+    \"\"\"Emit the contracted artifact through the public entry point.\"\"\"\n+    output = Path(\"fidelity.json\")\n+    output.write_text(\n+        json.dumps({\"branch_contract\": contract}, sort_keys=True) + \"\\n\",\n+        encoding=\"utf-8\",\n+    )\ndiff --git a/tests/test_fidelity.py b/tests/test_fidelity.py\nnew file mode 100644\nindex 0000000..9afaee3\n--- /dev/null\n+++ b/tests/test_fidelity.py\n@@ -0,0 +1,12 @@\n+import json\n+\n+from reviewer import critique_branch\n+\n+\n+def test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\n+    monkeypatch.chdir(tmp_path)\n+    critique_branch(\"frozen\")\n+    output = tmp_path / \"fidelity.json\"\n+    assert json.loads(output.read_text(encoding=\"utf-8\")) == {\n+        \"branch_contract\": \"frozen\",\n+    }\n\n\n=== FILE reviewer.py [M] ===\nimport json\nfrom pathlib import Path\n\n\ndef critique_branch(contract: str) -> None:\n    \"\"\"Emit the contracted artifact through the public entry point.\"\"\"\n    output = Path(\"fidelity.json\")\n    output.write_text(\n        json.dumps({\"branch_contract\": contract}, sort_keys=True) + \"\\n\",\n        encoding=\"utf-8\",\n    )\n\n\n=== FILE tests/test_fidelity.py [A] ===\nimport json\n\nfrom reviewer import critique_branch\n\n\ndef test_public_entry_point_emits_only_the_contract(tmp_path, monkeypatch) -> None:\n    monkeypatch.chdir(tmp_path)\n    critique_branch(\"frozen\")\n    output = tmp_path / \"fidelity.json\"\n    assert json.loads(output.read_text(encoding=\"utf-8\")) == {\n        \"branch_contract\": \"frozen\",\n    }\n",
+      "packet_sha256": "6ab98382912fa36e9af79875054e2fd8c5c8c148317286344946ce1cf62a246b",
       "plan_contract_reused": false,
       "plan_digest": "ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5",
+      "rendered_trailer": "LINEAGE: issue-68-plan-digest-conforming-v3 (rounds recorded: 1)\nPLAN-DIGEST: ee40d2e4191178b9026c20a31fc420f9dd4c9fa0f546ea9eb2a4a92f2caf9ea5\nCLASS-REGISTER: staged census parsed — NONE\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nSTRUCTURAL-PHASE: clear\nSTRUCTURAL-DEBT: 0 blocking open\nCONVERGENCE: NOT-BLOCKED — staged structural debt is clear.\nSTAGED-ATTEMPTS: total=4 validation-retries=0 validation-invalid=0 execution-failed=0",
       "round": 1,
-      "session_ref": "01a02abe-8315-7fe1-b3c1-27bc953cfbc1",
+      "session_ref": "01a02fe7-0ef1-7b53-a9f3-cb054ff119a6",
       "settlement": {
         "_class_record_pointers": [],
         "_finding_class_refs": {},
@@ -1895,18 +1853,18 @@
         "role": "census",
         "source_dispositions": []
       },
-      "structural_snapshot": "320b6f674b3824a3ed358aac8c7be8d2068f6144a3b7aff4b2b3ca5615939cf8"
+      "structural_snapshot": "c85ae95b4e4ecde1907cec58914b6fa1b77e99b3eb74d5a017b6e817cd1e70d8"
     }
   ],
-  "source_revision": "ac2c30edee7d3675e5bc27526638842d878c2418",
+  "source_revision": "a81e798c146169da0514deeee3172d848ae79219",
   "source_sha256": {
-    "scripts/build_branch_plan_fidelity_acceptance.py": "69be88a4cf394fcd28f8b53b075b70efeeef67949fe6aa01d7b30b2dfc1d15ec",
-    "src/paranoia_local/class_closure.py": "43d7d6053ecfda8a1f0d02df678ce1936b288bdded4f12834f03736b3d280f35",
-    "src/paranoia_local/handlers.py": "422cdf98cbc92839cd57a810b8d000b644970d78f0d8999361de8b30a3620fce",
-    "src/paranoia_local/prompts.py": "c848e47655d5b01a877cc0cf0efb202e4546ac99a8ccfac5fbf5867c45dd1dae",
+    "scripts/build_branch_plan_fidelity_acceptance.py": "58383b33079ee952f4dd06d62fc3ee0947ef512e81f5c6eb51a10772d579dd68",
+    "src/paranoia_local/class_closure.py": "7d85ecc7d7988c691b22b5cd620c98ee8254698d9eae8f4400d0063b40c0400a",
+    "src/paranoia_local/handlers.py": "f240165ea9a02fddb117cfaf0d722839e3fe022a75139feb10d4c52bab08f814",
+    "src/paranoia_local/prompts.py": "9f14214af5c21c61cad0b195c37ddd589730d0aaa218bf7cd70bfa28508c9490",
     "src/paranoia_local/runner.py": "fbbe1131126ab959eb84e9df9e0e0c10b040d08ee4a44870e3b9472042079c73",
-    "src/paranoia_local/server.py": "57f5ae783524cc77abda8e379bbabafb940095e20e80c7ef1d7664e2ee55fbf2",
+    "src/paranoia_local/server.py": "47d813cc9ffc356e7efdad4cb08e06c70ae515f07aec585858907657eb00996f",
     "src/paranoia_local/staged_protocol.py": "7288cdf4b53986dcc6c455efe76d58901ef22863daf84b025e3acd7f8b168483",
-    "tests/test_branch_plan_fidelity.py": "7c1610823b5513ea7a0777b9961beb646f09838769d81a170f41cec54d3dc46e"
+    "tests/test_branch_plan_fidelity.py": "e20f7e80b9fe5f2ccce90db7267f7d71ebc3db57cbb0167c29f5e12f930ca7a8"
   }
 }

--- a/scripts/build_branch_plan_fidelity_acceptance.py
+++ b/scripts/build_branch_plan_fidelity_acceptance.py
@@ -125,6 +125,7 @@ def _route(path: Path, state_path: Path, expected: str, fixture_repo: Path) -> d
         "lineage": audit.get("lineage"),
         "round": audit.get("round"),
         "plan_digest": audit.get("plan_digest"),
+        "rendered_trailer": audit.get("rendered_trailer"),
         "structural_snapshot": audit.get("structural_snapshot"),
         "packet": packet,
         "packet_sha256": _sha(packet.encode("utf-8")),
@@ -212,12 +213,17 @@ def validate_record(record: dict, root: Path = ROOT) -> None:
             "session_ref": audit.get("session_ref"), "base_id": audit.get("base_id"),
             "head_id": audit.get("head_id"), "lineage": audit.get("lineage"),
             "round": audit.get("round"), "plan_digest": audit.get("plan_digest"),
+            "rendered_trailer": audit.get("rendered_trailer"),
             "structural_snapshot": audit.get("structural_snapshot"),
             "plan_contract_reused": audit.get("plan_contract_reused"),
             "settlement": audit.get("staged_settlement"),
         }
         if any(route.get(key) != value for key, value in projected.items()):
             raise ValueError("route projection does not match its audit")
+        trailer = route.get("rendered_trailer")
+        digest_line = f"PLAN-DIGEST: {contract.digest}"
+        if not isinstance(trailer, str) or trailer.splitlines().count(digest_line) != 1:
+            raise ValueError("public trailer does not contain the exact plan digest once")
         if (
             audit.get("tool") != "critique_branch"
             or audit.get("mode") != "converge-packet"
@@ -410,6 +416,7 @@ def main() -> None:
         "source_sha256": {
             relative: _sha((ROOT / relative).read_bytes()) for relative in SOURCES
         },
+        "allowed_later_source_diffs": {},
         "routes": [
             _route(
                 args.nonconforming_audit, args.nonconforming_state,
@@ -425,6 +432,7 @@ def main() -> None:
                 "A signed-in Codex census accepted plan anchors and blocked a nonconforming branch.",
                 "A separate signed-in Codex census cleared a genuinely conforming branch through critique_branch.",
                 "Both routes used the production staged handler with immutable plan digests and retained attempt ledgers.",
+                "Both public result trailers rendered the exact immutable plan digest once.",
             ],
             "does_not_prove": [
                 "Every future provider response will classify implementation fidelity correctly.",

--- a/tests/test_branch_plan_fidelity.py
+++ b/tests/test_branch_plan_fidelity.py
@@ -1215,6 +1215,12 @@ def test_real_branch_plan_fidelity_acceptance_is_source_and_route_bound():
         route["plan_digest"] == artifact["fixture"]["contract_sha256"]
         for route in routes.values()
     )
+    assert all(
+        route["rendered_trailer"].splitlines().count(
+            f"PLAN-DIGEST: {route['plan_digest']}"
+        ) == 1
+        for route in routes.values()
+    )
     assert all(len(route["structural_snapshot"]) == 64 for route in routes.values())
     assert all(route["attempt_ledger"] for route in routes.values())
     assert all(route["accepted_plan_anchors"] for route in routes.values())


### PR DESCRIPTION
## Summary
- regenerate the source-bound branch-plan fidelity acceptance after the PLAN-DIGEST trailer change
- require each accepted public result trailer to contain the exact contract digest exactly once
- retain two fresh real Codex critique_branch routes: one conforming and one nonconforming

## Validation
- real nonconforming critique_branch route: exactly three intended blocking plan obligations
- real conforming critique_branch route: CONVERGENCE: NOT-BLOCKED
- acceptance record validates against source revision a81e798
- 46 branch-plan fidelity tests passed
- 1,348 full-suite tests passed

## Review scope
Operator override: no paranoia convergence was required for this acceptance-only follow-up.