### PR TITLE
Restructure documentation for users and agents

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,47 @@
 # Paranoia
 
-Get a cold, adversarial review of your code, your plans, and your decisions from
-the *other* frontier coding agent — running locally, on its own subscription, with
-full read access to your repository.
+Get a cold, adversarial review of your code, plans, and technical decisions from
+the other frontier coding agent.
 
-Install it into Claude Code and reviews are performed by Codex. Install it into
-Codex and reviews are performed by Claude Code. paranoia-local is the MCP server
-between them: it builds the prompt, runs the other agent read-only, and returns a
-structured critique.
+Paranoia Local is an MCP server that connects Claude Code and Codex CLI. Install
+it in one agent and it runs the other as a read-only reviewer, using that
+reviewer's existing subscription and full repository context.
 
-```
-┌──────────────┐   "paranoia: critique this branch"   ┌───────────────┐
-│  Claude Code │ ───────────────────────────────────► │ paranoia-local│
-│  (your work) │                                      │  (MCP, local) │
-└──────────────┘                                      └───────┬───────┘
-                                                              │ codex exec (read-only)
-                                                      ┌───────▼────────┐
-                                                      │  Codex / GPT-5 │ ← reads the repo,
-                                                      │  cold reviewer │   decides what to open
-                                                      └────────────────┘
+```text
+Claude Code ──MCP──> Paranoia Local ──read-only──> Codex
+Codex       ──MCP──> Paranoia Local ──read-only──> Claude Code
 ```
 
-**Contents** · [Quickstart](#quickstart) · [The five tools](#the-five-tools) ·
-[How reviews work: the convergence loop](#how-reviews-work-the-convergence-loop) ·
-[Tool reference](#tool-reference) · [Output reference](#output-reference) ·
-[Configuration](#configuration) · [Safety model](#safety-model) ·
-[Development](#development)
+Use it to:
 
----
+- review a branch, diff, or dirty working tree;
+- challenge a plan against the code it describes;
+- track findings and defect classes until they are closed;
+- verify load-bearing plan claims against captured authoritative sources;
+- ask a focused repository question;
+- rebut a finding in the same reviewer session; or
+- arbitrate a decision with both vendors independently.
+
+[Get started](#quickstart) · [Choose a tool](#choose-a-tool) ·
+[Understand tracked reviews](#tracked-reviews) · [Configure](#configuration) ·
+[Full tool reference](docs/tool-reference.md) · [LLM and agent entry point](llms.txt)
 
 ## Quickstart
 
-**1. Prerequisites**
+### 1. Install the prerequisites
 
-- Python 3.11+ and `git` on `PATH`
-- The reviewing agent's stable CLI, installed and signed in on a subscription:
-  [Codex CLI](https://developers.openai.com/codex) (`codex`, ≥ 0.144.6) **or**
-  [Claude Code](https://code.claude.com) (`claude`, ≥ 2.1.197)
-- `arbitrate` needs **both** CLIs; the four review tools need only the other one
+You need:
 
-**2. Install**
+- Python 3.11 or later;
+- Git 2.36 or later on `PATH`; and
+- the reviewing agent's stable CLI, installed and signed in:
+  [Codex CLI](https://developers.openai.com/codex) 0.144.6 or later, or
+  [Claude Code](https://code.claude.com) 2.1.197 or later.
+
+Most tools need only the reviewer CLI. `arbitrate` uses both vendors and needs
+both CLIs.
+
+### 2. Install Paranoia Local
 
 ```bash
 git clone https://github.com/subvertnormality/paranoia-local
@@ -47,27 +49,25 @@ cd paranoia-local
 pip install -e .
 ```
 
-**3. Wire it into your agent.** `--engine` names the agent that *performs* reviews,
-which is the opposite one from the caller.
+### 3. Add it to your coding agent
 
-<details open>
-<summary><strong>Into Claude Code</strong> (reviews performed by Codex)</summary>
+`--engine` names the agent that performs the review, so it is the opposite of
+the agent you are configuring.
+
+#### Claude Code: reviews performed by Codex
 
 ```bash
 claude mcp add paranoia -- paranoia-local --engine codex
 ```
-</details>
 
-<details>
-<summary><strong>Into Codex</strong> (reviews performed by Claude Code) — needs two extra keys</summary>
+#### Codex: reviews performed by Claude Code
 
 ```bash
 codex mcp add paranoia -- paranoia-local --engine claude
 ```
 
-Then edit `~/.codex/config.toml`. Codex defaults to a 60-second tool timeout and a
-10-second startup timeout; a review runs for minutes, so both must be raised or
-every call fails:
+Codex defaults to short MCP timeouts, while a thorough review can take several
+minutes. Add these values to `~/.codex/config.toml`:
 
 ```toml
 [mcp_servers.paranoia]
@@ -77,1283 +77,312 @@ tool_timeout_sec = 8400
 startup_timeout_sec = 60
 ```
 
-Verify with `codex mcp get paranoia`.
-</details>
+Verify the registration with `codex mcp get paranoia`.
 
-**4. Ask for a review.**
+### 4. Request your first review
 
-> "Use paranoia to critique this branch against main. Intent: add overdraft
-> protection to `withdraw()`."
+Ask your coding agent naturally:
 
-Your agent calls:
+> Use Paranoia to critique this branch against `main`. The change is intended
+> to add overdraft protection to `withdraw()`. This is an internal API with
+> authenticated first-party callers and no hostile local processes. Use round 1.
+
+The corresponding MCP call is:
 
 ```json
 {
   "name": "critique_branch",
   "arguments": {
-    "repo_path": "/Users/you/Work/my-project",
+    "repo_path": "/absolute/path/to/project",
     "base_ref": "main",
     "round": 1,
-    "diff_intent": "Add overdraft protection to withdraw()."
+    "diff_intent": "Add overdraft protection to withdraw().",
+    "stakes": "Internal API; authenticated first-party callers; no hostile local processes."
   }
 }
 ```
 
-You get back a five-section critique with severity-tagged findings, and a computed
-`CONVERGENCE:` trailer telling you whether the loop may stop.
+Paranoia returns cited findings, severity tags, a reusable `session_ref`, and a
+computed `CONVERGENCE` result. Fix the blocking findings, increment `round`, and
+run the review again until the result is `CONVERGENCE: NOT-BLOCKED`.
 
----
+## Choose a tool
 
-## The five tools
-
-| Tool | Use it to | Needs |
-|---|---|---|
-| [`critique_branch`](#critique_branch) | Review a git branch, a diff, or the dirty working tree, optionally against an explicit plan contract | `repo_path` |
-| [`critique_plan`](#critique_plan) | Review a plan or design doc against the code it claims things about | `repo_path` + `plan_text` \| `plan_path` |
-| [`query`](#query) | Ask one question and get a cited answer — not a full review | `question` |
-| [`rebut`](#rebut) | Dispute a finding from a review you just got | `session_ref` from that review |
-| [`arbitrate`](#arbitrate) | Decide between 2–4 options using **both** vendors independently | `repo_path`, `decision`, `options`, `stakes` |
-
-Every review returns a `session_ref` in its footer. Pass it to `rebut` to reopen
-that exact reviewer session.
-
----
-
-## How reviews work: the convergence loop
-
-A single review is rarely the end of it. You review, you fix, you review again.
-paranoia-local models that as a **convergence loop**, and gives you four controls
-over it plus one computed signal that tells you when to stop.
-
-### The loop
-
-```
-round 1 ──► review ──► fix ──► round 2 ──► review ──► fix ──► round 3 ──► CONVERGED
-             │                              │                              +
-             └── already_raised ────────────┴── already_raised ────► CONVERGENCE: NOT-BLOCKED
-```
-
-Tracked plan reviews use a staged lifecycle. A new or materially changed plan starts with three
-independent cold lanes and one consolidation call. Their complete finding census becomes durable
-debt. Later correction rounds target that debt and correction effects; once it closes, one fresh
-whole-artifact final regression is mandatory. A clear initial census may converge immediately.
-This preserves broad first-pass/final coverage without paying for novelty hunting over unchanged
-material on every correction round. Tracked branch reviews use the same lifecycle: a broad, cold
-three-lane census, targeted correction rounds over durable debt and changed code, and a mandatory
-broad, cold final regression before clearance. Every staged branch role retains the established
-code-review investigation, packet-use, proportionality, and warranted-web-search profile; only its
-structured output contract changes. The staged roles use closed, role-specific provider schemas,
-then the server validates the complete bounded schema and semantic graph independently. The
-server derives each census class outcome exactly once from the validated integrity-lane assessment;
-the consolidator supplies only the governing classification/source relationship needed for a
-violation. Cross-lane findings cannot append an outcome or override an integrity-lane satisfaction
-judgement. Correction and final class outcomes remain model-owned. The pinned Codex
-schema subset lacks `uniqueItems`, and Claude must not receive the draft-identifying
-`$schema` metadata. Those two non-semantic keywords are removed only from the provider projection;
-uniqueness remains mandatory in local validation, so duplicates can trigger the existing
-same-session correction but can never settle. There is no prose/marker fallback. One-shot reviews
-retain the single broad review.
-For Claude, schema success additionally requires an object in the provider envelope's
-`structured_output`; a zero exit status with only result prose is a provider failure. Branch class
-schemas reject leading-colon Git pathspec magic, and replacements of mechanized classes must retain
-a pattern plus literal pathspec. The local semantic pass returns bounded, deterministically ordered
-independent graph, model-owned anchor, and canonical-class issues with model-repairable JSON
-pointers so the single validation retry can repair more than the first defect. Whitespace-only
-semantic text, lane replies above 240,000 characters, and decision replies above 1,000,000
-characters fail before settlement or JSON decoding. The separate composed-prompt circuit breaker
-remains 5,000,000 characters.
-Issue #38's evidence-citation cutover gives every model-facing staged citation a closed
-`{anchor, rationale}` object. The exact anchor is projected into the existing string-only semantic,
-cache, and settlement contract; rationale is explanatory and never participates in authority or
-resolution. Legacy strings, prose in an anchor, joined citations, extra fields, and duplicate
-projected anchors reject through the existing bounded validation retry. Cached lane manifests
-remain canonical string data under cache schema version 3. See
-`docs/evidence_citation_shape_plan.md` for the design and acceptance boundaries.
-The dated [live Codex provider probe](docs/evidence_citation_shape_acceptance_2026-08-17.json)
-binds the exact provider schema, prompt, raw citation-object response, canonical projection, and
-successful production anchor resolution for one call. It explicitly does not claim to exercise
-the production handler, settlement, or persistence seam.
-The separate [production-handler acceptance](docs/evidence_citation_shape_handler_acceptance_2026-08-17.json)
-records one signed-in staged correction call through `critique_branch`, including its exact schema
-and response, standard attempt ledger, canonical settlement, persisted lineage, real timing and
-call count, production diff totals, and largest production-module sizes. Its replay test reconstructs the
-settlement and durable review state and recomputes the largest modules from the recorded head's
-complete production tree. The record does not claim future provider compliance, exact composed
-prompt bytes, independently attested wall-clock/service identity, or semantic correctness of the
-review findings. A hashed invocation envelope binds the recorded provider and timing observations
-to the production attempt's sequence, session, response digest, return code, and call count.
-For an evidenced violation of a closed unmechanized class, the server derives the redundant
-`reopen` lifecycle record. A model-owned non-downgrading reclassification is applied before that
-derived lifecycle transition; an explicit replacement remains model-owned, and a closed
-mechanized class still requires a replacement with its predicate and pathspec. A bare reopen never
-manufactures a violated assessment.
-If all three census lanes validate but consolidation is rejected, their manifests are persisted
-with the lineage and the next invocation reruns consolidation only. Reuse requires an exact match
-on mode, structural snapshot, complete review body and open debt, frozen stakes, active-class state,
-engine/model/effort/web capability settings, plan line context, and cache schema. It is recorded only
-after terminal validation rejection; the binding also digests the exact composed lane prompt bytes,
-including current instructions and provider schema. Execution failure, timeout, cancellation, or failed retry is
-not reusable. Any binding change or incomplete lane set forces a fresh census.
-
-Durable lineage state carries concrete findings, reusable classes, frozen stakes, phase, and plan
-claim evidence forward; the reviewer never relies on chat memory. `STRUCTURAL-PHASE` and
-`STRUCTURAL-DEBT` in the trailer show where the autonomous loop is. There is no fixed round ceiling:
-provider, parsing, deadline, or oversized-state failures block visibly rather than clearing.
-Claim debt blocks the combined `CONVERGENCE` verdict through `CLAIM-CLOSURE`, but it does not rewrite
-`STRUCTURAL-PHASE` or turn a claim-provider timeout into staged structural debt. The structural
-trailer remains independently truthful, so a retry can distinguish evidence work from code/plan
-correction work.
-
-### `round` — lineage ordering
-
-The 1-based round number. **Increment it every round.** In tracked staged plan and branch review,
-census and final remain complete at every in-scope severity while correction is limited to durable
-debt and repair effects; convergence comes from that phase boundary. One-shot and injected-engine
-legacy paths retain their single broad review and round-3 severity floor.
-
-`round` is required on `critique_branch` and `critique_plan` unless you pass
-`class_closure: false`.
-
-### `stakes` — the scope boundary
-
-The real deployment context, threat model, and scale the work operates in:
-
-```json
-"stakes": "Internal booking API, single team, authenticated first-party callers, ~1k req/min."
-```
-
-The reviewer treats it as the **boundary of legitimate concern**. Findings that
-assume adversaries, scale, or failure modes beyond it are dropped or tagged
-`[OUT-OF-SCOPE]`, never must-fix. Omit it and the reviewer assumes a modest
-internal tool; a review with no stakes ends with a `STAKES: unstated` line. Pass
-`stakes: "unstated"` to accept that reading deliberately and silence the line.
-
-Set it once per project in [`.paranoia.toml`](#paranoiatoml); override per call to
-tighten it for a specific surface.
-
-### `already_raised` — what not to repeat
-
-One-line, `file:line`-cited claims you have already accepted from earlier rounds.
-The reviewer is told not to restate them and to hunt for what they missed. Pass
-the claim and its citation, never the previous reviewer's prose.
-
-```json
-"already_raised": [
-  "withdraw() ignores pending holds — accounts.py:88",
-  "the overdraft test asserts the fee, not the balance — test_accounts.py:210"
-]
-```
-
-### `class_closure` — tracking defect *classes* across rounds
-
-**On by default.** A finding is usually an instance of a class: one violated
-invariant, several sites. Class closure makes the class itself a tracked object
-that survives the round.
-
-Tracked staged plan and branch reviews return provider-constrained semantic JSON. The model emits
-each source mapping, classification, debt outcome, and independent class action once. Correction and
-final also emit their class outcomes; census outcomes are derived from the validated integrity
-manifest. The server validates the graph, allocates new debt IDs, derives the internal mirror rows, and applies
-class operations through the same durable class engine used by the legacy terminal register.
-At the fresh provider boundary, class outcomes and actions are closed objects keyed by the exact
-active class IDs. This makes duplicate transitions, unknown targets, extra correction outcomes, and
-`close`/`reopen` on a mechanized class inexpressible in an ordinary schema-valid response. Duplicate
-raw JSON keys reject before mapping conversion. The server then restores the existing canonical
-arrays in encounter order, preserving action order and durable successor identity. Correction asks
-for authored outcomes only for classes already bound to open debt; a fresh occurrence of another
-active class carries distinct `assessment_evidence` on its finding classification and deterministically
-derives the violated class outcome. Finding evidence and class-assessment evidence remain separate.
-Decision-level finding IDs are response-local references: if a cold response reuses a historical
-finding ID it was not shown, the server deterministically rekeys that fresh finding and all of its
-coverage/class references before materialization, retaining the rename in the audit settlement.
-Durable history updates remain keyed only by supplied debt IDs. Duplicate response-local IDs and
-unknown or misbound references still reject the decision. Every
-governing finding must explicitly declare whether it is a genuine one-off, a new reusable class,
-or an occurrence of an active class. Every embedded new-class definition is bound to exactly one
-finding; omission or an unbound definition rejects the settlement instead of silently treating its
-finding as classless. Every lane finding must be named by at least one checklist
-row; a `finding` row names its finding IDs and non-finding rows cannot hide one. The integrity lane
-receives each active class's invariant and its procedure or mechanized predicate, not only an ID.
-If one atomic lane finding violates several active classes, census consolidation may map that source
-finding to one distinct governing finding per class. The source observation is not artificially
-split: every target of a repeated source must be an existing-class finding backed by its own
-violated assessment citing that source. One-off or new-class targets, duplicate source-to-governing
-pairs, and omitted sources still reject the settlement.
-An open, unmechanized active class assessed `satisfied` closes deterministically; the model does not
-need to repeat that derived action. A closed, unmechanized class assessed `violated` likewise
-reopens deterministically. Mechanized classes retain
-their separate mechanical closure rule. Rejections after parsing are recorded as
-`validation-invalid`, which covers both envelope/schema and semantic lifecycle failures.
-Only terminal consolidation validation populates `validation_debt`; lane/follow-up validation and
-execution, retry, timeout, cancellation, deadline, and consolidation-preflight failures persist as
-structured `staged_failure` records with their exact role, kind, and message. They invalidate any
-older census cache and cannot authorize reuse. Engine outcomes retain `timeout`, `unavailable`,
-`provider`, or `execution` rather than being flattened into an exit-code label; a failed validation
-retry and its attempt-ledger event use the same `*-validation-retry` role.
-Terminal validation debt retains that same structured role, kind, and message in lineage state and
-the convergence trailer. Every staged validation rejection records its bounded executable
-`validation_issue` on that exact attempt and corresponding rejected-payload row. Rejected extracted
-model replies are retained as a bounded head-and-tail excerpt plus their full SHA-256 in terminal
-lineage state and the audit log's top-level `rejected_payloads`; a rejected first response remains
-in the audit when its retry succeeds. Provider-envelope excerpts in `attempt_ledger` remain
-separate.
-Validation retry guidance includes the bounded server validation issue with a JSON Pointer, while
-the provider schema remains the structural source of truth. The server does not normalize aliases,
-fences, markers, partial objects, unresolved anchors, or missing semantic decisions.
-Concurrent lane failure fan-in retains replies from every failed lane in attempt-sequence order,
-and diagnostics are attached to the closure before lineage persistence so a save failure cannot
-erase them from the still-available branch or plan audit log.
-Rejected extracted-reply digests use UTF-8 `surrogatepass`, making diagnostic capture total for
-unpaired surrogates that a provider's JSON string can legally decode; structural state digests keep
-their existing encoding contract.
-For tracked plans, the reviewer sees immutable `NNNNN: ` display prefixes derived from the same
-`splitlines()` collection that supplies anchor bounds. Those prefixes are presentation metadata;
-the unnumbered original remains the sole input to plan/claim digests and persistence.
-Repository evidence anchors must resolve to ordinary files inside the exact inert snapshot. The
-Codex's server-created `repository/` alias is resolved only to that server-owned snapshot root;
-repository symlinks remain invalid. Disabling plan claim verification makes retained claim state
-dormant for that run: it is neither rendered nor gating, and is preserved for a later enabled run.
-If stakes change while claims are disabled, the packets remain intact and the lineage records that
-the next enabled claim phase must exhaustively reverify them under the new stakes.
-The terminal register below remains the compatible contract for one-shot and injected-engine reviews:
-
-```
-=== CLASS REGISTER ===
-CLASS: every public writer must validate its input before the first mutation
-SEVERITY: MAJOR
-PATTERN: def (create|update)_[a-z_]+\(.*\):\n(?!.*validate)
-PATHSPEC: src/
-```
-
-The server then, on every applicable snapshot:
-
-- **re-runs each registered regex itself** against the reviewed snapshot
-  (`git grep`), and lists every surviving match to the next reviewer;
-- **refuses to report the loop unblocked** while any `BLOCKER`/`MAJOR`/`FATAL`
-  class still matches;
-- **computes the verdict in Python** and appends it as the `CONVERGENCE:` trailer.
-
-A class closes when its predicate returns zero matches and reopens the moment it
-matches again. `MINOR` and `OUT-OF-SCOPE` classes are tracked but advisory — they
-never block.
-
-Staged census settlements preserve that distinction: exactly one concrete debt
-record is required for every blocking governing finding and for every governing
-finding cited by a violated class assessment, including advisory assessments.
-Advisory debt remains durable review context but is excluded from phase gating and
-the computed blocking-debt count.
-
-Where no regex can express the invariant, the reviewer registers a `PROCEDURE:`
-instead. Those are **unmechanized**: nothing re-runs them, they are shown to every
-later reviewer, and they close only when a reviewer explicitly writes
-`CLOSED: <class-id>`.
-
-**On `critique_plan`, every class is unmechanized** — a regex over prose closes as
-soon as the wording changes, so predicates are not accepted there at all. Plan
-closure gives you *non-forgetting plus explicit closure*, not automatic recurrence
-detection.
-
-Plan-class satisfaction is phase-relative: reviewers judge whether the plan completely binds an
-in-card implementation obligation to named scope, executable acceptance evidence, and fail-closed
-behavior. Ownership is additional metadata, not a substitute for scope. They do not demand that
-future runtime artifacts already exist. A vague
-promise remains violated, while an inherited class that itself demands implementation execution is
-replaced with a plan-reviewable invariant instead of recurring forever. This does not certify the
-implementation; tracked branch review remains a separate broad cold review of the code and tests.
-
-**Class transitions** a reviewer can emit, besides a new class:
-
-| Record | Effect |
+| Tool | Use it when |
 |---|---|
-| `CLOSED: <id>` | An unmechanized class is judged closed |
-| `REOPEN: <id>` | A closed unmechanized class is violated again |
-| `RECLASSIFY: <id> <severity>` | Correct a severity |
-| `SUPERSEDE: <id>` + `BY:` / `WITH-PATTERN:` / `WITH-PROCEDURE:` | Replace a class on the legacy text path |
-| staged `replace` | Atomically retire a predecessor and create its corrected open successor |
+| [`critique_branch`](docs/tool-reference.md#critique_branch) | You want a full review of committed or uncommitted code |
+| [`critique_plan`](docs/tool-reference.md#critique_plan) | You want a plan checked against the repository and its external premises |
+| [`query`](docs/tool-reference.md#query) | You need one cited answer, not a full review |
+| [`rebut`](docs/tool-reference.md#rebut) | You have evidence that a previous finding is wrong |
+| [`arbitrate`](docs/tool-reference.md#arbitrate) | You need Codex and Claude to decide independently between 2–4 options |
 
-You cannot emit these yourself — ask for them in `focus`, e.g. *"class 3f2a91c4 is
-registered MAJOR but its effect is cosmetic; reclassify it if you agree."*
+The [complete tool reference](docs/tool-reference.md) documents every argument,
+default, constraint, result, and failure mode.
 
-### Plan claim verification — evidence before critique
+## Common workflows
 
-`critique_plan` verifies external premises **by default**, before structural review. It uses
-the selected signed-in reviewer CLI's built-in search **only to discover candidate URLs**.
-Paranoia Local then downloads those public HTTP(S) pages itself, extracts main text with
-Trafilatura, and resumes the same reviewer session with web access disabled to bind exact
-passages. A separate cold, tool-free attester must accept both publisher authority and passage
-entailment before a packet can close a claim. Claude `WebFetch` is never enabled or trusted in
-this path. There is no `PARANOIA_SEARCH_ENDPOINT`, API key, plugin, or caller-supplied search
-adapter.
-Capture keeps a 5,000,000-byte response circuit breaker but admits complete Trafilatura output
-through 1,000,000 characters. Plan binding keeps complete-source context: an otherwise governing
-primary or authoritative capture that exceeds the ordinary 400,000-character batch may occupy one
-dedicated expanded packet when the exact rendered prompt fits 685,000 characters. Its complete
-capture accompanies the selected passage in the cold attestation packet, which is checked against
-the same exact bound before binding admission, including maximum output and correction-envelope
-reserves. Repeated identical captures are rendered once per binding prompt or
-batch and referenced by final URL plus content/text digests; distinct pages still obey the
-existing serialized aggregate ceilings. Arbitration deterministically marks the largest distinct
-captures unusable until its single binding prompt fits, so one large-source group fails closed
-without aborting all research. Plan binding sizes complete initial and correction prompts from
-their actual numbered, metadata-bearing, JSON-escaped representation.
-Requests use explicit HTML/text accept headers and identity content
-encoding (`Accept-Encoding: identity`). An HTTP 403 receives one same-URL browser-compatible retry inside
-the original deadline and redirect/public-address policy. A persistent 403 remains fail-closed
-with its final URL, status, bounded error, and retry fact visible in durable provenance; the
-server never uses cookies, browser automation, mirrors, snippets, or provider-fetched text.
-Redirect destinations govern URL eligibility, UGC/self-source classification, packet identity,
-and the persisted source URL; a benign discovery URL cannot launder an ineligible destination.
-Persisted claim provenance includes the captured-text digest and cold authority/entailment
-decisions, so legacy unattested support is researched once before freezing. A separate closed
-server-owned `capture_provenance` row retains the requested location, nullable effective HTTP(S)
-final URL, nullable response metadata, fallback fact, both digests, and bounded failure for every
-source outcome. Non-web repository/file/custom context therefore remains representable without
-pretending it was captured; model attestation cannot overwrite this provenance.
+### Review a branch or working tree
 
-The register is mechanically limited to load-bearing external propositions in three kinds:
+`critique_branch` reviews `base_ref..head_ref` in an isolated temporary worktree
+by default. To review local edits instead, pass `include_uncommitted: true`; that
+mode necessarily reads the live working tree, but the reviewer remains read-only.
 
-- `fact` — objective external-world state, event, quantity, identity, or history;
-- `design_principle` — a requirement, constraint, or recommended principle issued by the
-  external standard, regulator, protocol, platform, or vendor governing the plan;
-- `behavior` — behavior promised by an external API, dependency, platform, protocol, service,
-  or runtime on which the plan relies.
+Useful inputs are:
 
-All use `scope: "external"`. Repository state, code paths, internal history, implementation
-conformance, and internal function bridges are excluded from this register and remain the job
-of ordinary structural/code review and tests. Local decisions and project-authored preferences
-do not become external claims just because they are called “design principles.” Legacy
-repository claims are mechanically retired and stop consuming active inventory or prompts.
-Fresh model output mislabeled `repository` is rejected into bounded correction/debt rather than
-silently discarded, because it could actually be an eligible external premise.
+- `diff_intent`: what the change is supposed to accomplish;
+- `project_summary`: neutral project context;
+- `stakes`: the actual deployment, trust, scale, and failure consequences;
+- `focus`: an optional narrow concern; and
+- `already_raised`: short, accepted, `file:line`-cited claims from earlier rounds.
 
-External claims close only when an exact passage reproduced from Paranoia's server-captured
-page is accepted by the cold attester as both authoritative and entailing the exact proposition.
-Provider summaries, search snippets, and provider-fetched page text are not evidence.
-First-party documentation, standards,
-statutes/regulators, government data, original papers/datasets, and the relevant
-entity's records are preferred. Secondary material can corroborate or locate a
-source. Reddit, Stack Overflow, forums, social media, wikis, blogs, and other UGC
-can expose leads or conflicts, but the server prevents known UGC hosts from being
-treated as governing evidence even if the model labels them `primary`.
-Only canonical HTTP(S) web locations with a host can govern a verdict; repository,
-file, and custom-scheme locations remain context only. A repository plan's own canonical
-blob/raw HTTP(S) URL is also context, never evidence for its own assertions.
+You can bind an approved implementation plan to the branch review with
+`plan_text` or an absolute `plan_path`. The first plan-bearing round freezes that
+contract for the lineage; later rounds verify the implementation against the same
+text. Changing the contract requires a new lineage.
 
-Every contradicted or unresolved external claim returns an **actionable source packet**:
+### Review a plan
 
-- the verbatim plan wording and atomic proposition;
-- the canonical web URL and precise section/table/page;
-- publisher and authority class;
-- the exact supporting/refuting passage;
-- an evidence-entailed replacement when one is actually proven.
-
-Evidence that refutes old wording does **not** prove replacement wording. When no
-authoritative passage entails a replacement, the packet explicitly says to remove,
-weaken, or research the assertion instead of inventing a correction.
-If a reviewer nevertheless proposes unsupported replacement text, the server drops
-that optional text and retains the valid verdict and evidence packet; the cold attester
-judges the exact replacement separately from the refuted proposition. It does not
-discard the rest of the claim batch.
-Likewise, evidence that does not entail the model's `supported`/`refuted` verdict is retained
-only as context and that individual claim is forced to blocking `unverified`. One bad packet
-does not invalidate the rest of the audit.
-Other valid claims in the same response are still registered.
-If an indexed captured-text binding response omits an expected source key, the server materializes
-that omission as a distinct conservative outcome: its source becomes context and any claim left
-without qualifying evidence is forced to blocking `unverified`, with provenance that the binding
-row was omitted. A returned `usable:false` row instead records that the model explicitly marked the
-captured source unusable when a capture exists; if the server capture itself failed, the durable
-context records that server-owned failure reason instead. Valid rows in the same batch survive.
-Non-integer, unknown, or duplicate keys, malformed rows, unavailable captures claimed as usable,
-and passages absent from the capture still reject the batch and receive the bounded same-session
-correction.
-Cold-attestation rows apply the same exact-integer identity rule before key construction; Boolean,
-float, string, null, array, and object aliases cannot bind authority or entailment to another claim.
-If the bounded correction retry still contains an unbindable anchor, that item is
-recorded as explicit blocking audit debt while the retry's valid claims and valid
-removal dispositions are persisted. The next round therefore repairs one item
-instead of researching the whole inventory again.
-Likewise, a missing retained ID is detected before capture, rejects the initial discovery, and is
-named on the same search-capable correction retry. Only the corrected complete inventory is
-downloaded and bound. If the
-final retry still omits it, valid corrected packets are applied and only that retained claim
-is carried forward as blocking `unverified`; one omission does not invalidate the edit cone.
-
-#### Fully autonomous correction loop
-
-The spawned paranoia reviewer is deliberately read-only. “Autonomous” means the
-calling coding agent performs the edit/rerun loop without waiting for a human:
-
-1. call `critique_plan` with a stable `lineage`, explicit `stakes`, and `round: 1`;
-2. validate each blocking packet, then edit `plan_path` (or the source that produced
-   `plan_text`) using only a proven replacement or a justified removal/qualification;
-3. increment `round` and call again **after the edit**;
-4. after exhaustive round 1, the server freezes every exact unchanged supported claim with
-   its authoritative packet. The claim verifier receives only edited/new eligible external
-   wording plus retained refuted or unverified claims.
-   Freeze identity includes the assertion-bearing Markdown block, structured heading levels,
-   and list-parent chain, so quoting, negating, moving into code, changing list ownership, or
-   relocating old words cannot preserve stale support;
-   Unverified, refuted, or otherwise non-freezable claims require complete current evidence
-   packets on the next targeted round; compact verdict-only assessments cannot cross the
-   server-capture boundary. Settled claims
-   cause no model call or web search. Edited claims inherit no verdict;
-5. repeat until the single computed trailer
-   says `CONVERGENCE: NOT-BLOCKED`.
-
-Claim targeting changes only the external-evidence phase. Structural review runs a complete cold
-three-lane census for a new lineage/cleared snapshot, targeted correction against its durable debt,
-then one complete cold final regression. The full plan, repository, active claim register, and
-class lineage remain available throughout.
-The structural reviewer can still find architectural and repository blockers, but it is told
-not to manufacture evidence-register claims for repository mechanics or missing atomic bridges.
-
-Do not rerun unchanged text expecting reviewer variance to fix a claim. Do not ask a
-human to translate evidence the packet already makes actionable. A human may inspect
-or override the process, but is not required for ordinary convergence.
-
-A later audit cannot clear a prior claim by omitting it or attaching its ID to edited text.
-Exact propositions alone retain identity. Otherwise the old external anchor must actually
-leave the plan and receive an explicit `removed` disposition; there is no model-only
-`nonfactual` escape. To make that closure efficient, the server lists every prior anchor
-that is absent from the current plan as a removal candidate in both the initial audit and
-its correction retry. The reviewer must still confirm an explicit `removed` disposition;
-absence is never an automatic retirement. The old packet remains active as `unverified`
-until then. The cold structural reviewer receives the complete evidence for every
-supported claim and every current-round disposition, so model-supplied authority and
-entailment labels are independently checked before the combined gate can clear.
-One plan audit may contain up to 500 claims and 20 evidence rows per claim as schema-corruption
-guards, but its composed execution budget is deliberately narrower: at most 200 source captures
-and five 400,000-character binding batches. Exceeding an aggregate budget becomes visible
-blocking debt; the server never starts a multiplicative hours-long tail or truncates it into
-false closure.
-The complete evidence phase has an 8,160-second monotonic circuit breaker and 22 model calls
-maximum. Whole-plan discovery and its one correction each receive 900 seconds; the five
-maximum-size binding batches, five exact-size cold-attestation batches, and their corrections keep
-the 300-second phase cap. Before first spend the server reserves that complete 22-call graph, 300
-seconds for capture and bounded local processing, and 60 seconds of scheduling slack. Before each
-initial call it also reserves both call-count and the full timeout for its correction.
-Every claim and staged attempt row records the timeout actually supplied to the provider and the
-local monotonic call duration, with a provider-reported duration retained separately when present,
-so retained acceptance can distinguish an enforced cap from an inferred role policy. Successful
-and failed rows both retain the actual return code plus separate bounded, hashed raw-output,
-structured-detail, and stderr channels.
-The capture pool and exact pre-binding packing share that one enforced 300-second monotonic
-deadline; exhaustion blocks visibly before the first binding call rather than consuming time
-reserved for later model phases.
-These are pathology guards, not targets or reasons to shorten an admitted review. The full verified
-plan call remains bounded to 8,280 seconds inside the documented 8,400-second MCP timeout.
-If exact packing would require a sixth binding or cold-attestation batch, the complete evidence
-phase fails globally before that role spends or settles any prefix. The limit cannot act as
-cross-round pagination for a partially supported inventory.
-Evidence state is persisted first. A staged census starts only when its full 4,320-second
-lane/consolidation/retry reserve still fits; correction and final use a 3,120-second reserve. If the
-reserve no longer fits, the result is visibly pending and the next round reuses frozen supported
-claims instead of repeating research. The exact same-snapshot legacy claim-only migration needs
-no provider call and is applied before this positive model-reserve admission. Individual structural
-calls use 1,800/1,200/2,400 and
-600-second role limits. A legacy class-register correction has its own 600-second cap under the
-same deadline.
-The disposition parser consumes the claim ID, `removed` token, and reason while ignoring
-harmless extra model metadata; required fields, unambiguous aliases, and transition validity
-remain strict. Both governing coverage arrays remain required even when empty, and malformed
-required values receive the normal bounded correction attempt rather than escaping the audit
-failure path.
-
-On upgrade, active rows from the replaced versionless claim-array schema become explicit
-blocking migration debt and force one exhaustive external audit; they are never interpreted as
-an empty verified register. Empty legacy inventory migrates without work. This is separate from
-version-1 repository rows, which are known mechanically out of scope and retire from inventory.
-
-When unresolved old wording is still present, it is not rediscovered from scratch. The server
-supplies its exact ID, anchor, proposition, and retained packet as a mandatory targeted
-checklist. A missing unresolved ID makes the response invalid and triggers the one bounded
-correction request before state is committed. Exact unchanged supported IDs are server-frozen
-outside that prompt. A malformed targeted audit records blocking debt but does not invalidate
-those settled packets, so one edited assertion cannot turn hundreds of supported claims back
-into research work.
-
-### `lineage` — which loop this round belongs to
-
-Class state lives in `~/.paranoia/lineages/<lineage>.json`.
-
-- `critique_branch` derives the key from repo + `base_ref` + reviewed branch. Pass
-  `lineage` explicitly when the reviewed ref is **not** a branch (a detached HEAD
-  or a raw commit), where there is no stable key to derive.
-- `critique_plan` **always requires** an explicit `lineage` — a plan has no branch,
-  and nothing is derived from its text or path.
-
-The key is used verbatim as the state filename with no namespacing, so make it
-globally unique and mode-qualified: `myproject-42-plan` for a plan seam,
-`myproject-42-branch` for the branch seam of the same work. A key already used by
-the other tool is refused rather than merged.
-
-### When to stop
-
-The stop condition is **two-part**:
-
-1. the computed trailer reads `CONVERGENCE: NOT-BLOCKED` (all active external claims
-   supported and no blocking class open), **and**
-2. the round returns `CONVERGED`, or only `[MINOR]`/`[OUT-OF-SCOPE]` items.
-
-When the two disagree, **the trailer governs** — and says so in its own output.
-
-### One-shot reviews
-
-For a review with no loop behind it — a design sketch, a quick second opinion —
-pass `class_closure: false`. That is the single escape, and it also drops the
-`round` and `lineage` requirements.
-
-For plan reviews, one-shot mode still performs default external-claim verification and returns
-source packets, but emits **no computed `CONVERGENCE:` line**. Without a parsed class
-register the server cannot incorporate the structural review's free-text FATAL/MAJOR
-findings into a mechanical clearance. Use the default tracked mode for convergence.
-
-```json
-{ "repo_path": "/path/to/repo", "plan_text": "…", "class_closure": false }
-```
-
-### Handling a false positive
-
-When a registered regex matches a line that does not actually violate the
-invariant, exempt that exact line:
-
-```json
-"exempt": [{
-  "class_id": "3f2a91c4",
-  "path": "src/app.py",
-  "line": 17,
-  "line_text": "    legacy_open(state)"
-}]
-```
-
-`line_text` must be byte-exact including indentation. The exemption is keyed on it
-and goes void the moment that line changes, so the match resurfaces. Every
-exemption is shown to every later reviewer, with the invariant attached, so it can
-be challenged; `unexempt` takes the same `class_id`/`path`/`line` and revokes one.
-
-A match inside a binary blob cannot be exempted — narrow the class's `PATHSPEC`
-instead.
-
----
-
-## Tool reference
-
-Arguments marked **required** are enforced; everything else has the default shown.
-
-### `critique_branch`
-
-Adversarial review of a git branch, a committed range, or the dirty working tree.
-Returns a [five-section critique](#review-output) plus a
-[`CONVERGENCE:` trailer](#class-closure-trailer).
-
-| Argument | Type | Default | Description |
-|---|---|---|---|
-| `repo_path` | string | **required** | Absolute path to the git repo |
-| `base_ref` | string | `main` | Base ref for the diff |
-| `head_ref` | string | `HEAD` | Head ref to review |
-| `round` | integer | **required** unless `class_closure: false` | 1-based caller label; after a settled tracked round it must strictly increase. Forward jumps count toward persistence; a failed/rejected label may be retried |
-| `include_uncommitted` | boolean | `false` | Review the dirty working tree vs HEAD instead of a committed range. Runs in the live repo, not a worktree |
-| `isolate` | boolean | `true` | Review inside a throwaway worktree of `head_ref`. Ignored for uncommitted reviews |
-| `converge` | boolean | `true` | Pre-gather a bounded deterministic diff/file packet and materialize an immutable snapshot for tracked broad review. Always materializes, overriding `isolate` |
-| `max_packet_chars` | integer | `400000` | Character budget for that packet. `already_raised` is always preserved; only file evidence is trimmed |
-| `plan_text` | string | — | Optional implementation contract for tracked convergence. Mutually exclusive with `plan_path`; its exact accepted UTF-8 text is checked throughout the branch lifecycle |
-| `plan_path` | string | — | Optional path to the implementation contract. Read once before review and then treated identically to `plan_text` |
-| `plan_digest` | string | — | Optional assertion for the supplied plan: the existing 16-hex frozen digest or a full 64-hex SHA-256. The server computes the authoritative full digest |
-| `class_closure` | boolean | `true` | Track defect classes across rounds. `false` is the one-shot mode |
-| `lineage` | string | derived | Explicit class-closure key. Required when the reviewed ref is not a branch |
-| `exempt` / `unexempt` | array | — | Mark or revoke false positives of a class's regex — see [above](#handling-a-false-positive) |
-| `stakes` | string | — | The scope boundary |
-| `already_raised` | array | `[]` | Claims already accepted from prior rounds |
-| `project_summary` | string | — | Neutral factual description of the project. The reviewer tests the diff against it |
-| `diff_intent` | string | — | What the diff is *supposed* to achieve. Treated as a claim to verify, never a fact to accept |
-| `focus` | string | — | Narrow the review to a specific concern |
-| `engine`, `model`, `effort`, `web_search` | — | see [Common arguments](#common-arguments) | |
-
-`converge: false` falls back to a legacy in-place review that has no class closure,
-so it must be paired with `class_closure: false`.
-
-When a plan contract is supplied, branch review checks every plan obligation for an
-implementation or traceable deferral, every named acceptance criterion through its named
-entry point, and every new persisted/public contract for correspondence with the plan.
-The plan is displayed under a separate numbered `plan:` evidence namespace and is bound
-with the pinned Git snapshot across census, retry, correction, and cold final. It is
-project-authored specification data, not external evidence, and branch review does not
-reopen the plan's design review.
-Plan-bearing reviews require `converge:true` and `class_closure:true`; the legacy
-one-shot path is rejected rather than given a weaker repository/contract binding.
-The first plan-bearing branch-lineage round freezes the contract's full digest and exact
-text in a closed, versioned top-level authority record before provider work. A contract-free
-lineage retains the acquired authority latch through its first review; once substantive, missing
-authority is immutable absence, so neither kind of first review can race the other.
-Later rounds reuse that stored text; adding,
-removing, or changing the contract requires a new explicit lineage. Audit logs remain
-diagnostic and need no special retention for plan evidence.
-`plan_path` must be absolute; it is resolved/read once, and all review consumers use the
-captured text rather than rereading the mutable path.
-The first plan-bearing reservation requires `round: 1`; contract-free branch reviews keep
-their existing round-label behavior. Supplying a plan for a missing lineage at a later
-round blocks instead of silently recreating contract authority.
-Plan anchors govern only while that active lineage state is available. A continuing round
-with missing/unreadable lineage yields `STATE-UNAVAILABLE`; paranoia-local does not treat best-effort logs as a
-backup authority or promise historical citation replay after state loss.
-The checked-in `docs/branch_plan_fidelity_acceptance_2026-08-22.json` records bounded,
-source-bound signed-in Codex attempts for one blocked nonconforming branch and one independently
-clear conforming branch through the production handler; its claims are deliberately limited to
-those two fixtures.
-
-### `critique_plan`
-
-Adversarial review of a plan or design document. The reviewer reads the real code
-to test every premise the plan makes about current behaviour. Returns the same
-five sections, tagged `[FATAL]`/`[MAJOR]`/`[MINOR]`/`[OUT-OF-SCOPE]`.
-
-| Argument | Type | Default | Description |
-|---|---|---|---|
-| `repo_path` | string | **required** | The repo the plan concerns |
-| `plan_text` | string | **one of these two** | The plan as markdown |
-| `plan_path` | string | **one of these two** | Absolute path to a markdown plan file |
-| `round` | integer | **required** unless `class_closure: false` | 1-based caller label; after a settled tracked round it must strictly increase. Forward jumps count toward persistence; a failed/rejected label may be retried |
-| `lineage` | string | **required** unless `class_closure: false` | Globally unique, mode-qualified key. Nothing is derived |
-| `class_closure` | boolean | `true` | Unmechanized classes only. `false` is the one-shot mode |
-| `claim_verification` | boolean | `true` | Verify load-bearing external facts, externally issued design principles, and promised external behaviors with authoritative built-in web evidence before structural review. Set `false` only for an explicit legacy structural-only review |
-| `context` | string | — | Background the reviewer needs to judge the plan fairly |
-| `focus` | string | — | Narrow the review to a specific concern |
-| `stakes` | string | — | The scope boundary |
-| `already_raised` | array | `[]` | Claims already accepted from prior rounds |
-| `engine`, `model`, `effort`, `web_search` | — | see [Common arguments](#common-arguments) | `web_search: false` is rejected while claim verification is enabled |
-
-`class_closure` and `lineage` are **call arguments only** here — `.paranoia.toml`
-is not consulted for either.
-
-### `query`
-
-One question, one answer. Not a full review: no five-section scaffold, lower
-reasoning effort by default. The reviewer reads the repo (when given one) and
-returns a direct answer, citations, and a stated confidence level.
-
-| Argument | Type | Default | Description |
-|---|---|---|---|
-| `question` | string | **required** | The specific question to double-check |
-| `repo_path` | string | — | Repo to ground the answer in |
-| `files` | array | `[]` | `{path, reason?}` hints to look at first — hints, not a payload; it can read anything |
-| `focus` | string | — | Extra framing for the question |
-| `engine`, `model`, `effort`, `web_search` | — | `effort` defaults to `medium` | |
-
-### `rebut`
-
-Dispute one finding from a review. Resumes **that same reviewer session** with your
-counter-evidence, so it is cheaper and higher-resolution than a fresh round. The
-reviewer replies `CONCEDE` or `HOLD` with fresh citations.
-
-| Argument | Type | Default | Description |
-|---|---|---|---|
-| `repo_path` | string | **required** | Same repo the review ran against |
-| `session_ref` | string | **required** | From the prior review's footer |
-| `rebuttal` | string | **required** | Your counter-evidence |
-| `lineage` | string | — | With `class_id` and `lineage_mode`, reset a gated class's correction window after this rebut |
-| `class_id` | string | — | Exact gated class ID; requires `lineage` and `lineage_mode` |
-| `lineage_mode` | `plan` or `branch` | — | Mode of the named lineage; requires `lineage` and `class_id` |
-| `engine`, `model`, `effort`, `web_search` | — | see [Common arguments](#common-arguments) | |
-
-The three class-binding arguments are all-or-none. A bound rebut is accepted only for the
-current session durably stored for that class. Success grants another bounded correction window
-but does not close the class or debt, change severity, or itself produce clearance. A provider or
-state-write failure records no reset. A legacy exhausted class with no stored session gets no
-extra provider call: its ordinary gated correction and single validation retry may acquire the
-current session only when they terminate specifically on the correction gate. If neither attempt
-returns a valid session, the trailer offers only close/replacement recovery.
-Repeated or backward tracked round labels return a zero-attempt blocked review with an exact
-audited trailer; they do not call the provider or enter cache, snapshot, packet, or worktree work.
-Retained correction-gate acceptance replay also binds its bounded attempt-channel digests and
-exact response evidence to the artifact's committed Git blob; local edits cannot forge matching
-ledger copies without failing that envelope check.
-
-### `arbitrate`
-
-Decides between 2–4 options. Both frontier vendors judge independently and cold
-over one pinned snapshot, and Python computes the verdict.
+Tracked plan reviews require an explicit, stable lineage because plans do not
+have a branch name that can identify their history.
 
 ```json
 {
-  "repo_path": "/Users/you/Work/my-project",
-  "decision": "Choose the numeric type for the position-size threshold.",
-  "options": [
-    {"id": "opt-float",   "statement": "Store it as a float."},
-    {"id": "opt-decimal", "statement": "Store it as a Decimal."}
-  ],
-  "stakes": "Internal CLI, single team, threshold used only in a log line.",
-  "files": [{"path": "scripts/lib/registry.py", "reason": "the writer"}]
+  "name": "critique_plan",
+  "arguments": {
+    "repo_path": "/absolute/path/to/project",
+    "plan_path": "/absolute/path/to/project/docs/overdraft-plan.md",
+    "lineage": "payments-42-plan",
+    "round": 1,
+    "stakes": "Internal API; one service team; about 1,000 requests/minute."
+  }
 }
 ```
 
-What it does, in order:
+The reviewer reads the repository to test the plan's claims about current
+behavior. By default, it also verifies load-bearing external facts, requirements,
+and dependency behavior. Search discovers candidate URLs; Paranoia downloads the
+pages, extracts the text, binds exact passages, and uses a separate cold check for
+authority and entailment. Search summaries, snippets, and user-generated content
+cannot close a claim.
 
-1. **Pins one snapshot.** Each decider gets its own inert materialization of the same raw Git
-   tree and bounded metadata history. Git filters, hooks, textconv, executable bits, symlinks,
-   gitlinks, and lazy-fetch helpers are never executed as part of evidence presentation.
-   Initialized submodules contribute their currently checked-out commit; uninitialized
-   submodules retain the pinned superproject gitlink.
-   Every Git evidence read—including citation resolution, label scans, refs, trees, symlinks,
-   and blobs—uses the shared inert launcher with lazy fetching disabled, so a missing promised
-   object cannot execute a repository-configured transport.
-   Git refs and the reflog are digested before and after. Movement while the snapshot
-   is being built fails before model spend; later movement is reported as
-   `REFS-MOVED: yes` provenance and cannot change the inert views the deciders saw.
-2. **Neutralizes the framing** with an Opus agent — advocacy and rhetorical presentation
-   asymmetry stripped without transferring facts, constraints, caveats, or qualifications between
-   options — then has the *other* vendor attest that field by field. Substantive differences in
-   option detail remain intact for the deciders.
-   `stakes` and caller `context` are passed through verbatim, never rewritten.
-   Stakes are server-owned read-only cleaner input and are not part of the cleaner's
-   output schema; undeclared cleaner output blocks are rejected.
-   The attester separately rejects advocacy in either caller-owned field. It also
-   judges the complete canonical originals for neutrality. If a complete bounded
-   cleaner candidate is unusable but those originals pass, the server atomically
-   sends the original decision, options, and validated hints to both deciders and
-   reports `CLEANING: original-attested`; it never mixes original and cleaned fields.
-   Facts, governing constraints, costs, risks, tradeoffs, and consequences remain merits context even
-   when they affect the options unequally; asymmetry alone is not advocacy. A neutral record that a
-   prior decision exists and governs the current bytes is shared context. Directives, endorsements,
-   rhetorical preference, pre-emptive conclusions, praise for a prior result, or instructions to
-   follow it still fail the context/stakes gate.
-   The retained [consequence-framing acceptance](docs/arbitration_consequence_acceptance_2026-08-22.json)
-   exercises this distinction through the real cleaner, cross-vendor attester, and both deciders;
-   separate [stakes steering](docs/arbitration_steering_rejection_acceptance_2026-08-22.json)
-   and [context steering](docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json)
-   cases stop after the attester. Each negative case proves its complete packet is rejected, not
-   that every phrase in that packet independently triggers the gate. A closed replay validator
-   requires an exact per-route source manifest, byte-identical replayed production modules and inert
-   Git launcher, hash-checked historical replay-validator sources, inert source/snapshot evidence,
-   exact prompts and replies, the configured cleaner/attester engine-model identities, parsed votes,
-   and recomputed outcomes. Acceptance inputs may not override the cleaner model; validator changes
-   do not force a provider rerun when the recorded production route is unchanged. Every historical
-   blob read first resolves the recorded revision as that exact commit; missing or non-commit objects
-   fail before any `revision:path` specification is constructed. The proof envelope has a closed
-   top-level and input schema and server-owned claim/limitation text. Unbound wall-clock and branch-
-   diff observations are intentionally omitted; the retained provider attempt ledger is the execution
-   evidence. Proof inputs retain only caller content plus route-defining `clean`, `research`,
-   `web_search`, and `order_seed`: caller content is replayed against `raw_input`, route booleans are
-   fixed to the exercised path, and the seed must equal the audit. Local paths and effort settings are
-   operational inputs, not proof claims, and are omitted from the envelope. Nested proof input is
-   closed too: exactly two unique, nonempty `{id, statement}` option rows and one nonempty
-   `{path, reason}` file row; extensions, duplicate IDs, and duplicate file rows reject. Numeric
-   proof fields use exact JSON integer types, so booleans, floats, strings, and nulls cannot alias
-   `version` or the retained model-call count.
-3. **Researches shared external premises by default.** Codex live search and Claude
-   `WebSearch` independently discover candidate URLs in parallel. The server downloads and
-   extracts them with Trafilatura; the same sessions bind exact passages with browsing disabled.
-   Claude `WebFetch` is not enabled. Python deterministically unions the results, hard-demotes
-   known UGC hosts, rejects caller IDs anywhere in the complete rendered packet, and sends
-   byte-identical packets to both deciders.
-4. **Counterbalances presentation.** One decider sees canonical order, the other
-   reversed, under opaque per-decider labels. Neither is told the other exists.
-5. **Computes the verdict.** No model adjudicates the adjudication. A decisive external
-   reference must name a captured packet and explicitly pass publisher-authority,
-   passage-entailment, and decision-relevance checks.
-6. **On divergence**, runs one reconciliation round carrying only `path:line`
-   citations and bytes the server itself read — never the other model's prose —
-   and only when there is genuinely novel evidence.
+Set `claim_verification: false` only when you deliberately want a structural-only
+review. See [external claim verification](docs/how-it-works.md#external-claim-verification)
+for the evidence model and limits.
 
-| Argument | Type | Default | Description |
-|---|---|---|---|
-| `repo_path` | string | **required** | Repository context to pin; decisive evidence may be a repository citation or captured source packet |
-| `decision` | string | **required** | What is being decided (max 2500 chars) — not the evidence for it |
-| `options` | array | **required** | 2–4 mutually exclusive `{id, statement}`. Array order is irrelevant; canonical order is derived by sorting ids |
-| `stakes` | string | **required** | Max 20000 chars; pass `"unstated"` to accept a fixed default reading |
-| `context` | string | — | Facts and specification shared by every option (max 20000 chars) |
-| `files` | array | `[]` | Up to 32 `{path, reason?}` starting points; each reason max 1200 chars. Both deciders see the same list |
-| `subject` | string | — | Short label for the paste-ready record block |
-| `clean` | boolean | `true` | Run the cleaner and its cross-vendor attestation |
-| `models` | object | — | `{codex?, claude?}` per-vendor overrides |
-| `cleaner_model` | string | `claude-opus-5` | Override the cleaner model |
-| `order_seed` | string | — | Replay a previous run's `ORDER-SEED` to reproduce its labels and ordering |
-| `retain_snapshot` | boolean | `false` | Create `refs/paranoia/arbitrate/<stamp>` so evidence survives `git gc` |
-| `research` | boolean | `true` | Run bounded shared external research. Set `false` only for an explicit repository-only decision; both deciders then run with web disabled |
-| `effort`, `web_search` | — | see [Common arguments](#common-arguments) | |
+### Ask a focused question
 
-`research: true` requires `web_search: true`; the incompatible combination is rejected before
-any model call. `web_search` authorizes only the isolated discovery roles. Binding and every
-decider call run with web disabled, and other evidence roles retain their narrower tool surface.
-Claude evidence roles use matching
-availability and permission allowlists on fresh and resumed calls; denial of a tool required by
-the active role is a visible provider-capability failure, never an empty-search success. Binding
-and text roles use explicit empty allowlists. Only server-captured packets can affect substantiation.
-Evidence roles require Codex CLI 0.144.6 or later and Claude Code 2.1.197 or later. Newer versions
-are accepted; compatibility is then checked by the real call, so unsupported flags or tools,
-permission denial, missing structured output, and malformed provider envelopes remain visible
-blocking failures.
-Signed-in structured probes and complete verified-plan lifecycles on later Claude and Codex
-releases are recorded in
-[`docs/minimum_provider_cli_acceptance_2026-08-16.json`](docs/minimum_provider_cli_acceptance_2026-08-16.json).
-The signed-in end-to-end record, including exact versions, packet digest, source references,
-plan-claim closure, repository-only closure, and defects found by the first real runs, is
-[`docs/evidence_capture_acceptance_2026-08-10.json`](docs/evidence_capture_acceptance_2026-08-10.json).
+Use `query` for a fast second opinion:
 
-**`arbitrate` has no `engine` or `model`** — it drives both vendors, so a single
-override could only degrade it to one of them or send one vendor's model name to
-the other CLI.
+```json
+{
+  "name": "query",
+  "arguments": {
+    "question": "Can this retry loop duplicate a payment?",
+    "repo_path": "/absolute/path/to/project",
+    "files": [{"path": "src/payments/retry.py", "reason": "retry owner"}]
+  }
+}
+```
 
-**Input bounds**, checked before anything is spent:
+It returns a direct, cited answer with a confidence level and does not create a
+tracked review.
 
-| Bound | Limit |
+### Challenge a finding
+
+Every review returns a `session_ref`. Pass it to `rebut` with concrete
+counter-evidence:
+
+```json
+{
+  "name": "rebut",
+  "arguments": {
+    "repo_path": "/absolute/path/to/project",
+    "session_ref": "<session_ref from the review>",
+    "rebuttal": "The call is guarded by the transaction opened at db.py:74."
+  }
+}
+```
+
+The same reviewer session responds `CONCEDE` or `HOLD` with fresh citations.
+For a persistently gated class, optional `lineage`, `class_id`, and
+`lineage_mode` arguments can reset its bounded correction window after a
+successful rebuttal. They do not close debt or grant clearance.
+
+### Arbitrate a decision
+
+`arbitrate` runs both vendors independently over one pinned repository snapshot:
+
+```json
+{
+  "name": "arbitrate",
+  "arguments": {
+    "repo_path": "/absolute/path/to/project",
+    "decision": "Choose the numeric type for the position-size threshold.",
+    "options": [
+      {"id": "float", "statement": "Store the threshold as a float."},
+      {"id": "decimal", "statement": "Store the threshold as a Decimal."}
+    ],
+    "stakes": "Internal CLI; the threshold is used only in a log line.",
+    "files": [{"path": "scripts/lib/registry.py", "reason": "current writer"}]
+  }
+}
+```
+
+Put facts shared by every option in `context`. Put each option's distinct
+mechanism, scope, tradeoffs, and consequences in its own `statement`. Research is
+enabled by default; Paranoia gives both deciders the same server-captured evidence
+with live browsing disabled. Python computes the outcome rather than asking a
+third model to choose between the votes.
+
+`arbitrate` is the only tool that consumes both subscriptions in one call. Read
+its [full reference](docs/tool-reference.md#arbitrate) before relying on the
+outcome or using `retain_snapshot`.
+
+## Tracked reviews
+
+Tracking is on by default for branch and plan reviews. A tracked review has three
+phases:
+
+1. **Census:** three cold review lanes inspect the complete artifact and one call
+   consolidates their findings.
+2. **Correction:** later rounds target durable debt and the effects of your fixes.
+3. **Final:** after debt closes, one fresh whole-artifact regression is required.
+
+A clear census can finish immediately. Otherwise, increase `round` only after
+you have changed the reviewed artifact. Failed or rejected rounds can reuse the
+same label; a successfully settled round requires the next label to increase.
+
+Paranoia tracks both concrete findings and reusable defect classes. Blocking
+classes remain open across rounds even if a reviewer forgets to mention them.
+Mechanized branch classes are rechecked against each snapshot. Plan classes are
+procedural and require explicit reviewer closure. `MINOR` and `OUT-OF-SCOPE`
+classes remain visible but do not block convergence.
+
+The key trailer fields are:
+
+| Field | Meaning |
 |---|---|
-| option statement | 1200 chars |
-| `decision` | 2500 chars |
-| `context` | 20000 chars |
-| `stakes` | 20000 chars |
-| file hints | 32; 1200 chars per stripped reason; 20000 chars in the canonical `- path (reason)` downstream rendering |
-| cleaner reply | 50000 chars |
-| complete cleaner or attester prompt | 180000 chars |
-| complete initial or correction decider prompt | 240000 chars |
+| `CLASS-CLOSURE` | Open and closed reusable classes |
+| `STRUCTURAL-PHASE` | The next tracked phase: `census`, `correction`, `final`, or `clear` |
+| `STRUCTURAL-DEBT` | Remaining blocking findings |
+| `CLAIM-CLOSURE` | External-plan-claim status, when verification is enabled |
+| `CONVERGENCE` | The single governing `BLOCKED` or `NOT-BLOCKED` result |
 
-Put only facts and specification shared by every option in `context`. Keep each
-option's distinct mechanism, scope, consequences, caveats, and qualifications in that
-option's own statement. Substantive detail may differ; the cleaner may normalize
-presentation but may not transfer content between options to make their lengths match.
+`NOT-BLOCKED` means the tracked gates are clear under the stated stakes. It is a
+review result, not proof that the artifact is correct.
 
-**Behaviour worth knowing before you rely on it:**
+For lifecycle details, persistence controls, false-positive exemptions, and
+failure recovery, read [How Paranoia works](docs/how-it-works.md).
 
-- **It decides only from pinned evidence.** A converging vote must cite either a repository
-  line that resolves or a governing server-captured `SOURCE:<packet-id>`. Provider summaries,
-  unknown packet IDs, and live decider browsing cannot substantiate convergence. Repository
-  citations resolve only against regular-file bytes exposed in the inert snapshot; historical
-  blobs and symlink-path referents are rejected because the reviewer did not receive those bytes.
-- **`ADVISORY` does not block.** Each decider reports whether it judges that a
-  named human owner should be authorizing the decision. That is reported, never
-  gated: `CONVERGED` with `ADVISORY: human-owner` is still `CONVERGED`. Enforcing
-  it is your policy.
-- **`SNAPSHOT` is provenance, not a replay handle.** The snapshot commit is
-  unreferenced and `git gc` reclaims it. The audit log holds both prompts, both
-  replies, and the carried evidence. `retain_snapshot: true` pins it behind a ref.
-- **`REFS-MOVED` is provenance after snapshot setup.** Deciders receive no live Git
-  directory: each sees a separate inert tree and bounded history rendered from
-  `SNAPSHOT`. A later branch advance therefore does not invalidate their votes. If
-  the initial or final ref/reflog observation fails, the run reports
-  `REFS-MOVED: unavailable` and records null digests plus the structured error; it
-  never aliases unavailable provenance to `no`.
-- **Research failures keep the state already established.** Their trailer and audit
-  retain the real snapshot, order seed, cleaning/attestation result, final ref digest,
-  completed peer research, bounded attempt replies, accepted discovery/capture
-  artifacts, bindings, sessions, usage, durations, and the engine or parser diagnostic.
-  Raw provider envelopes are stored as SHA-256 plus bounded excerpts. Structured
-  provider failure detail and process stderr remain distinct. Shared packet-union
-  and reserved-token failures use the same stateful path. If the durable audit sink
-  fails, the response includes a bounded, hashed fallback record containing the
-  accumulated attempts and accepted artifacts before the machine trailer.
-- **Captured claim-binding debt preserves all engine diagnostic channels.** Initial
-  and correction binding failures hash and bound provider stdout, structured failure
-  detail, and process stderr separately, so timeout and unavailable-executable debt
-  remains actionable even when the provider emitted no stdout.
-- **Every ordinary failure after snapshot setup uses that stateful path.** Cleaner,
-  attester, budget, label, evidence-resolution, and decision-setup failures therefore
-  cannot fall back to `SNAPSHOT: none` or erase cleaner/attester attempts, completed
-  research, label maps, decider prompts/replies/votes, or carried evidence.
-  Round-two carried bytes are recorded before either second-round call starts, and
-  even an initial execution failure retains the exact prompt as an attempt.
-  Failed staged attempts and their durable failure record retain return code, raw provider
-  stdout, structured failure detail, and process stderr as distinct bounded, hashed channels.
-  Once shared research completes, later failures retain the normalized packet bytes
-  and real `RESEARCH-DIGEST` as well as the per-lane ledger.
-  The packet becomes established immediately after normalization/rendering, so a
-  subsequent reserved-token rejection audits the exact rejected bytes and digest.
-- **Research attempts start before provider invocation.** The ledger binds phase,
-  intended session, and bounded prompt/digest before `run` or `resume`; a thrown
-  provider exception therefore counts as the attempted call and retains its binding.
-  Immediately before every discovery/binding invocation or validation resume, the
-  handler admits that attempt's full cap against the remaining monotonic whole-run
-  deadline; a refused call retains the already-established lane attempts. Research
-  JSON accepts markdown fencing and one measured terminal truncation only: a complete
-  outer object missing its final `}`. Internal or multi-character JSON damage remains
-  invalid and receives the one same-session correction before failing closed.
-- **Attempt state distinguishes preparation from spend.** Cleaner, attester,
-  research, and decider records expose whether a prompt was prepared, admitted,
-  invoked, completed, refused by the deadline, or blocked during inert-workspace
-  setup. Cleaner, attester, and decider attempts also record the requested engine
-  and model plus a closed execution route: `external-cli`, `injected-agent`,
-  `deterministic-cleaner`, or `not-invoked`. External routes retain the executable
-  and compatible CLI version; non-external routes retain neither. Call counts are
-  derived from these rows, not from separately asserted acceptance metadata.
-  A locally oversized composed prompt is retained as `local-rejected` with an exact
-  prompt binding and `admitted:false` / `invoked:false`. Cleaner/attester prompts
-  are capped at 180,000 characters and initial/correction decider prompts at 240,000.
-- **Cleaned packet audits are complete.** Success and late-failure records retain
-  cleaned decision, context, hints, and statements plus one digest of that exact
-  normalized packet. Cleaner and attester reply copies retain complete normal
-  protocol outputs up to a 32,000-character circuit breaker and always carry full-reply
-  digests. The cleaner's context copy is non-authoritative: the server always
-  restores the caller's exact context, including leading and trailing whitespace,
-  before attestation and voting. A changed fidelity verdict must name each field,
-  quote the original and cleaned passages, classify the semantic change with the
-  closed enum, and use the exact `<field>: <change>` reason label. The enum and bound
-  passages are the enforceable explanation; free-form semantic heuristics are not used. Valid option arrays are
-  audited as the same ID-to-statement mapping on success and every failure path.
-  `original-attested` means the attester rejected or mechanically disqualified the
-  cleaner candidate but explicitly passed the complete originals for neutrality;
-  the audit retains that rejected candidate while decider prompts record the exact
-  canonical originals actually used. The separately versioned
-  [`original-attested` acceptance](docs/arbitration_fallback_acceptance_2026-08-16.json)
-  binds that route to a reported destructive candidate, a signed-in Codex attester,
-  both signed-in decider prompts, attempt-derived provider versions and call routes,
-  elapsed time, and current source hashes. The source-hashed acceptance runner also
-  retains a separate ordinary signed-in Claude-cleaner compatibility run. Its fallback
-  cleaner candidate is deterministic, so it does not claim
-  that the current Claude cleaner will probabilistically reproduce the historical
-  rewrite. Regenerate both records with
-  `python scripts/run_arbitration_fallback_acceptance.py /absolute/repo/path`.
-  The older cleaning-attestation v1 artifact remains historical evidence for
-  the five-line protocol and is validated without inventing a v2 neutrality judgement.
-  Signed-in reproductions are recorded in
-  [`docs/cleaning_attestation_acceptance_2026-08-13.json`](docs/cleaning_attestation_acceptance_2026-08-13.json).
-  They prove that exact caller context and normalized options reached both deciders and
-  that the recorded cleaning lifecycle and production results are reproducible. The
-  positive run records a unanimous production result but does not independently attest
-  that its resolved repository citation entails either constraint. The original run
-  records ordinary decider selection divergence; it does not claim to exercise the
-  agreed-but-unsubstantiated fail-closed path.
-- **Cleaner and attester attempts use the same before-call discipline.** Provider
-  exceptions retain prompt bindings. Research becomes `running` only after deadline
-  admission, and packet digesting remains total on model-controlled Unicode.
-- **On divergence, only a decider that *moved* must ground in the carried
-  evidence.** One that held its round-1 position needs only a citation that
-  resolves — provided its round-1 decisive citation resolved too. A holder that
-  was never substantiated must ground in gained evidence like a mover.
-- **Bias is reduced, not eliminated.** Order counterbalancing equalizes mean rank
-  but not higher moments for 3–4 options; attestation is a model's judgement, not
-  a proof; and a `files` list pointing only at evidence favouring one option biases
-  both deciders identically. `docs/arbitration_plan.md` §2 enumerates the residuals.
+### One-shot reviews
 
-### Common arguments
+For an exploratory branch review with no durable convergence state, pass both:
 
-Accepted by the four review tools:
-
-| Argument | Values | Default |
-|---|---|---|
-| `engine` | `codex` \| `claude` | the server's configured engine |
-| `model` | any model name | the engine's strongest: `gpt-5.6-sol` / `claude-fable-5` |
-| `effort` | `low` \| `medium` \| `high` | `high` (`query`: `medium`) |
-| `web_search` | boolean | `true` |
-
----
-
-## Output reference
-
-### Review output
-
-Every completed review returns exactly five headings, in this order. One-shot reviews populate
-their natural categories; tracked staged plan and branch reviews put governing findings in `What
-doesn't work`, bounded remedies in `Improvements`, and write `Nothing notable.` in categories the
-settlement does not represent.
-
-| Section | Contains |
-|---|---|
-| `## What works` | Specific correct decisions, cited. "Nothing notable." when there are none |
-| `## What doesn't work` | Actual defects: quoted lines, failure mechanism, observable symptom. Worst first |
-| `## Risks` | Failure modes the author didn't consider that the code is exposed to |
-| `## Gaps` | What the change should do to reach its stated intent but doesn't |
-| `## Improvements` | Concrete changes that alter the outcome under the stated stakes |
-
-Every item in the last four sections carries exactly one severity tag:
-
-| Code review | Plan review | Meaning |
-|---|---|---|
-| `[BLOCKER]` | `[FATAL]` | Ships a bug / kills the plan as written |
-| `[MAJOR]` | `[MAJOR]` | Fix before merge / before execution |
-| `[MINOR]` | `[MINOR]` | Fix opportunistically |
-| `[OUT-OF-SCOPE]` | `[OUT-OF-SCOPE]` | Real, but beyond the stated stakes — file separately |
-
-A finding that recurs from a tracked class is marked `[RECURRENCE <class-id>]`
-next to its severity tag.
-
-The footer carries the `session_ref` for [`rebut`](#rebut).
-
-A terminal staged failure is deliberately not shaped like a successful review:
-
-```
-# STAGED REVIEW FAILED
-
-The staged structural review did not complete settlement. No durable structural verdict is available.
-
-## Diagnostic
-
-[paranoia-local error] ...
+```json
+{"class_closure": false, "converge": false}
 ```
 
-If settlement was computed but its durable write could not be confirmed, the lifecycle sentence
-says exactly that instead. The diagnostic is bounded and indented as inert code, and the result
-never emits `Nothing notable.` `STRUCTURAL-ERROR` encodes line breaks and controls as JSON string
-content on one trailer line, so retained provider text cannot create a heading or convergence row.
-
-### Tracked convergence trailer
-
-Appended below a staged tracked plan or branch review:
-
-```
-CLASS-REGISTER: staged census parsed — NEW 19ef00ab
-CLASS-CLOSURE: 1 open, 0 closed
-  19ef00ab repeated state transitions preserve their owner (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)
-STRUCTURAL-PHASE: correction
-STRUCTURAL-DEBT: 2 blocking open
-PERSISTENCE: 19ef00ab currently open; round-label span 3 (first raised 1, now 3), current debt open since 1 — repeated correction may be unsatisfiable within this unit's scope; rebut with session_ref=...
-STAGED-ATTEMPTS: total=4 validation-retries=0 validation-invalid=0 execution-failed=0
-CONVERGENCE: BLOCKED — staged structural debt remains open.
-```
-
-| Line | Meaning |
-|---|---|
-| `CLASS-REGISTER` | The class operations applied by this staged settlement, including canonical IDs minted by the existing class engine |
-| `CLASS-CLOSURE` | Open/closed reusable-class counts plus blocking class detail |
-| `STRUCTURAL-PHASE: census\|correction\|final\|clear` | The next broad/targeted gate; `final` requires one fresh cold regression |
-| `STRUCTURAL-DEBT: N blocking open` | Concrete governing findings still requiring correction |
-| `PERSISTENCE` | A currently blocking class spans at least three caller-supplied round labels; names that label span, current-debt start label, and the exact `rebut` session when available |
-| `REOPEN-WAVE` | One or more previously closed classes reopened this round; prior scope/disposition decisions need to be re-armed before another correction |
-| `STAGED-ATTEMPTS: total=N validation-retries=N validation-invalid=N execution-failed=N` | Exact call shape derived from the ledger: retry-role count, locally invalid response count, and all other non-completed attempts |
-| `CONVERGENCE: NOT-BLOCKED` | Structural debt/classes and, for plans, external claims are clear |
-| `CONVERGENCE: BLOCKED` | The named phase, debt, class, claim, format, or state condition still blocks |
-| `STRUCTURAL-ERROR` / `STRUCTURAL-PENDING` | A bounded format/deadline path did not produce a settled review |
-| `STATE-UNAVAILABLE` | Lineage state is unreadable, unwritable, or a previous write may not have completed. The message names the absolute path; repair or delete it, then re-run |
-
-`STRUCTURAL-DEBT` counts concrete governing findings only. An unbound live reusable class remains a
-first-class blocker in `CLASS-CLOSURE`; it is not duplicated into synthetic finding prose or given
-invented evidence anchors. The class trailer lists bounded path/line/text match detail and renders a
-binary recurrence as `path: binary match (line not shown)`. In that case the governing line says
-class closure remains open.
-Persistence first warns without blocking. It uses the durable first-class and current-debt labels
-plus the current caller-supplied round label and does not claim how many intervening rounds
-contained a finding. After six unresolved labels, another plain correction settlement is refused:
-the class must close or be replaced, or the operator must run a class-bound `rebut` against the
-current stored session to grant a new bounded correction window. Three undisposed reopen waves use
-the same gate. A rebut reset changes only the correction window; it cannot close debt or clear a
-class. The exact rendered trailer is retained in the audit JSON.
-`CORRECTION-GATE` is the human trailer row for a load-bearing class in that call.
-`correction_gates` is the audit's closed server-owned projection of the same pre-call rows:
-`class_id`, `reason` (`persistence`, `reopen`, or both), label `span`, and `reopen_count`.
-It is empty outside correction and for an ungated correction. A failed label does not advance
-durable `last_round`, so that label may be retried; a forward jump deliberately contributes its
-full distance. Provider/validation failure keeps substantive class and debt state unchanged,
-while an ambiguous lineage write keeps the pending latch and returns state unavailable.
-The lineage's closed `review_state.correction_control` V1 map has exactly one row per active
-nonsuperseded class. `reset_round` is the last durable bound-rebut or replacement reset,
-`reopen_count` is the undisposed reopen-wave count, and `last_session_ref` is only the valid
-session from the latest successful settlement that left the class blocking. A null or invalid
-current-attempt session clears stale authority. Terminal gate bootstrap reads only the exact
-validation-invalid terminal retry and fills only a previously sessionless row; it never searches
-backward to an earlier attempt or overwrites already-bound authority.
-The retained [class-persistence acceptance](docs/class_persistence_acceptance_2026-08-22.json)
-exercises that reopen and diagnostic lifecycle through the public branch handler with one real
-Codex call on a tiny synthetic committed diff.
-
-One-shot, injected-engine, and successfully persisted staged tracked trailers all retain
-`CLASS-REGISTER`, `CLASS-CLOSURE`, match, and unmechanized-class detail. If lineage state cannot be
-loaded or a write may not have persisted, the staged trailer instead emits `CLASS-REGISTER` plus
-`CLASS-CLOSURE: STATE-UNAVAILABLE`; reporting in-memory counts as durable in that case would be
-misleading. Staged plan and branch reviews additionally
-bind concrete debt to the corresponding canonical class IDs and use one final structural verdict;
-the class trailer does not emit a competing convergence line.
-
-`NOT-BLOCKED` asserts only that the computed structural-debt, class, and (for verified plans)
-external-claim gates are clear. It is a review result, not a proof that the change is correct.
-
-For verified plan reviews the claim gate and class gate are combined into one
-governing verdict:
-
-```
-CLAIM-REGISTER: 18 active external claims; 7 retired and excluded from active inventory
-CLAIM-CLOSURE: 17 supported, 1 refuted, 0 unverified
-ACTIONABLE SOURCE PACKETS:
-- CLAIM C-4e2d… — REFUTED
-  Plan wording: …
-  Atomic proposition: …
-  Evidence-entailed replacement: …
-  Source 1: [primary/refutes_claim] …
-    Location: https://… (Section 4, table 2)
-    Exact passage: …
-STRUCTURAL-CONVERGENCE: NOT-BLOCKED — staged structural debt is clear.
-CONVERGENCE: BLOCKED — external claim closure remains open.
-```
-
-`CLAIM-AUDIT-DEBT` includes the validator reason, SHA-256, and a bounded rejected
-output excerpt. Malformed model JSON, a failed audit/retry, unsupported authority,
-or missing entailment blocks; it never becomes an empty successful register.
-On upgrade, a same-snapshot predecessor that is in `correction` with no blocking structural debt,
-blocking or unbound class, or staged failure is the mechanically recognizable legacy shape created
-by claim-only phase pinning. The server migrates that structural phase directly to `clear` without
-spending a correction or final reviewer call; claim debt continues to block the combined verdict.
-If discovery and its single correction are both rejected locally, the debt reports the
-ordered initial and correction validator reasons and hashes the exact two provider envelopes
-joined by the discovery-correction separator. A successful provider process is not labeled as
-`reviewer failed (exit 0)` solely because its payload was invalid.
-
-### `arbitrate` outcomes
-
-| Outcome | Meaning |
-|---|---|
-| `CONVERGED` | Unanimous, unblocked, and each vote substantiated by a resolved citation |
-| `BLOCKED` | They agree on an option and one of them tags it `[MAJOR]`/`[FATAL]` |
-| `REFRAME_REQUIRED` | A decider surfaced a better unlisted option. Give it an id and re-run |
-| `UNRESOLVED` | Still split, or agreement nobody could substantiate |
-| `FAILED` | Preflight, execution, cleaning, parsing, capture, or protocol failure |
-
-The reply ends with a machine-readable trailer whose fields are always present:
-`ARBITRATION`, `SELECTED`, `ADVISORY`, `AUTHORITY-POLICY`, `CLEANING`, `SNAPSHOT`,
-`ORDER-SEED`, `REFS-MOVED`, `AUDIT`, `ROUNDS`, `RESEARCH`, and `RESEARCH-DIGEST`.
-
----
+For a one-shot plan review, pass `class_closure: false`; `converge` is not a plan
+argument. One-shot plan reviews still return structural prose and claim packets,
+but no computed convergence verdict. Plan-backed branch contracts are not
+available in one-shot mode.
 
 ## Configuration
 
-### `.paranoia.toml`
-
-Drop one at the repo root so callers stop retyping context. Keys go at the top
-level or under `[paranoia]`. Precedence: **call argument > `.paranoia.toml` >
-built-in default**.
+Add `.paranoia.toml` to a repository to avoid repeating branch-review defaults.
+Keys can be top-level or under `[paranoia]`. Precedence is call argument, then
+repository configuration, then built-in default.
 
 ```toml
-project_summary = "A booking API. Python/FastAPI, Postgres. Auth via short-lived JWTs."
+project_summary = "A Python booking API backed by Postgres."
 base_ref = "develop"
-stakes = "Internal booking API, single team, authenticated first-party callers, ~1k req/min."
+stakes = "Internal service; authenticated callers; one team; about 1,000 requests/minute."
 web_search = true
 isolate = true
 ```
 
-Honoured keys: `base_ref`, `project_summary`, `stakes`, `isolate`, `converge`,
-`class_closure`, `max_packet_chars`, `model`, `effort`, `web_search`.
+Supported keys are `base_ref`, `project_summary`, `stakes`, `isolate`,
+`converge`, `class_closure`, `max_packet_chars`, `model`, `effort`, and
+`web_search`.
 
-`critique_plan`'s `class_closure` and `lineage` are **not** read from here.
+For `critique_plan`, `lineage` and `class_closure` are call-only arguments and
+are never read from `.paranoia.toml`.
 
-### Command line
+The executable accepts:
 
-```
+```text
 paranoia-local --engine {codex|claude} [--log-dir DIR]
 ```
 
-| Flag | Default | Description |
-|---|---|---|
-| `--engine` | **required** | Which local engine performs reviews — the *other* agent from the caller |
-| `--log-dir` | `~/.paranoia/logs` | Audit-log directory |
+Audit records default to `~/.paranoia/logs/`. Durable review state defaults to
+`~/.paranoia/lineages/` and deliberately does not follow `--log-dir`. Set
+`PARANOIA_STATE_ROOT` to relocate lineage state.
 
-### State on disk
+## Safety and cost
 
-| Path | Contents |
-|---|---|
-| `~/.paranoia/logs/` | One JSON audit record per call: engine, model, round, `already_raised`, session ref, timings, review text, tracked `correction_gates`, and exact returned `rendered_trailer` (`null` for one-shot calls) |
-| `~/.paranoia/lineages/` | Atomic class + external-claim state, one file per lineage. Retired and mechanically out-of-scope claims are excluded from active prompt inventory |
+- Reviewers are read-only. The calling coding agent owns all edits and test runs.
+- Committed branch reviews use temporary worktrees; dirty reviews read the live
+  working tree without writing to it.
+- Verified plans and arbitration use inert repository materializations that do
+  not execute repository hooks, filters, helpers, symlinks, or executables.
+- Reviewer subprocesses ignore user tool configuration and receive only the
+  capabilities required for their role.
+- Paranoia uses the CLI subscriptions you are already signed into. It needs no
+  API keys and sends no Paranoia telemetry.
+- Tracked census reviews use multiple model calls. `query` is the lower-cost
+  choice for a single question; `arbitrate` is the most expensive tool.
+- `arbitrate` normally creates no durable Git ref. Opting into
+  `retain_snapshot: true` creates `refs/paranoia/arbitrate/<stamp>` until you
+  delete it with `git update-ref -d <ref>`.
 
-Lineage state deliberately does **not** follow `--log-dir`, so moving your logs
-cannot silently reset a tracked lineage. Set `PARANOIA_STATE_ROOT` to relocate it.
+Read the complete [safety, evidence, state, and rate-limit model](docs/how-it-works.md).
 
----
+## Troubleshooting
 
-## Safety model
+**The MCP call times out in Codex.** Set `tool_timeout_sec = 8400` in the MCP
+configuration shown in the quickstart.
 
-- **Role-bounded reviewer.** Ordinary reviews remain read-only. Evidence discovery receives
-  only provider search; binding and cold attestation receive no web or repository tools; verified
-  plan structure and arbitration voting receive only read access to an inert evidence tree and
-  no web. The reviewer cannot edit your code or run your test suite. The separate calling coding
-  agent owns autonomous corrections.
-- **Reviewer capability is hermetic.** Codex is spawned with `--ignore-user-config`:
-  authentication remains available, while registered MCP servers and user-configured tools
-  do not. This prevents a reviewer from recursively calling paranoia-local even when repo
-  instructions request it; model, reasoning effort, sandbox, and built-in web search are
-  supplied explicitly. Claude is spawned
-  with `--setting-sources ""`, so it loads no `.claude` settings files — otherwise
-  the reviewed repo's `.claude/settings.local.json` and your global settings would
-  merge on top of the allowlist, and those routinely grant `Bash(python3:*)` and
-  friends. This applies to the spawned reviewer subprocess only; it does not read,
-  write, or affect your interactive `claude` sessions. Codex also remains covered by its
-  OS-level sandbox, which no repo setting can loosen.
-- **Isolated.** Committed reviews run inside a throwaway `git worktree` of the
-  target ref, so they never collide with your working tree and can review a branch
-  that isn't checked out. Dirty-working-tree reviews necessarily run in the live
-  repo, read-only. Verified plan structure and arbitration instead use disposable inert
-  materializations, because those paths must not expose repository-selected Git helpers,
-  executable bits, symlink traversal, or live Git commands.
-- **No API keys, no telemetry.** The server shells out to a CLI you are already
-  signed into.
-- **Minimal footprint.** In `converge` mode the server creates a short-lived
-  worktree and a few unreferenced git objects in the target repo. Both are cleaned
-  up on exit and no ref is created. A hard crash can leave the worktree
-  registration until the next `git worktree prune` / `git gc`. Your working tree
-  and index are never touched. Verified plan and arbitration evidence modes create disposable
-  directories plus unreferenced snapshot objects, but no worktree registration.
+**The reviewer executable is unavailable or too old.** Run `codex --version` or
+`claude --version`, update the CLI, and confirm it is signed in in the same
+environment that launches the MCP server.
 
-  **One opt-in exception:** `arbitrate` with `retain_snapshot: true` creates
-  `refs/paranoia/arbitrate/<stamp>` so its evidence survives `git gc`. It is the
-  only mode in the server that writes a ref. Remove one with
-  `git update-ref -d <ref>`.
+**A tracked plan call rejects `lineage`.** Use a globally unique, mode-qualified
+key such as `myproject-42-plan`. Do not reuse a branch lineage for a plan.
 
-### Rate limits
+**A continuing review reports `STATE-UNAVAILABLE`.** Follow the absolute state
+path in the diagnostic. Repair or deliberately remove that lineage before
+starting again; audit logs are not backup authority for convergence state.
 
-Reviews draw on your subscription's agentic-usage pool. A tracked plan cold census is three concurrent
-reviewer calls plus consolidation; correction and final are one call each, with at most one bounded
-same-session validation correction per call. It covers schema and semantic settlement rejection and
-is recorded as `*-validation-retry`. Use `query` for quick checks.
+**You only need a quick opinion.** Use `query`, or deliberately select the
+one-shot settings described above.
 
-Audit `attempt_ledger` rows enumerate every provider run/resume exactly once. A synchronized
-sequence is assigned immediately before each concurrent census run/resume boundary, and the stage
-ledger is serialized by that sequence. Duration and session fields remain per-call telemetry.
+## Documentation
 
-For `critique_plan`, round 1 pays for the exhaustive external-claim inventory. Later rounds send
-only the external edit cone and unresolved claims to the claim verifier; an unchanged plan
-whose active claims are all supported makes zero claim-model calls. Structural correction then
-targets durable debt instead of paying for another broad novelty search; the cold final remains the
-regression gate.
-
-`arbitrate` is the expensive one and the only tool that spends from **both**
-subscriptions in a single call. Research is on unless `research: false` explicitly
-selects repository-only mode. Both modes validate each decider's exact supported
-evidence-isolation CLI profile before snapshot creation or model spend. A
-parser-rejected decider reply receives one
-complete correction attempt while the sibling result and completed cleaning/research
-work are retained. If correction still fails, the audit records both rejected replies,
-the completed sibling, and the actual phase provenance; execution failures are not
-retried. Every attempt remains subject to the phase cap and 7,200-second whole-call deadline.
-
----
+- [Complete MCP tool reference](docs/tool-reference.md)
+- [Review lifecycle, evidence, safety, state, and limits](docs/how-it-works.md)
+- [Dense LLM/agent operating reference](docs/llm-reference.md)
+- [Standard LLM documentation index](llms.txt)
+- [Claim-verification design and acceptance notes](docs/claim_verification.md)
+- [Arbitration design](docs/arbitration_plan.md)
+- [Developer and acceptance documentation](docs/)
 
 ## Development
 
-Validate a checked-in arbitration acceptance record against its exact durable audit
-and current production sources before treating it as release evidence:
-
-```bash
-python scripts/validate_arbitration_acceptance.py \
-  docs/arbitration_reliability_acceptance_2026-08-12.json .
-```
-
-The command fails on stale provider-call counts, packet identities/count/digest,
-audit digest, outcome/selection/snapshot, or production hashes.
-
 ```bash
 pip install -e '.[dev]'
-python -m pytest        # unit + integration; integration uses fake CLIs, no quota
-python scripts/run_staged_protocol_mutation_checks.py  # bounded Protocol v2 release gate
+python -m pytest
+python scripts/run_staged_protocol_mutation_checks.py
 ```
 
-The engine subprocess boundary is dependency-injected, so the whole stack is
-unit-tested without spending subscription quota. A separate integration test drives
-the real subprocess runner against fake `codex`/`claude` binaries on `PATH`.
+Tests use dependency-injected fake CLIs and do not consume subscription quota.
+The [`docs/`](docs/) directory contains design records and signed-in acceptance
+artifacts for provider-sensitive paths.
 
-Design documents for the two non-obvious subsystems live in
-[`docs/`](docs/): [`class_closure_plan.md`](docs/class_closure_plan.md),
-[`plan_class_closure_proposal.md`](docs/plan_class_closure_proposal.md), and
-[`claim_verification.md`](docs/claim_verification.md), and
-[`arbitration_plan.md`](docs/arbitration_plan.md). The proposed simplification of the
-staged model contract is specified in
-[`staged_review_protocol_v2_plan.md`](docs/staged_review_protocol_v2_plan.md), with
-implementation evidence in
-[`staged_review_protocol_v2_acceptance.md`](docs/staged_review_protocol_v2_acceptance.md). Its
-census-outcome amendment is specified in
-[`derive_census_class_outcomes_plan.md`](docs/derive_census_class_outcomes_plan.md).
-The issue #42 class-register amendment is specified in
-[`keyed_class_decision_plan.md`](docs/keyed_class_decision_plan.md), with exact fresh/resumed
-Codex and Claude capability evidence in
-[`keyed_class_decision_provider_acceptance_2026-08-19.json`](docs/keyed_class_decision_provider_acceptance_2026-08-19.json).
-That bounded gate covers census, correction, and final schemas on both fresh and resumed routes.
-Its signed-in production-handler lifecycle and executable replay are retained in
-[`keyed_class_handler_acceptance_2026-08-19.json`](docs/keyed_class_handler_acceptance_2026-08-19.json).
-The latest real Codex verification evidence is recorded in
-[`docs/external_claim_acceptance_2026-08-09.json`](docs/external_claim_acceptance_2026-08-09.json).
+## Help and maintenance
+
+Paranoia Local is maintained by Andrew Hillel. Open a GitHub issue with a minimal
+reproduction, the tool name, bounded error text, and relevant CLI versions. Do
+not publish secrets or a complete private audit log.
 
 ## License
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -1,0 +1,228 @@
+# How Paranoia Local works
+
+This guide explains the behavior behind the public tools. Start with the
+[README](../README.md) for installation or the [tool reference](tool-reference.md)
+for exact inputs.
+
+## Cross-agent review
+
+Paranoia Local is a local MCP server. The calling coding agent sends a review
+request; Paranoia starts the other vendor's signed-in CLI as a read-only reviewer
+and returns the result through MCP.
+
+The reviewer is intentionally cold. It receives the artifact, repository
+evidence, request context, and durable state required for its role. It does not
+inherit the calling conversation's rationale or its normal user tool configuration.
+
+## Stakes define the boundary
+
+`stakes` should describe the deployment, operators, trusted actors, untrusted
+inputs, active adversary capabilities, concurrency, network boundary, scale,
+useful latency, consequences of false clear versus false block, and exclusions.
+
+The reviewer drops or labels concerns that require conditions outside this
+boundary. If `stakes` is omitted, Paranoia assumes a modest internal tool with
+trusted operators and no hostile local process. Pass `stakes: "unstated"` when
+that default is deliberate.
+
+## The tracked lifecycle
+
+Tracked review is the default for `critique_branch` and `critique_plan`.
+
+1. **Census:** three independent cold lanes inspect the complete artifact. A
+   separate call consolidates their validated findings into durable debt.
+2. **Correction:** later rounds target open debt, claimed fixes, and their
+   transitive effects.
+3. **Final:** after debt closes, one fresh whole-artifact regression must pass.
+
+A clear census can converge immediately. Otherwise, increase `round` after each
+successfully settled edit. Failed or rejected rounds may reuse their label.
+Repeated or backward labels after settlement block without provider spend.
+
+## Findings, classes, and closure
+
+A finding is one observed defect. A class is its reusable violated invariant.
+Every governing finding is classified as a one-off, the first instance of a new
+class, or an instance of an active class.
+
+Blocking findings and classes gate convergence. `MINOR` and `OUT-OF-SCOPE`
+entries remain durable but advisory.
+
+### Branch classes
+
+Mechanized branch classes have a pattern and literal path scope. Paranoia reruns
+the predicate against later snapshots; zero matches closes it and a new match
+reopens it. Invariants that cannot be represented safely carry a review procedure
+and require an explicit reviewer decision.
+
+An exact match can be marked as a false positive with `exempt`. The exemption
+binds class, path, line, and exact line text and expires when the text changes.
+`unexempt` revokes it. Later reviewers see and may challenge exemptions.
+
+### Plan classes
+
+Plan classes are procedural because a regex over prose could disappear while the
+design defect remains. Later reviewers receive the invariant and procedure, and
+blocking plan classes require explicit evidenced closure.
+
+Plan review judges whether an in-scope future obligation is bound to named scope,
+executable acceptance evidence, and fail-closed behavior. It does not require
+runtime artifacts that can exist only after implementation. Code review owns the
+implemented result.
+
+### Persistence and rebuttal
+
+When a blocking class persists across enough round-label span or repeatedly
+reopens, Paranoia stops accepting another ordinary correction. The class must
+close, be replaced with a more accurate invariant, or receive a class-bound
+`rebut` using the reported current session. A successful rebuttal opens another
+bounded correction window; it does not close debt or grant clearance.
+
+## Plan contracts in branch review
+
+`critique_branch` can receive `plan_text` or an absolute `plan_path` as an
+implementation contract. On the first plan-bearing round, Paranoia reads it once,
+computes its full SHA-256, stores a versioned authority record, and binds that
+captured contract to the Git snapshot, every staged role, class state, and audit.
+
+Reviewers check plan obligations for implementation or traceable deferral, named
+acceptance criteria through their named production entry points, and new public
+or persisted contracts for correspondence with the plan. The contract remains
+declarative data and cannot instruct the reviewer.
+
+Later rounds reuse the exact stored text. Adding, removing, or changing the
+contract requires a new lineage. One-shot review rejects plan contracts because
+it cannot provide the same binding.
+
+## External claim verification
+
+`critique_plan` verifies eligible external premises by default before structural
+review.
+
+### Eligible claims
+
+The register contains only atomic, load-bearing propositions in three categories:
+
+- `fact`: external state, event, quantity, identity, or history;
+- `design_principle`: a requirement or recommendation from the governing
+  external standard, regulator, protocol, platform, or vendor; and
+- `behavior`: behavior promised by an external dependency, API, platform,
+  protocol, service, or runtime.
+
+Repository state, implementation conformance, internal history, and
+project-authored choices stay in structural review and tests.
+
+### Evidence boundary
+
+Verification has four stages:
+
+1. The reviewer uses built-in search only to inventory claims and discover URLs.
+2. Paranoia downloads public HTTP(S) pages and extracts main text with Trafilatura.
+3. The same session, now without browsing, binds exact captured passages to claims.
+4. A separate cold, tool-free attester judges authority and entailment.
+
+Provider summaries, snippets, and provider-fetched bodies are never evidence.
+Claude `WebFetch` is not used. Known UGC can provide leads but cannot govern
+closure. A repository's own web URL remains self-context, not evidence for its
+plan. Redirect destinations determine source eligibility and identity.
+
+HTTP 403 receives at most one browser-compatible same-URL retry. Paranoia does
+not add cookies, browser automation, mirrors, or access-control bypasses.
+
+### Outcomes and later rounds
+
+A claim is `supported` only when authoritative captured text entails its exact
+wording; otherwise it is `refuted` or `unverified`. Both latter states block
+combined plan convergence without rewriting independently settled structural
+state.
+
+Actionable packets include plan wording, atomic proposition, canonical URL,
+location, publisher/authority, exact passage, and a replacement only when the
+replacement is itself entailed. Refutation does not prove substitute wording.
+
+Round 1 performs exhaustive inventory. Exact unchanged supported claims keep
+their packets without new search. Edited, new, refuted, and unverified claims
+re-enter full verification. Claim identity includes the assertion-bearing block,
+heading ancestry, and list ancestry.
+
+The path is bounded to 200 candidate sources, five binding batches, five cold
+attestation batches, and 22 possible model calls including reserved corrections.
+These are pathology circuit breakers. Oversized or unavailable sources fail for
+the affected claim rather than being silently truncated.
+
+See [`claim_verification.md`](claim_verification.md) for protocol-level detail.
+
+## Arbitration
+
+`arbitrate` pins one Git snapshot and gives both deciders separate inert views of
+the same regular-file bytes and bounded history. It does not run repository Git
+filters, hooks, text conversion, configured transports, executables, or symlink
+traversal. Ref movement during setup fails before model spend; later movement is
+reported but cannot alter the pinned evidence.
+
+With `clean: true`, Claude Opus removes advocacy and presentation asymmetry, and
+Codex attests that substantive meaning was preserved. Caller `context` and
+`stakes` remain byte-for-byte authoritative and are checked separately. Deciders
+see opposite option order under opaque labels and are unaware of each other.
+
+Research is on by default. Both vendors discover URLs; Paranoia downloads,
+extracts, deduplicates, and binds the sources, then sends identical captured
+evidence to both deciders with live web disabled. A decisive vote must cite a
+repository line in the snapshot or a captured source that passes authority,
+entailment, and decision-relevance checks.
+
+Python compares the votes. One fact-only reconciliation can run on divergence
+when new evidence exists; it carries server-read bytes and citations, never the
+sibling model's prose. Results are `CONVERGED`, `BLOCKED`, `REFRAME_REQUIRED`,
+`UNRESOLVED`, or `FAILED`.
+
+The whole call has a 7,200-second circuit breaker. Cleaning/attestation calls use
+420-second phase limits, decision calls 1,800 seconds, and the research group
+1,440 seconds. See [`arbitration_plan.md`](arbitration_plan.md) for residual risks.
+
+## Safety model
+
+- Reviewer subprocesses are read-only; the calling coding agent owns edits and tests.
+- Codex starts without user-configured MCP servers or tools. Claude starts
+  without user/repository settings that could expand its allowlist.
+- Committed branch reviews normally use a temporary worktree. Dirty review reads
+  the live tree. Verified plans and arbitration use inert materializations.
+- A hard crash can leave temporary worktree registration or unreferenced Git
+  objects until `git worktree prune` or `git gc`; the working tree and index are
+  not changed.
+- Paranoia uses already authenticated local CLIs. It needs no API key and adds no
+  Paranoia telemetry.
+- Public HTTP(S) capture occurs only for enabled claim verification and
+  arbitration research.
+
+## Audit logs and durable state
+
+Every call writes a JSON audit record under `~/.paranoia/logs/` by default. It
+includes inputs, engine/model identity, round, sessions, timings, attempt ledgers,
+bounded provider channels, review text, and the returned trailer.
+
+Tracked state lives under `~/.paranoia/lineages/` and atomically stores findings,
+classes, phase, claim packets, contract authority, and persistence controls. Set
+`PARANOIA_STATE_ROOT` to relocate it. `--log-dir` never moves lineage state.
+
+If state is unreadable, unwritable, or ambiguous, Paranoia reports
+`STATE-UNAVAILABLE` and does not present unconfirmed in-memory counts as durable.
+Audit logs are diagnostic, not a recovery protocol.
+
+## Usage and failure behavior
+
+- A tracked census normally uses three concurrent calls plus consolidation.
+- Correction and final use one main call; each staged role can receive one
+  bounded same-session validation correction.
+- Verified plan round 1 adds discovery, binding, and cold attestation.
+- `query` is the lower-cost focused operation.
+- `arbitrate` is the only tool that spends from both subscriptions in one call.
+
+Malformed output, unsupported structured output, provider errors, timeouts,
+missing executables, capture failures, and ambiguous persistence block visibly.
+None becomes an empty successful review. Validation-invalid responses receive at
+most one role-specific correction; execution failures remain distinct.
+
+A failed staged structural review begins `# STAGED REVIEW FAILED` and states
+whether failure occurred before settlement or after unconfirmed persistence. It
+never renders a clean-review scaffold.

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -1,0 +1,316 @@
+# Paranoia Local: LLM operating reference
+
+Purpose: provide enough precise context for an agent to install, select, and call
+Paranoia Local without inferring behavior from introductory prose. Runtime MCP
+schemas are authoritative.
+
+## Identity
+
+- Package and executable: `paranoia-local`
+- Protocol: local MCP over stdio
+- Requirements: Python 3.11+, Git 2.36+
+- Engines: `codex`, `claude`
+- Minimum evidence-profile CLIs: Codex 0.144.6; Claude Code 2.1.197
+- Default models: `gpt-5.6-sol`; `claude-fable-5`
+- Arbitration cleaner: `claude-opus-5`
+- Tools: `critique_branch`, `critique_plan`, `query`, `rebut`, `arbitrate`
+
+## Host/reviewer invariant
+
+- Claude Code host: `paranoia-local --engine codex`.
+- Codex host: `paranoia-local --engine claude`.
+- `--engine` names the reviewer, not the host.
+- `arbitrate` invokes both vendors. It accepts `models:{codex?,claude?}`, not
+  `engine` or singular `model`.
+
+## Installation
+
+```bash
+git clone https://github.com/subvertnormality/paranoia-local
+cd paranoia-local
+pip install -e .
+claude mcp add paranoia -- paranoia-local --engine codex
+# OR
+codex mcp add paranoia -- paranoia-local --engine claude
+```
+
+Codex host configuration:
+
+```toml
+[mcp_servers.paranoia]
+command = "paranoia-local"
+args = ["--engine", "claude"]
+tool_timeout_sec = 8400
+startup_timeout_sec = 60
+```
+
+## Tool selection
+
+1. Full code/diff/working-tree review: `critique_branch`.
+2. Plan review against code and external premises: `critique_plan`.
+3. One factual or analytical question: `query`.
+4. Dispute a prior finding using its session: `rebut`.
+5. Independent choice between 2–4 explicit options: `arbitrate`.
+
+Do not use `query` when durable convergence is required. Do not use `arbitrate`
+as a full code review.
+
+## Shared semantics
+
+- `repo_path`: absolute path.
+- `stakes`: concrete deployment, actors, trust, adversary capabilities,
+  concurrency, network, scale, latency, false-clear/false-block consequences,
+  and exclusions. Avoid vague labels.
+- `round`: integer >= 1. After a settled tracked call, use a greater label. A
+  failed/rejected call may retry the same label.
+- `already_raised`: accepted one-line claims with `file:line`; never previous
+  reviewer prose.
+- `focus`: optional narrowing; does not replace intent or stakes.
+- `engine`: `codex` or `claude` single-reviewer override.
+- `model`: provider-specific override.
+- `effort`: `low|medium|high`; review default high, `query` default medium.
+- `web_search`: default true. Required by enabled plan claim verification.
+
+## `critique_branch`
+
+Required: `repo_path`; also `round` unless `class_closure:false`.
+
+Defaults: `base_ref=main`, `head_ref=HEAD`, `include_uncommitted=false`,
+`isolate=true`, `converge=true`, `max_packet_chars=400000`,
+`class_closure=true`; lineage is derived when the reviewed head is a branch.
+
+```json
+{
+  "repo_path": "/absolute/repo",
+  "base_ref": "main",
+  "round": 1,
+  "project_summary": "Neutral system description.",
+  "diff_intent": "Exact intended behavior.",
+  "stakes": "Concrete operating model and exclusions."
+}
+```
+
+Dirty review: add `"include_uncommitted":true`. It reads the live repository
+because uncommitted bytes cannot be isolated. Reviewer access remains read-only.
+
+One-shot branch review:
+
+```json
+{"repo_path":"/absolute/repo","class_closure":false,"converge":false}
+```
+
+Never set only one of those false values.
+
+Optional contract arguments: exactly zero or one of `plan_text`, `plan_path`;
+optional `plan_digest` requires a plan. `plan_path` must be absolute. Plan-backed
+review requires tracked convergence and round 1 for first reservation. The first
+accepted contract is immutable for the lineage; any add/remove/change requires a
+new lineage. Later calls may omit the plan and reuse stored authority.
+
+Exemption shapes:
+
+```json
+{
+  "exempt": [{"class_id":"id","path":"src/a.py","line":12,"line_text":"exact text"}],
+  "unexempt": [{"class_id":"id","path":"src/a.py","line":12}]
+}
+```
+
+## `critique_plan`
+
+Required: `repo_path` and exactly one of `plan_text`, `plan_path`. Tracked mode
+also requires `lineage` and `round`.
+
+Defaults: `class_closure=true`, `claim_verification=true`, `web_search=true`.
+
+```json
+{
+  "repo_path": "/absolute/repo",
+  "plan_path": "/absolute/repo/docs/plan.md",
+  "lineage": "project-issue-42-plan",
+  "round": 1,
+  "context": "Neutral background.",
+  "stakes": "Concrete operating model and exclusions."
+}
+```
+
+Rules:
+
+- Use a globally unique, mode-qualified lineage; never reuse a branch lineage.
+- `.paranoia.toml` does not supply plan `lineage` or `class_closure`.
+- `claim_verification:true` with `web_search:false` is invalid.
+- `claim_verification:false` is structural-only and preserves dormant claim state.
+- One-shot plan: `class_closure:false`; computed convergence is omitted.
+- After editing the plan, increment `round` and keep lineage/stakes stable unless
+  the real operating model changed.
+
+Eligible external claims are only load-bearing external facts, externally issued
+governing requirements/principles, and promised external-system behavior.
+Repository facts and local design choices belong to structural review.
+
+## `query`
+
+Required: `question`. Optional: `repo_path`, `files:[{path,reason?}]`, `focus`, and
+shared overrides.
+
+```json
+{
+  "question": "Can this retry path duplicate a payment?",
+  "repo_path": "/absolute/repo",
+  "files": [{"path":"src/retry.py","reason":"retry owner"}]
+}
+```
+
+Expected: direct answer, citations, confidence; no tracked lineage. File entries
+are hints and do not prevent the reviewer from reading elsewhere.
+
+## `rebut`
+
+Required: `repo_path`, `session_ref`, `rebuttal`.
+
+```json
+{
+  "repo_path": "/absolute/repo",
+  "session_ref": "prior-session-reference",
+  "rebuttal": "Counter-evidence with exact citations."
+}
+```
+
+Expected: `CONCEDE` or `HOLD` with fresh citations.
+
+Optional class-gate reset requires all three: `lineage`, `class_id`,
+`lineage_mode` (`branch|plan`). The session must be current for the active
+blocking class. Success resets a correction window only; it does not close or
+reclassify debt.
+
+## `arbitrate`
+
+Required: `repo_path`, `decision`, `options`, `stakes`.
+
+```json
+{
+  "repo_path": "/absolute/repo",
+  "decision": "Neutral decision statement.",
+  "options": [
+    {"id":"a","statement":"Self-contained mechanism, scope, and consequences."},
+    {"id":"b","statement":"Self-contained mechanism, scope, and consequences."}
+  ],
+  "stakes": "Concrete operating model and consequences.",
+  "context": "Only facts and specification shared by every option.",
+  "files": [{"path":"src/relevant.py","reason":"shared evidence"}]
+}
+```
+
+Bounds: decision 2500 chars; 2–4 options; each statement 1200; context 20000;
+stakes 20000; 32 files; each stripped reason 1200.
+
+Defaults: `clean=true`, `cleaner_model=claude-opus-5`,
+`retain_snapshot=false`, `research=true`, `web_search=true`, `effort=high`.
+
+Optional: `subject`, `models`, `cleaner_model`, `order_seed`, `retain_snapshot`,
+`research`, `effort`, `web_search`.
+
+Rules:
+
+- `context` contains only common facts/specification.
+- Each statement contains that option's distinct mechanism, scope,
+  qualifications, tradeoffs, and consequences.
+- Statements are self-contained and do not refer to sibling IDs.
+- `research:true` requires `web_search:true`.
+- There is no `engine` or singular `model`.
+- `retain_snapshot:true` creates a Git ref. Remove it with
+  `git update-ref -d refs/paranoia/arbitrate/<stamp>`.
+
+Results: `CONVERGED`, `BLOCKED`, `REFRAME_REQUIRED`, `UNRESOLVED`, `FAILED`.
+`ADVISORY: human-owner` is non-gating.
+
+## Tracked state machine
+
+```text
+new -> census
+census clear -> clear
+census blocked -> correction
+correction blocked -> correction
+correction debt closed -> final
+final clear -> clear
+final blocked -> correction
+```
+
+After a tracked result:
+
+1. Read `STRUCTURAL-PHASE`, `STRUCTURAL-DEBT`, `CLASS-CLOSURE`, optional
+   `CLAIM-CLOSURE`, and `CONVERGENCE`.
+2. Fix validated in-scope debt and transitive effects.
+3. Increment `round` only after changing the artifact.
+4. Reuse lineage and stakes.
+5. Stop only at `CONVERGENCE: NOT-BLOCKED`.
+
+Do not rerun unchanged text hoping model variance removes durable debt. Do not
+treat `NOT-BLOCKED` as proof.
+
+## Output parsing
+
+Completed reviews have five sections in order: `What works`, `What doesn't work`,
+`Risks`, `Gaps`, `Improvements`.
+
+Code severities: `BLOCKER`, `MAJOR`, `MINOR`, `OUT-OF-SCOPE`. Plan severities:
+`FATAL`, `MAJOR`, `MINOR`, `OUT-OF-SCOPE`.
+
+Tracked fields can include `CLASS-REGISTER`, `CLASS-CLOSURE`,
+`STRUCTURAL-PHASE`, `STRUCTURAL-DEBT`, `PERSISTENCE`, `REOPEN-WAVE`,
+`CORRECTION-GATE`, `STAGED-ATTEMPTS`, `CLAIM-REGISTER`, `CLAIM-CLOSURE`,
+`STRUCTURAL-CONVERGENCE`, `CONVERGENCE`, `STRUCTURAL-ERROR`, and
+`STRUCTURAL-PENDING`.
+
+Failure rule: `# STAGED REVIEW FAILED` has no durable clean structural verdict.
+Never infer success from absent findings. `STATE-UNAVAILABLE` is blocking.
+
+Arbitration always reports `ARBITRATION`, `SELECTED`, `ADVISORY`,
+`AUTHORITY-POLICY`, `CLEANING`, `SNAPSHOT`, `ORDER-SEED`, `REFS-MOVED`, `AUDIT`,
+`ROUNDS`, `RESEARCH`, `RESEARCH-DIGEST`.
+
+## Configuration and state
+
+`.paranoia.toml` can use top-level keys or `[paranoia]`. Precedence: call > repo
+config > built-in. Supported keys: `base_ref`, `project_summary`, `stakes`,
+`isolate`, `converge`, `class_closure`, `max_packet_chars`, `model`, `effort`,
+`web_search`.
+
+- audits: `~/.paranoia/logs/` or `--log-dir`;
+- lineages: `~/.paranoia/lineages/` or `PARANOIA_STATE_ROOT`.
+
+`--log-dir` never moves lineage state. Do not edit/delete active lineage files
+unless the user explicitly abandons the lineage. Audit logs are not state backup.
+
+## Safety, cost, and recovery
+
+- Reviewer tools cannot edit repository files or run repository tests.
+- Committed review may create temporary worktrees and unreferenced Git objects.
+- Dirty review reads the live working tree.
+- Verified-plan and arbitration evidence trees are inert.
+- Local signed-in subscriptions are used; no API key or Paranoia telemetry.
+- `retain_snapshot:true` is the only ordinary mode that creates a durable Git ref.
+- `query` is cheapest; census uses three lanes plus consolidation; plan
+  verification adds evidence calls; `arbitrate` uses both subscriptions.
+
+Recovery:
+
+- Codex MCP timeout: set `tool_timeout_sec=8400`.
+- Missing/old CLI: check version, update, and sign in.
+- Failed/rejected tracked call: address the diagnostic and retry the same round.
+- Settled blocked call: edit, increment round, retry the same lineage.
+- Persistence gate: close/replace the class or use the named class-bound rebut.
+- `STATE-UNAVAILABLE`: repair or intentionally abandon the diagnosed state path;
+  never synthesize convergence from logs.
+- Claim evidence failure: remove, weaken, or replace wording only as supported by
+  the actionable evidence packet.
+
+## Sources of truth
+
+1. MCP schemas: `src/paranoia_local/server.py`.
+2. CLI flags: `src/paranoia_local/cli.py`.
+3. Provider versions/models: `src/paranoia_local/engines.py`.
+4. Configuration: `src/paranoia_local/config.py`.
+5. Human tool reference: `docs/tool-reference.md`.
+6. Lifecycle and safety: `docs/how-it-works.md`.
+7. Protocol detail: `docs/claim_verification.md`, `docs/arbitration_plan.md`.

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -1,0 +1,255 @@
+# Paranoia Local tool reference
+
+This page documents the public MCP interface. The runtime schemas in
+[`src/paranoia_local/server.py`](../src/paranoia_local/server.py) are authoritative
+if this page and an installed version differ.
+
+## Shared review arguments
+
+`critique_branch`, `critique_plan`, `query`, and `rebut` accept these overrides:
+
+| Argument | Values | Default |
+|---|---|---|
+| `engine` | `codex` or `claude` | Server configuration |
+| `model` | Provider model name | `gpt-5.6-sol` or `claude-fable-5` |
+| `effort` | `low`, `medium`, or `high` | `high`; `query` uses `medium` |
+| `web_search` | Boolean | `true` |
+
+`engine` names the reviewer. `arbitrate` has no single `engine` or `model`
+argument because it always uses both vendors.
+
+## `critique_branch`
+
+Reviews a committed Git range or the dirty working tree. The tracked path is the
+default and returns cited findings plus a computed convergence trailer.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `repo_path` | string | Required | Absolute Git repository path |
+| `base_ref` | string | `main` or config | Diff base |
+| `head_ref` | string | `HEAD` | Diff head |
+| `round` | integer ≥ 1 | Required unless `class_closure: false` | Increase after every settled tracked round |
+| `include_uncommitted` | boolean | `false` | Review working-tree changes against `HEAD` in the live repository |
+| `isolate` | boolean | `true` | Use a temporary worktree for committed review; ignored for dirty review |
+| `converge` | boolean | `true` | Use the immutable-packet tracked review path |
+| `max_packet_chars` | integer | `400000` | Tracked packet budget; file evidence may be trimmed, but `already_raised` is retained |
+| `plan_text` | string | — | Optional frozen implementation contract; mutually exclusive with `plan_path` |
+| `plan_path` | string | — | Absolute path to the optional contract; mutually exclusive with `plan_text` |
+| `plan_digest` | string | — | Optional 16-hex frozen digest or full 64-hex SHA-256 assertion; requires a plan |
+| `project_summary` | string | — | Neutral project description |
+| `diff_intent` | string | — | Intended result, treated as a claim to verify |
+| `focus` | string | — | Optional review focus |
+| `stakes` | string | Modest internal-tool assumptions | Deployment, trust boundary, scale, and consequences |
+| `already_raised` | string array | `[]` | Accepted one-line `file:line` findings from earlier rounds |
+| `class_closure` | boolean | `true` | Track findings/classes and compute convergence |
+| `lineage` | string | Derived | Explicit key; required for a detached head or raw commit |
+| `exempt` | object array | `[]` | Exempt exact `{class_id,path,line,line_text}` predicate matches |
+| `unexempt` | object array | `[]` | Revoke exact `{class_id,path,line}` exemptions |
+
+Rules:
+
+- Pair `converge: false` with `class_closure: false` for a one-shot branch review.
+- A dirty review cannot use a temporary worktree.
+- A plan-bearing branch review requires tracked convergence and `round: 1` for
+  the first contract reservation.
+- `plan_path` is resolved and read once. Its captured text and server-computed
+  digest are frozen for the lineage.
+- Later rounds may omit the plan input. Adding, removing, or changing the
+  contract requires a new lineage.
+- A contract is declarative requirements data, not reviewer instructions.
+- Lost or ambiguous substantive lineage state blocks with `STATE-UNAVAILABLE`.
+
+Example:
+
+```json
+{
+  "repo_path": "/repo",
+  "base_ref": "main",
+  "round": 1,
+  "diff_intent": "Reject withdrawals that exceed available funds.",
+  "stakes": "Internal API; authenticated callers; one region; 1,000 requests/minute."
+}
+```
+
+## `critique_plan`
+
+Reviews a plan against the repository it describes. External claim verification
+runs before structural review by default.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `repo_path` | string | Required | Absolute relevant repository path |
+| `plan_text` | string | Exactly one plan input required | Plan Markdown |
+| `plan_path` | string | Exactly one plan input required | Absolute path to plan Markdown |
+| `round` | integer ≥ 1 | Required unless `class_closure: false` | Caller round label |
+| `lineage` | string | Required unless `class_closure: false` | Globally unique, mode-qualified durable key |
+| `class_closure` | boolean | `true` | Track procedural plan classes and compute convergence |
+| `claim_verification` | boolean | `true` | Verify eligible external premises before structural review |
+| `context` | string | — | Background needed to judge the plan |
+| `focus` | string | — | Optional review focus |
+| `stakes` | string | Modest internal-tool assumptions | Scope and consequence boundary |
+| `already_raised` | string array | `[]` | Accepted cited findings from earlier rounds |
+
+Rules:
+
+- Provide exactly one of `plan_text` and `plan_path`.
+- Use a unique, mode-qualified lineage such as `project-issue-42-plan`. A plan
+  lineage cannot be shared with branch review.
+- `lineage` and `class_closure` are call-only values; `.paranoia.toml` does not
+  supply them for plan reviews.
+- `claim_verification: true` requires `web_search: true` on bundled engines.
+- The external claim register excludes repository facts, code paths, internal
+  conformance, and local design choices.
+- One-shot plan review uses `class_closure: false`. It returns review prose and
+  claim packets but no computed convergence verdict.
+
+```json
+{
+  "repo_path": "/repo",
+  "plan_path": "/repo/docs/change-plan.md",
+  "lineage": "project-issue-42-plan",
+  "round": 1,
+  "stakes": "Single-team service; trusted operators; authenticated public requests."
+}
+```
+
+## `query`
+
+Asks one focused question without creating a tracked review.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `question` | string | Required | Specific question |
+| `repo_path` | string | — | Optional repository grounding |
+| `files` | object array | `[]` | `{path, reason?}` starting hints; the reviewer may read elsewhere |
+| `focus` | string | — | Additional framing |
+
+The response is a direct answer with citations and a stated confidence level.
+
+## `rebut`
+
+Resumes the reviewer session that produced a disputed finding.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `repo_path` | string | Required | Same repository used for the review |
+| `session_ref` | string | Required | Session reference from the review footer |
+| `rebuttal` | string | Required | Concrete counter-evidence |
+| `lineage` | string | — | Optional gated lineage; requires `class_id` and `lineage_mode` |
+| `class_id` | string | — | Optional active blocking class; requires both other binding values |
+| `lineage_mode` | `plan` or `branch` | — | Optional lineage mode; requires both other binding values |
+
+The unbound form returns `CONCEDE` or `HOLD` with fresh citations. The three
+class-binding arguments are all-or-none. A successful bound rebut resets only
+that class's correction window. It does not close the class, remove debt, change
+severity, or grant convergence. The session must be the durable current session
+for an active blocking class.
+
+## `arbitrate`
+
+Asks Codex and Claude to decide independently between two to four options over
+the same pinned evidence. Python computes the outcome.
+
+| Argument | Type | Default | Description |
+|---|---|---|---|
+| `repo_path` | string | Required | Repository whose snapshot supplies context |
+| `decision` | string, max 2,500 chars | Required | Neutral question and relevant properties |
+| `options` | 2–4 objects | Required | Unique `{id, statement}` options; statement max 1,200 chars |
+| `stakes` | string, max 20,000 chars | Required | Scope and consequence boundary; use `unstated` deliberately if needed |
+| `context` | string, max 20,000 chars | — | Facts and specification shared by every option |
+| `files` | object array, max 32 | `[]` | Snapshot-relative `{path, reason?}` hints; reason max 1,200 chars |
+| `subject` | string | — | Short label for the record |
+| `clean` | boolean | `true` | Neutralize framing with Claude Opus and cross-vendor attestation |
+| `models` | object | Provider defaults | Optional `{codex, claude}` model overrides |
+| `cleaner_model` | string | `claude-opus-5` | Cleaner override |
+| `order_seed` | string | Generated | Reproduce labels and ordering from an earlier run |
+| `retain_snapshot` | boolean | `false` | Create `refs/paranoia/arbitrate/<stamp>` to survive Git GC |
+| `research` | boolean | `true` | Discover and server-capture shared authoritative web evidence |
+| `effort` | `low`, `medium`, or `high` | `high` | Both deciders' effort |
+| `web_search` | boolean | `true` | Discovery authorization; required by `research: true` |
+
+Input design is load-bearing:
+
+- Put only shared facts and specification in `context`.
+- Put each option's unique mechanism, scope, qualifications, consequences, and
+  tradeoffs in its own self-contained statement.
+- Do not refer to another option by ID inside a statement. Deciders see different
+  opaque labels and counterbalanced orders.
+- Keep file hints balanced; both deciders receive the same list.
+- Caller `context` and `stakes` remain byte-for-byte authoritative and are
+  checked for advocacy.
+
+Processing sequence:
+
+1. Pin a Git snapshot and materialize inert evidence for each decider.
+2. Clean and cross-attest framing unless `clean: false`.
+3. With `research: true`, let both vendors discover URLs, then capture and bind
+   the sources server-side.
+4. Give both deciders identical evidence with live web disabled and
+   counterbalanced presentation.
+5. Resolve citations and compute the result in Python.
+6. On divergence, run one fact-only reconciliation only when new evidence exists.
+
+| Outcome | Meaning |
+|---|---|
+| `CONVERGED` | Unanimous, unblocked, and substantiated by resolved evidence |
+| `BLOCKED` | Same option, but at least one decider marks it major/fatal |
+| `REFRAME_REQUIRED` | A decider found a better unlisted option; add it and rerun |
+| `UNRESOLVED` | Split decision or unsubstantiated agreement |
+| `FAILED` | Preflight, execution, cleaning, capture, parsing, or protocol failure |
+
+The trailer always includes `ARBITRATION`, `SELECTED`, `ADVISORY`,
+`AUTHORITY-POLICY`, `CLEANING`, `SNAPSHOT`, `ORDER-SEED`, `REFS-MOVED`, `AUDIT`,
+`ROUNDS`, `RESEARCH`, and `RESEARCH-DIGEST`.
+
+`ADVISORY: human-owner` is informational. `SNAPSHOT` is provenance, not a durable
+replay handle, unless `retain_snapshot: true` was used. That option is the only
+ordinary Paranoia mode that writes a Git ref.
+
+## Review output
+
+A completed review uses these headings in order: `What works`, `What doesn't
+work`, `Risks`, `Gaps`, and `Improvements`.
+
+Code findings use `[BLOCKER]`, `[MAJOR]`, `[MINOR]`, or `[OUT-OF-SCOPE]`. Plan
+findings use `[FATAL]`, `[MAJOR]`, `[MINOR]`, or `[OUT-OF-SCOPE]`. Tracked
+recurrences include `[RECURRENCE <class-id>]`.
+
+A terminal staged failure begins `# STAGED REVIEW FAILED`, contains a bounded
+diagnostic, and never implies that missing findings mean success.
+
+| Trailer field | Meaning |
+|---|---|
+| `CLASS-REGISTER` | Class operations applied in this settlement |
+| `CLASS-CLOSURE` | Durable open/closed class status |
+| `STRUCTURAL-PHASE` | `census`, `correction`, `final`, or `clear` |
+| `STRUCTURAL-DEBT` | Blocking governing findings |
+| `PERSISTENCE` | A class has remained blocking long enough to need special handling |
+| `REOPEN-WAVE` | Previously closed classes reopened |
+| `STAGED-ATTEMPTS` | Provider and validation attempt counts |
+| `CLAIM-REGISTER` | Active and retired external claims |
+| `CLAIM-CLOSURE` | Supported, refuted, and unverified claims |
+| `CONVERGENCE` | Governing tracked result |
+| `STATE-UNAVAILABLE` | Lineage state could not be trusted or persisted |
+
+`CONVERGENCE: NOT-BLOCKED` is not a correctness proof.
+
+## Configuration reference
+
+`.paranoia.toml` accepts top-level keys or a `[paranoia]` table. Resolution order
+is call argument, repository config, then built-in default.
+
+Supported keys: `base_ref`, `project_summary`, `stakes`, `isolate`, `converge`,
+`class_closure`, `max_packet_chars`, `model`, `effort`, and `web_search`.
+
+```text
+paranoia-local --engine {codex|claude} [--log-dir DIR]
+```
+
+| Location | Purpose |
+|---|---|
+| `~/.paranoia/logs/` | One JSON audit record per call |
+| `~/.paranoia/lineages/` | Atomic tracked finding, class, phase, and claim state |
+| `PARANOIA_STATE_ROOT` | Optional lineage-state root override |
+
+Changing `--log-dir` does not move or reset lineage state.

--- a/llms.txt
+++ b/llms.txt
@@ -1,0 +1,31 @@
+# Paranoia Local
+
+> Paranoia Local is a local MCP server for cross-vendor adversarial review. Claude Code can run Codex as a read-only reviewer, Codex can run Claude Code, and arbitration uses both independently over pinned evidence.
+
+Use the quickstart for installation. Use the LLM operating reference when selecting or calling a tool. Runtime MCP schemas are authoritative if prose differs from the installed version. The five tools are `critique_branch`, `critique_plan`, `query`, `rebut`, and `arbitrate`.
+
+## Core documentation
+
+- [Human quickstart and overview](https://github.com/subvertnormality/paranoia-local/blob/main/README.md): Installation, first review, workflows, configuration, troubleshooting, safety, and cost.
+- [LLM operating reference](https://github.com/subvertnormality/paranoia-local/blob/main/docs/llm-reference.md): Dense selection rules, call shapes, defaults, constraints, state transitions, output parsing, and recovery.
+- [Complete tool reference](https://github.com/subvertnormality/paranoia-local/blob/main/docs/tool-reference.md): Every public MCP argument, output field, constraint, and tool-specific rule.
+- [How Paranoia works](https://github.com/subvertnormality/paranoia-local/blob/main/docs/how-it-works.md): Review lifecycle, class closure, plan contracts, external evidence, arbitration, isolation, state, limits, and failures.
+
+## Authoritative implementation
+
+- [MCP schemas](https://github.com/subvertnormality/paranoia-local/blob/main/src/paranoia_local/server.py): Public tool names, JSON schemas, descriptions, and dispatch.
+- [CLI entry point](https://github.com/subvertnormality/paranoia-local/blob/main/src/paranoia_local/cli.py): Executable flags and defaults.
+- [Provider engines](https://github.com/subvertnormality/paranoia-local/blob/main/src/paranoia_local/engines.py): Models, minimum CLI versions, capability profiles, and process construction.
+- [Package metadata](https://github.com/subvertnormality/paranoia-local/blob/main/pyproject.toml): Python version, dependencies, executable, and development extras.
+
+## Detailed protocols
+
+- [Claim verification](https://github.com/subvertnormality/paranoia-local/blob/main/docs/claim_verification.md): Claim eligibility, discovery, capture, binding, cold attestation, persistence, and acceptance boundaries.
+- [Arbitration design](https://github.com/subvertnormality/paranoia-local/blob/main/docs/arbitration_plan.md): Evidence isolation, neutralization, counterbalancing, reconciliation, outcomes, and residual risks.
+- [Class closure](https://github.com/subvertnormality/paranoia-local/blob/main/docs/class_closure_plan.md): Durable reusable defect classes and convergence semantics.
+- [Staged review protocol](https://github.com/subvertnormality/paranoia-local/blob/main/docs/staged_review_protocol_v2_plan.md): Census, correction, final, validation, and atomic settlement.
+
+## Optional
+
+- [Documentation directory](https://github.com/subvertnormality/paranoia-local/tree/main/docs): Design records and dated acceptance artifacts.
+- [Tests](https://github.com/subvertnormality/paranoia-local/tree/main/tests): Unit, integration, protocol, and acceptance coverage.


### PR DESCRIPTION
## Summary

- replace the root README with a concise first-time-user path
- move complete tool and lifecycle detail into focused linked references
- add an llms.txt index and dense LLM operating reference

## Validation

- schema-property coverage check
- relative-link validation
- JSON and TOML example parsing
- git diff --check
- 26 focused server/config tests