### PR TITLE
Distinguish staged provider and validation failures

### DIFF
--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -103,10 +103,10 @@
     "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
     "source_commit": "20464241b5838dbac30f2df5c44897b1e7075f2e",
     "allowed_later_handlers_diff": {
-      "sha256": "3fa7743d934adcb8a2a0e809af7f8cff678bbfab670ffce7035d53d9a98d7678",
-      "additions": 1031,
-      "deletions": 97,
-      "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, and failure-diagnostic changes through issue #66; does not alter capture, binding, cold-attestation, prompt-size, or source-admission semantics proved by this record."
+      "sha256": "82761d0097e9aa866b5c7097d3cd398d462ff7270216347e46b20a50e203ede9",
+      "additions": 1058,
+      "deletions": 105,
+      "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, and operator-facing failure-taxonomy changes through this revision; does not alter capture, binding, cold-attestation, prompt-size, or source-admission semantics proved by this record."
     },
     "allowed_later_review_census_diff": {
       "sha256": "5d5f653e7c40e91e389325a83402dfc7148263949a8f94c1cb6206ba1e380674",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -1,6 +1,11 @@
 {
   "acceptance_kind": "branch-plan-fidelity-public-handler-v1",
-  "allowed_later_source_diffs": {},
+  "allowed_later_source_diffs": {
+    "src/paranoia_local/handlers.py": {
+      "scope": "Operator-facing staged failure taxonomy only; this does not alter branch plan-contract binding or either accepted provider route.",
+      "sha256": "2e08c3b978b2596ae8b243fcf7f55d0f7cc1540d542578f41fb459b458643ffb"
+    }
+  },
   "claims": {
     "does_not_prove": [
       "Every future provider response will classify implementation fidelity correctly.",

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -2,30 +2,30 @@
   "acceptance_kind": "code-branch-class-persistence-reopen-lifecycle",
   "attempt_ledger": [
     {
-      "duration_ms": 37790,
+      "duration_ms": 36572,
       "engine": "codex",
       "failure_detail_excerpt": "",
       "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "outcome": "completed",
       "provider_duration_ms": null,
-      "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02f63-4b45-7fb3-8a7d-6db7b594c831\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"60c1a55e\\\":{\\\"kind\\\":\\\"reopen\\\"}},\\\"class_outcomes\\\":{\\\"60c1a55e\\\":{\\\"basis\\\":{\\\"finding_id\\\":\\\"F1\\\",\\\"kind\\\":\\\"new_finding\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:1-3\\\",\\\"rationale\\\":\\\"The policy requires destructive deletion before deployment and explicitly states that both the rollback command and rollback test are omitted.\\\"}],\\\"verdict\\\":\\\"violated\\\"}},\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The only operational instruction explicitly acknowledges that the two required rollback artifacts are absent.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The destructive migration policy is incomplete because it supplies neither required rollback artifact.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:1-3\\\",\\\"rationale\\\":\\\"The reviewed artifact directly identifies itself as a destructive migration and specifies deletion of stored accounts; no broader repository premise is needed to establish the class recurrence.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"The policy text itself establishes the relevant destructive stored-data premise.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"Deleting every stored account is the destructive stored-data transformation governed by the active class.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The proposed destructive transformation lacks its required rollback command and test.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The supplied one-file policy does not define downstream software consumers; the material effect is the stored-account deletion itself.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"not_applicable\\\",\\\"summary\\\":\\\"No distinct code or data consumers are introduced or changed in the supplied artifact.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The policy expressly omits an exact rollback command, leaving no documented recovery path for the deletion.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"No rollback procedure is provided before deployment.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The policy expressly omits the executable rollback test required to validate recovery.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"There is no executable acceptance test for rollback.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:1-3\\\",\\\"rationale\\\":\\\"The migration document directs destructive pre-deployment work while documenting that its required rollback command and test are absent.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The operational migration documentation is unsafe to use as written.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:1-3\\\",\\\"rationale\\\":\\\"The heading and instruction consistently describe a destructive migration, and the stated omission consistently exposes the same active-class violation.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"The document is internally consistent, although consistently incomplete.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"Requiring one exact rollback command and one executable rollback test is directly proportional to an instruction to delete every stored account and to the supplied review focus.\\\"}],\\\"finding_ids\\\":[\\\"F1\\\"],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The merge-blocking remedy is limited to the two artifacts required by the active class",
-      "raw_sha256": "fd56b9a0f294397e1c5365f9e658ea9ca45ad38c8f05b53f896fd19324f4e62f",
+      "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a03402-f373-7c52-98d6-475ea9c94605\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"60c1a55e\\\":{\\\"kind\\\":\\\"reopen\\\"}},\\\"class_outcomes\\\":{\\\"60c1a55e\\\":{\\\"basis\\\":{\\\"finding_id\\\":\\\"F-001\\\",\\\"kind\\\":\\\"new_finding\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The policy requires destructive deletion of every stored account while explicitly stating that both the rollback command and rollback test are omitted.\\\"}],\\\"verdict\\\":\\\"violated\\\"}},\\\"coverage\\\":[{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The destructive policy is incomplete because it omits both recovery artifacts required by the active class.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"artifact-complete\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The migration artifact lacks the required rollback command and executable rollback test.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:1-3\\\",\\\"rationale\\\":\\\"The document explicitly defines a destructive migration affecting stored accounts.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"repository-premises\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"The reviewed policy clearly identifies its destructive stored-data premise.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The transformation deletes every stored account before deployment and therefore requires the missing rollback provisions.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"transformations\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The destructive transformation has no specified reversal mechanism.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The only identified affected data is stored account data; no separate consumer behavior is introduced by this documentation-only change.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"consumers\\\",\\\"status\\\":\\\"not_applicable\\\",\\\"summary\\\":\\\"No distinct consumer implementation is changed in the supplied artifact.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The policy explicitly omits an exact rollback command for its destructive deletion.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"failure-recovery\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"No executable recovery path is named.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The policy explicitly omits the executable rollback test required before deployment.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"tests-acceptance\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The required rollback acceptance test is absent.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The operational policy directs pre-deployment deletion but supplies no exact rollback command.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"docs-operations\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The documented destructive operation is missing mandatory rollback instructions.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"The document consistently acknowledges that both required rollback artifacts are deliberately omitted; this directly demonstrates recurrence of the closed class.\\\"}],\\\"finding_ids\\\":[\\\"F-001\\\"],\\\"id\\\":\\\"consistency\\\",\\\"status\\\":\\\"finding\\\",\\\"summary\\\":\\\"The new policy is consistently written but contradicts the active lifecycle invariant.\\\"},{\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"rationale\\\":\\\"Requiring a rollback command and one executable rollback test is proportionate to deletion of every stored account under the stated recoverable-blocking stakes.\\\"}],\\\"finding_ids\\\":[],\\\"id\\\":\\\"proportionality\\\",\\\"status\\\":\\\"covered\\\",\\\"summary\\\":\\\"Reopening the MAJOR class is proportionate to the destructive scope and stated review stakes.\\\"}],\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[{\\\"classification\\\":{\\\"class_id\\\":\\\"60c1a55e\\\",\\\"kind\\\":\\\"existing_class\\\"},\\\"evidence\\\":[{\\\"anchor\\\":\\\"repository/migration.md:3\\\",\\\"",
+      "raw_sha256": "0ec9dea7079772ded63c120aa3b7ed973a9b75ff04f578b15ddcec616f3bc3ce",
       "rejected_reply_excerpt": null,
       "rejected_reply_sha256": null,
       "requested_timeout_sec": 2400,
-      "response_excerpt": "{\"class_actions\":{\"60c1a55e\":{\"kind\":\"reopen\"}},\"class_outcomes\":{\"60c1a55e\":{\"basis\":{\"finding_id\":\"F1\",\"kind\":\"new_finding\"},\"evidence\":[{\"anchor\":\"repository/migration.md:1-3\",\"rationale\":\"The policy requires destructive deletion before deployment and explicitly states that both the rollback command and rollback test are omitted.\"}],\"verdict\":\"violated\"}},\"coverage\":[{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The only operational instruction explicitly acknowledges that the two required rollback artifacts are absent.\"}],\"finding_ids\":[\"F1\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"The destructive migration policy is incomplete because it supplies neither required rollback artifact.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:1-3\",\"rationale\":\"The reviewed artifact directly identifies itself as a destructive migration and specifies deletion of stored accounts; no broader repository premise is needed to establish the class recurrence.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The policy text itself establishes the relevant destructive stored-data premise.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"Deleting every stored account is the destructive stored-data transformation governed by the active class.\"}],\"finding_ids\":[\"F1\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The proposed destructive transformation lacks its required rollback command and test.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The supplied one-file policy does not define downstream software consumers; the material effect is the stored-account deletion itself.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"not_applicable\",\"summary\":\"No distinct code or data consumers are introduced or changed in the supplied artifact.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The policy expressly omits an exact rollback command, leaving no documented recovery path for the deletion.\"}],\"finding_ids\":[\"F1\"],\"id\":\"failure-recovery\",\"status\":\"finding\",\"summary\":\"No rollback procedure is provided before deployment.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The policy expressly omits the executable rollback test required to validate recovery.\"}],\"finding_ids\":[\"F1\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"There is no executable acceptance test for rollback.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:1-3\",\"rationale\":\"The migration document directs destructive pre-deployment work while documenting that its required rollback command and test are absent.\"}],\"finding_ids\":[\"F1\"],\"id\":\"docs-operations\",\"status\":\"finding\",\"summary\":\"The operational migration documentation is unsafe to use as written.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:1-3\",\"rationale\":\"The heading and instruction consistently describe a destructive migration, and the stated omission consistently exposes the same active-class violation.\"}],\"finding_ids\":[],\"id\":\"consistency\",\"status\":\"covered\",\"summary\":\"The document is internally consistent, although consistently incomplete.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"Requiring one exact rollback command and one executable rollback test is directly proportional to an instruction to delete every stored account and to the supplied review focus.\"}],\"finding_ids\":[\"F1\"],\"id\":\"proportionality\",\"status\":\"finding\",\"summary\":\"The merge-blocking remedy is limited to the two artifacts required by the active class.\"}],\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"class_id\":\"60c1a55e\",\"kind\":\"existing_class\"},\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The destructive pre-deployment deletion explicitly omits both the exact rollback command and executable rollback test required by the closed class, constituting a fresh recurrence.\"}],\"id\":\"F1\",\"remedy\":\"Before deployment, amend the migration policy to name the exact r",
-      "response_sha256": "b4b2bad85900248dcb0231ba9f67990bd98ecedd748d086755298cfdc54d0923",
+      "response_excerpt": "{\"class_actions\":{\"60c1a55e\":{\"kind\":\"reopen\"}},\"class_outcomes\":{\"60c1a55e\":{\"basis\":{\"finding_id\":\"F-001\",\"kind\":\"new_finding\"},\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The policy requires destructive deletion of every stored account while explicitly stating that both the rollback command and rollback test are omitted.\"}],\"verdict\":\"violated\"}},\"coverage\":[{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The destructive policy is incomplete because it omits both recovery artifacts required by the active class.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"artifact-complete\",\"status\":\"finding\",\"summary\":\"The migration artifact lacks the required rollback command and executable rollback test.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:1-3\",\"rationale\":\"The document explicitly defines a destructive migration affecting stored accounts.\"}],\"finding_ids\":[],\"id\":\"repository-premises\",\"status\":\"covered\",\"summary\":\"The reviewed policy clearly identifies its destructive stored-data premise.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The transformation deletes every stored account before deployment and therefore requires the missing rollback provisions.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"transformations\",\"status\":\"finding\",\"summary\":\"The destructive transformation has no specified reversal mechanism.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The only identified affected data is stored account data; no separate consumer behavior is introduced by this documentation-only change.\"}],\"finding_ids\":[],\"id\":\"consumers\",\"status\":\"not_applicable\",\"summary\":\"No distinct consumer implementation is changed in the supplied artifact.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The policy explicitly omits an exact rollback command for its destructive deletion.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"failure-recovery\",\"status\":\"finding\",\"summary\":\"No executable recovery path is named.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The policy explicitly omits the executable rollback test required before deployment.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"tests-acceptance\",\"status\":\"finding\",\"summary\":\"The required rollback acceptance test is absent.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The operational policy directs pre-deployment deletion but supplies no exact rollback command.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"docs-operations\",\"status\":\"finding\",\"summary\":\"The documented destructive operation is missing mandatory rollback instructions.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"The document consistently acknowledges that both required rollback artifacts are deliberately omitted; this directly demonstrates recurrence of the closed class.\"}],\"finding_ids\":[\"F-001\"],\"id\":\"consistency\",\"status\":\"finding\",\"summary\":\"The new policy is consistently written but contradicts the active lifecycle invariant.\"},{\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"Requiring a rollback command and one executable rollback test is proportionate to deletion of every stored account under the stated recoverable-blocking stakes.\"}],\"finding_ids\":[],\"id\":\"proportionality\",\"status\":\"covered\",\"summary\":\"Reopening the MAJOR class is proportionate to the destructive scope and stated review stakes.\"}],\"debt_outcomes\":[],\"governing_findings\":[{\"classification\":{\"class_id\":\"60c1a55e\",\"kind\":\"existing_class\"},\"evidence\":[{\"anchor\":\"repository/migration.md:3\",\"rationale\":\"This is a fresh recurrence: the change orders deletion of every stored account and explicitly omits both the exact rollback command and executable rollback test.\"}],\"id\":\"F-001\",\"remedy\":\"Before deployment, amend the policy to name the exact rollback command and provide an executable test that runs and verifies that rollback.\",\"severity\":\"MAJOR\",\"summary\":\"REOPEN: destructive account deletion omits the required rollback command and executable rollbac",
+      "response_sha256": "aec0db241c8bd4e617b0d18176b2a1955cad821ab8600d06672b96f13d7092a6",
       "returncode": 0,
       "role": "final",
       "sequence": 1,
-      "session_ref": "01a02f63-4b45-7fb3-8a7d-6db7b594c831",
-      "stderr_excerpt": "2026-08-23T16:10:31.196669Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T16:11:07.653701Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-      "stderr_sha256": "f4461f38473443c1c48e438316c802760ae1980139f6dce360a1573877a539df",
+      "session_ref": "01a03402-f373-7c52-98d6-475ea9c94605",
+      "stderr_excerpt": "2026-08-24T13:43:23.338614Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-24T13:43:58.426090Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+      "stderr_sha256": "88b504a801eefebed1fbeea4a407452751dc237d984900b50c070a74d256a859",
       "usage": {
         "cached_input_tokens": 0,
-        "input_tokens": 18068,
-        "output_tokens": 1399,
-        "reasoning_output_tokens": 516
+        "input_tokens": 18163,
+        "output_tokens": 1151,
+        "reasoning_output_tokens": 301
       },
       "validation_issue": null,
       "validation_pointer": null
@@ -43,18 +43,18 @@
     ]
   },
   "date": "2026-08-22",
-  "elapsed_seconds": 39.32,
+  "elapsed_seconds": 36.631,
   "fixture": {
-    "base_id": "3e1852ada9d1f2bcf0f33da168ddd8650ca427e9",
+    "base_id": "2d32e2099e957e009f95fc54ed874f138d1146ed",
     "class_after": "open",
     "class_before": "closed",
     "class_first_round": 1,
     "class_id": "60c1a55e",
-    "head_id": "d04dc0460cd8502d14da2305e54e453f1255a952",
+    "head_id": "991966fde58d86d044d19caede46162436b8df8b",
     "lineage": "class-persistence-acceptance-20260822",
-    "packet_sha256": "42ff6b9846ba417e45916da6a37e2040a3bcc39d7042bae2940d8e2f73cd149d",
+    "packet_sha256": "03e5520db589047df88b145c7897642f9a3303b2a26c1207e6f26982ca3630ba",
     "round": 3,
-    "structural_snapshot": "c0e687fdd71c97cb81bd1d0a81a6d122538991dca3434bad3b033470abf1420b"
+    "structural_snapshot": "e1f90a4995a970d87eedfb8631221906a8fcff949fd53def3f1cbe2c4126d8b3"
   },
   "provider": {
     "cli_version": "codex-cli 0.144.6",
@@ -64,35 +64,35 @@
     "model": "gpt-5.6-sol",
     "web_search": false
   },
-  "result_sha256": "a3b0ff17ad1f3b3fd318b83eaa36d80d5f652e26d2b17847978db993f10af57e",
-  "result_text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\n- [MAJOR] The destructive account-deletion policy omits both required rollback safeguards. [classes: 60c1a55e] (repository/migration.md:3)\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\n- [MAJOR] Before deployment, amend the migration policy to name the exact rollback command and provide an executable rollback test that demonstrates restoration after the stored-account deletion.\n\n---\n_paranoia-local · engine=codex · session_ref=`01a02f63-4b45-7fb3-8a7d-6db7b594c831` — to dispute a finding, call `rebut` with this session_ref and your counter-evidence._\n\nLINEAGE: class-persistence-acceptance-20260822 (rounds recorded: 3)\nCLASS-REGISTER: staged final parsed — REOPEN 60c1a55e\nCLASS-CLOSURE: 1 open, 0 closed, 0 surviving matches, 0 exempt, 1 unmechanized\n  60c1a55e A destructive stored-data deletion change names an exact rollback command and an executable rollback test before deployment. (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)\nSTRUCTURAL-PHASE: correction\nSTRUCTURAL-DEBT: 1 blocking open\nPERSISTENCE: 60c1a55e currently open; round-label span 3 (first raised 1, now 3), current debt open since 3 — repeated correction may be unsatisfiable within this unit's scope; rebut with session_ref=01a02f63-4b45-7fb3-8a7d-6db7b594c831\nREOPEN-WAVE: 1 previously closed class(es) reopened this round: 60c1a55e — re-arm any prior disposition and reassess scope before another correction\nCONVERGENCE: BLOCKED — staged structural debt remains open.\nSTAGED-ATTEMPTS: total=1 validation-retries=0 validation-invalid=0 execution-failed=0",
+  "result_sha256": "ccb4a968c127f113a1a26a46f0e583e4ea44051ef5f725690dd3c895e45efb71",
+  "result_text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\n- [MAJOR] REOPEN: destructive account deletion omits the required rollback command and executable rollback test. [classes: 60c1a55e] (repository/migration.md:3)\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\n- [MAJOR] Before deployment, amend the policy to name the exact rollback command and provide an executable test that runs and verifies that rollback.\n\n---\n_paranoia-local · engine=codex · session_ref=`01a03402-f373-7c52-98d6-475ea9c94605` — to dispute a finding, call `rebut` with this session_ref and your counter-evidence._\n\nLINEAGE: class-persistence-acceptance-20260822 (rounds recorded: 3)\nCLASS-REGISTER: staged final parsed — REOPEN 60c1a55e\nCLASS-CLOSURE: 1 open, 0 closed, 0 surviving matches, 0 exempt, 1 unmechanized\n  60c1a55e A destructive stored-data deletion change names an exact rollback command and an executable rollback test before deployment. (unmechanized: awaiting reviewer CLOSED or RECLASSIFY)\nSTRUCTURAL-PHASE: correction\nSTRUCTURAL-DEBT: 1 blocking open\nPERSISTENCE: 60c1a55e currently open; round-label span 3 (first raised 1, now 3), current debt open since 3 — repeated correction may be unsatisfiable within this unit's scope; rebut with session_ref=01a03402-f373-7c52-98d6-475ea9c94605\nREOPEN-WAVE: 1 previously closed class(es) reopened this round: 60c1a55e — re-arm any prior disposition and reassess scope before another correction\nCONVERGENCE: BLOCKED — staged structural debt remains open.\nSTAGED-ATTEMPTS: total=1 validation-retries=0 validation-invalid=0 execution-failed=0",
   "settlement": {
     "_class_record_pointers": [
       "/class_actions/60c1a55e"
     ],
     "_finding_class_refs": {
-      "F1": "60c1a55e"
+      "F-001": "60c1a55e"
     },
     "assessment_dispositions": [
       {
         "assessment_id": "60c1a55e",
-        "governing_id": "F1"
+        "governing_id": "F-001"
       }
     ],
     "class_assessments": [
       {
         "class_id": "60c1a55e",
         "evidence": [
-          "repository/migration.md:1-3"
+          "repository/migration.md:3"
         ],
-        "finding_id": "F1",
+        "finding_id": "F-001",
         "verdict": "violated"
       }
     ],
     "class_dispositions": [
       {
         "class_id": "60c1a55e",
-        "finding_id": "F1",
+        "finding_id": "F-001",
         "kind": "existing_class"
       }
     ],
@@ -108,11 +108,11 @@
           "repository/migration.md:3"
         ],
         "finding_ids": [
-          "F1"
+          "F-001"
         ],
         "id": "artifact-complete",
         "status": "finding",
-        "summary": "The destructive migration policy is incomplete because it supplies neither required rollback artifact."
+        "summary": "The migration artifact lacks the required rollback command and executable rollback test."
       },
       {
         "evidence": [
@@ -121,18 +121,18 @@
         "finding_ids": [],
         "id": "repository-premises",
         "status": "covered",
-        "summary": "The policy text itself establishes the relevant destructive stored-data premise."
+        "summary": "The reviewed policy clearly identifies its destructive stored-data premise."
       },
       {
         "evidence": [
           "repository/migration.md:3"
         ],
         "finding_ids": [
-          "F1"
+          "F-001"
         ],
         "id": "transformations",
         "status": "finding",
-        "summary": "The proposed destructive transformation lacks its required rollback command and test."
+        "summary": "The destructive transformation has no specified reversal mechanism."
       },
       {
         "evidence": [
@@ -141,60 +141,60 @@
         "finding_ids": [],
         "id": "consumers",
         "status": "not_applicable",
-        "summary": "No distinct code or data consumers are introduced or changed in the supplied artifact."
+        "summary": "No distinct consumer implementation is changed in the supplied artifact."
       },
       {
         "evidence": [
           "repository/migration.md:3"
         ],
         "finding_ids": [
-          "F1"
+          "F-001"
         ],
         "id": "failure-recovery",
         "status": "finding",
-        "summary": "No rollback procedure is provided before deployment."
+        "summary": "No executable recovery path is named."
       },
       {
         "evidence": [
           "repository/migration.md:3"
         ],
         "finding_ids": [
-          "F1"
+          "F-001"
         ],
         "id": "tests-acceptance",
         "status": "finding",
-        "summary": "There is no executable acceptance test for rollback."
-      },
-      {
-        "evidence": [
-          "repository/migration.md:1-3"
-        ],
-        "finding_ids": [
-          "F1"
-        ],
-        "id": "docs-operations",
-        "status": "finding",
-        "summary": "The operational migration documentation is unsafe to use as written."
-      },
-      {
-        "evidence": [
-          "repository/migration.md:1-3"
-        ],
-        "finding_ids": [],
-        "id": "consistency",
-        "status": "covered",
-        "summary": "The document is internally consistent, although consistently incomplete."
+        "summary": "The required rollback acceptance test is absent."
       },
       {
         "evidence": [
           "repository/migration.md:3"
         ],
         "finding_ids": [
-          "F1"
+          "F-001"
         ],
-        "id": "proportionality",
+        "id": "docs-operations",
         "status": "finding",
-        "summary": "The merge-blocking remedy is limited to the two artifacts required by the active class."
+        "summary": "The documented destructive operation is missing mandatory rollback instructions."
+      },
+      {
+        "evidence": [
+          "repository/migration.md:3"
+        ],
+        "finding_ids": [
+          "F-001"
+        ],
+        "id": "consistency",
+        "status": "finding",
+        "summary": "The new policy is consistently written but contradicts the active lifecycle invariant."
+      },
+      {
+        "evidence": [
+          "repository/migration.md:3"
+        ],
+        "finding_ids": [],
+        "id": "proportionality",
+        "status": "covered",
+        "summary": "Reopening the MAJOR class is proportionate to the destructive scope and stated review stakes."
       }
     ],
     "debt": [
@@ -202,12 +202,12 @@
         "evidence": [
           "repository/migration.md:3"
         ],
-        "finding_id": "F1",
+        "finding_id": "F-001",
         "id": "D1",
-        "remedy": "Before deployment, amend the migration policy to name the exact rollback command and provide an executable rollback test that demonstrates restoration after the stored-account deletion.",
+        "remedy": "Before deployment, amend the policy to name the exact rollback command and provide an executable test that runs and verifies that rollback.",
         "severity": "MAJOR",
         "status": "open",
-        "summary": "The destructive account-deletion policy omits both required rollback safeguards."
+        "summary": "REOPEN: destructive account deletion omits the required rollback command and executable rollback test."
       }
     ],
     "debt_updates": [],
@@ -216,15 +216,15 @@
         "evidence": [
           "repository/migration.md:3"
         ],
-        "id": "F1",
-        "remedy": "Before deployment, amend the migration policy to name the exact rollback command and provide an executable rollback test that demonstrates restoration after the stored-account deletion.",
+        "id": "F-001",
+        "remedy": "Before deployment, amend the policy to name the exact rollback command and provide an executable test that runs and verifies that rollback.",
         "severity": "MAJOR",
-        "summary": "The destructive account-deletion policy omits both required rollback safeguards."
+        "summary": "REOPEN: destructive account deletion omits the required rollback command and executable rollback test."
       }
     ],
     "role": "final",
     "source_dispositions": []
   },
-  "source_revision": "d1d6996171a35bf868523ea5c745f1b5e9c017dd",
+  "source_revision": "3429549231c040f5039e49b903774c06ea3202ae",
   "version": 2
 }

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -223,6 +223,12 @@ missing executables, capture failures, and ambiguous persistence block visibly.
 None becomes an empty successful review. Validation-invalid responses receive at
 most one role-specific correction; execution failures remain distinct.
 
+The primary staged-failure headline preserves that taxonomy: provider and local
+engine outcomes render as `engine failed (<kind>)`, schema or semantic rejection
+as `staged rejected (validation)`, and reserve exhaustion as
+`staged blocked (deadline)`. These labels also appear in `CLASS-REGISTER`, so a
+transient provider failure cannot be mistaken for repeated structural rejection.
+
 A failed staged structural review begins `# STAGED REVIEW FAILED` and states
 whether failure occurred before settlement or after unconfirmed persistence. It
 never renders a clean-review scaffold.

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -229,6 +229,11 @@ as `staged rejected (validation)`, and reserve exhaustion as
 `staged blocked (deadline)`. These labels also appear in `CLASS-REGISTER`, so a
 transient provider failure cannot be mistaken for repeated structural rejection.
 
+Persistent correction control stores `reset_round`, `reopen_count`, and
+`last_session_ref`. A load-bearing `CORRECTION-GATE` is projected from
+`correction_gates` into the exact `rendered_trailer`; only an exact
+validation-invalid terminal retry may recover a previously sessionless gate.
+
 A failed staged structural review begins `# STAGED REVIEW FAILED` and states
 whether failure occurred before settlement or after unconfirmed persistence. It
 never renders a clean-review scaffold.

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -36,8 +36,8 @@
           ],
           "evidence": [
             "plan:4",
-            "repository/scripts/run_persistent_correction_gate_acceptance.py:589-594",
-            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-148"
+            "repository/scripts/run_persistent_correction_gate_acceptance.py:677-682",
+            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-149"
           ],
           "finding_id": "G1",
           "first_round": 1,
@@ -52,7 +52,7 @@
       ],
       "last_round": 7,
       "phase": "final",
-      "snapshot_digest": "824ebf9ffdd4cf974aa0a6911de3863896fca7e66c7b8cfdfbacb55eff5c13f3",
+      "snapshot_digest": "8afaa9aeead1c46e8e6aa66574db7accd72e13849b80d672eedcbea170af0349",
       "stakes": "One trusted operator and OS; repository and plan bytes are untrusted data; no hostile local race or repository execution; one class and one claim-free plan; false clearance is high impact and recoverable blocking is acceptable.",
       "stakes_digest": "241252a03212adae7708447f4c05289e76185a7eb363b024b25d3f101dd78fea",
       "version": 1
@@ -61,30 +61,30 @@
   },
   "attempt_ledger": [
     {
-      "duration_ms": 50175,
+      "duration_ms": 69741,
       "engine": "codex",
       "failure_detail_excerpt": "",
       "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
       "outcome": "completed",
       "provider_duration_ms": null,
-      "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02f72-8a49-7a70-9376-75c25f8b9d85\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"gate-class\\\":null},\\\"class_outcomes\\\":{\\\"gate-class\\\":{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"I’m inspecting the plan’s acceptance obligation against the repository’s public-handler surface before deciding whether the persistent gate can be closed or must be replaced.\\\"}],\\\"verdict\\\":\\\"satisfied\\\"}},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"correction\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"repository/CLAUDE.md\\nrepository/README.md\\nrepository/AGENTS.md\\nrepository/pyproject.toml\\nrepository/LICENSE\\nrepository/scripts/run_class_persistence_acceptance.py\\nrepository/scripts/run_claim_discovery_timeout_acceptance.py\\nrepository/scripts/run_authoritative_capture_entrypoint_acceptance.py\\nrepository/scripts/run_authoritative_capture_acceptance.py\\nrepository/scripts/run_arbitration_steering_rejection_acceptance.py\\nrepository/scripts/run_arbitration_fallback_acceptance.py\\nrepository/scripts/run_arbitration_context_steering_rejection_acceptance.py\\nrepository/scripts/run_arbitration_consequence_acceptance.py\\nrepository/scripts/record_claim_discovery_timeout_acceptance.py\\nrepository/scripts/build_branch_plan_fidelity_acceptance.py\\nrepository/scripts/run_staged_protocol_mutation_checks.py\\nrepository/scripts/run_persistent_correction_gate_acceptance.py\\nrepository/scripts/run_keyed_handler_acceptance.py\\nrepository/scripts/run_keyed_class_provider_acceptance.py\\nrepository/scripts/run_cleaning_acceptance_checks.py\\nrepository/scripts/validate_arbitration_consequence_acceptance.py\\nrepository/scripts/validate_arbitration_acceptance.py\\nrepository/scripts/validate_arbitration_fallback_acceptance.py\\nrepository/scripts/validate_cleaning_attestation_acceptance.py\\nrepository/tests/test_handlers.py\\nrepository/tests/test_external_sources.py\\nrepository/tests/test_evidence.py\\nrepository/tests/test_engines.py\\nrepository/tests/test_converge.py\\nrepository/tests/test_config_logs.py\\nrepository/tests/test_class_closure_integration.py\\nrepository/tests/test_class_closure.py\\nrepository/tests/test_branch_plan_fidelity.py\\nrepository/tests/test_arbitration_research.py\\nrepository/tests/test_arbitration_fallback_acceptance.py\\nrepository/tests/test_arbitration_consequence_acceptance.py\\nrepository/tests/test_arbitration.py\\nrepository/tests/test_arbitrate_handler.py\\nrepository/tests/test_acceptance_validator.py\\nrepository/tests/conftest.py\\nrepository/tests/test_progress.py\\nrepository/tests/test_plan_class_closure.py\\nrepository/tests/test_plan_claims.py\\nrepository/tests/test_packet.py\\nrepository/tests/test_orientation.py\\nrepository/tests/test_integration.py\\nrepository/tests/test_instrumentation.py\\nrepository/tests/test_inert_tree.py\\nrepository/tests/test_snapshot.py\\nrepository/tests/test_server.py\\nrepository/tests/test_review_census.py\\nrepository/tests/test_prompts.py\\nrepository/tests/test_worktree.py\\nrepository/tests/test_staged_protocol.py\\nrepository/tests/__init__.py\\nrepository/docs/claim_binding_acceptance_2026-08-14.json\\nrepository/docs/arbitration_consequence_acceptance_2026-08-22.json\\nrepository/docs/exhaustive_census_prototype_evidence.md\\nrepository/docs/branch_plan_fidelity_plan.md\\nrepository/docs/branch_plan_fidelity_acceptance_2026-08-22.json\\nrepository/docs/authoritative_capture_segmentation_plan.md\\nrepository/docs/authoritative_capture_acceptance_2026-08-20.json\\nrepository/doc",
-      "raw_sha256": "1585717993380e953a1161907dd559a272ccc60d4e8bc4f0581b17c9408c464e",
+      "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a03414-da03-7303-b13d-9c6236eb6f5f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"gate-class\\\":null},\\\"class_outcomes\\\":{\\\"gate-class\\\":{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The plan explicitly requires tests to exercise the correction gate through its public handler, which directly satisfies the class invariant at plan phase.\\\"}],\\\"verdict\\\":\\\"satisfied\\\"}},\\\"debt_outcomes\\\":[{\\\"debt_id\\\":\\\"D1\\\",\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The current plan now contains the required public-handler acceptance obligation; plan review does not require the future implementation test to have already run.\\\"}],\\\"status\\\":\\\"closed\\\"}],\\\"governing_findings\\\":[],\\\"role\\\":\\\"correction\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"repository/CLAUDE.md\\nrepository/AGENTS.md\\nrepository/llms.txt\\nrepository/docs/arbitration_fallback_acceptance_2026-08-16.json\\nrepository/docs/claim_binding_acceptance_2026-08-14.json\\nrepository/docs/arbitrate_original_neutrality_fallback_plan.md\\nrepository/scripts/run_cleaning_acceptance_checks.py\\nrepository/scripts/run_arbitration_consequence_acceptance.py\\nrepository/scripts/run_keyed_class_provider_acceptance.py\\nrepository/scripts/validate_arbitration_fallback_acceptance.py\\nrepository/scripts/run_claim_discovery_timeout_acceptance.py\\nrepository/scripts/validate_arbitration_acceptance.py\\nrepository/scripts/run_arbitration_context_steering_rejection_acceptance.py\\nrepository/scripts/run_class_persistence_acceptance.py\\nrepository/scripts/build_branch_plan_fidelity_acceptance.py\\nrepository/scripts/run_arbitration_fallback_acceptance.py\\nrepository/scripts/validate_cleaning_attestation_acceptance.py\\nrepository/scripts/run_persistent_correction_gate_acceptance.py\\nrepository/scripts/run_authoritative_capture_entrypoint_acceptance.py\\nrepository/scripts/run_authoritative_capture_acceptance.py\\nrepository/scripts/run_arbitration_steering_rejection_acceptance.py\\nrepository/scripts/validate_arbitration_consequence_acceptance.py\\nrepository/scripts/run_staged_protocol_mutation_checks.py\\nrepository/scripts/run_keyed_handler_acceptance.py\\nrepository/scripts/record_claim_discovery_timeout_acceptance.py\\nrepository/README.md\\nrepository/LICENSE\\nrepository/tests/test_review_census.py\\nrepository/tests/__init__.py\\nrepository/tests/test_external_sources.py\\nrepository/tests/test_server.py\\nrepository/tests/test_arbitration_consequence_acceptance.py\\nrepository/tests/test_engines.py\\nrepository/tests/test_arbitration_research.py\\nrepository/tests/test_orientation.py\\nrepository/tests/test_branch_plan_fidelity.py\\nrepository/tests/test_instrumentation.py\\nrepository/tests/test_config_logs.py\\nrepository/tests/test_inert_tree.py\\nrepository/tests/test_evidence.py\\nrepository/tests/test_integration.py\\nrepository/tests/conftest.py\\nrepository/tests/test_prompts.py\\nrepository/tests/test_class_closure.py\\nrepository/tests/test_arbitration_fallback_acceptance.py\\nrepository/tests/test_arbitrate_handler.py\\nrepository/tests/test_arbitration.py\\nrepository/tests/test_staged_protocol.py\\nrepository/tests/test_packet.py\\nrepository/tests/test_plan_claims.py\\nrepository/tests/test_progress.py\\nrepository/tests/test_converge.py\\nrepository/tests/test_worktree.py\\nrepository/tests/test_class_closure_integration.py\\nrepository/tests/test_plan_class_closure.py\\nrepository/tests/test_acceptance_validator.py\\nrepository/tests/test_handlers.py\\nrepository/tests/test_snapshot.py\\nrepository/d",
+      "raw_sha256": "2e3327fc8d1891a330b84c4d80693cd7d14b1d0aa0ed76bca1d6d4e37d07770e",
       "rejected_reply_excerpt": null,
       "rejected_reply_sha256": null,
       "requested_timeout_sec": 2400,
-      "response_excerpt": "{\"class_actions\":{\"gate-class\":{\"kind\":\"close\"}},\"class_outcomes\":{\"gate-class\":{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan expressly requires tests to exercise the correction gate through its public handler.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:24-31\",\"rationale\":\"The acceptance runner binds the exact class, four-line plan, and review stakes supplied for this correction.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:589-594\",\"rationale\":\"The executable acceptance invokes the bound plan through the public critique_plan handler.\"}],\"verdict\":\"satisfied\"}},\"debt_outcomes\":[{\"debt_id\":\"D1\",\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The current plan contains the previously missing public-handler acceptance obligation.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:589-594\",\"rationale\":\"The repository acceptance runner exercises that obligation through the public plan handler.\"},{\"anchor\":\"repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-148\",\"rationale\":\"The retained acceptance audit records the parsed class closure and resulting closed class register.\"}],\"status\":\"closed\"}],\"governing_findings\":[],\"role\":\"correction\"}",
-      "response_sha256": "ee25b0755d60ea927595b185f460e51509d5792b16c8cc1d656499092996bb23",
+      "response_excerpt": "{\"class_actions\":{\"gate-class\":{\"kind\":\"close\"}},\"class_outcomes\":{\"gate-class\":{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan expressly requires tests to exercise the correction gate through its public handler.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:677-682\",\"rationale\":\"The executable acceptance invokes the bound plan through the public critique_plan handler.\"}],\"verdict\":\"satisfied\"}},\"debt_outcomes\":[{\"debt_id\":\"D1\",\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The current plan contains the required public-handler acceptance obligation.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:677-682\",\"rationale\":\"The repository acceptance runner exercises that obligation through the public plan handler.\"},{\"anchor\":\"repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-149\",\"rationale\":\"The retained acceptance audit records the parsed CLOSE disposition and successful closed-class trailer.\"}],\"status\":\"closed\"}],\"governing_findings\":[],\"role\":\"correction\"}",
+      "response_sha256": "92ab1f86b05d3330149f5de33cf2b41dfe09b5c34b889b43a1be8e9fce3b3ca5",
       "returncode": 0,
       "role": "correction",
       "sequence": 1,
-      "session_ref": "01a02f72-8a49-7a70-9376-75c25f8b9d85",
-      "stderr_excerpt": "2026-08-23T16:27:10.332294Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T16:27:59.373247Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-      "stderr_sha256": "fcca81252cdca55e6d8e7d3b82fbc6626594478e2494a172c949903d815ab9aa",
+      "session_ref": "01a03414-da03-7303-b13d-9c6236eb6f5f",
+      "stderr_excerpt": "2026-08-24T14:02:56.487640Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:25.436230Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:32.389262Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:37.221279Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:04:05.174312Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+      "stderr_sha256": "04ce4f66af68433cd754e33e9a830232880f4e67a4955d8502ff459f91dbb6f2",
       "usage": {
-        "cached_input_tokens": 61696,
-        "input_tokens": 95719,
-        "output_tokens": 1916,
-        "reasoning_output_tokens": 1135
+        "cached_input_tokens": 126720,
+        "input_tokens": 165579,
+        "output_tokens": 2667,
+        "reasoning_output_tokens": 1666
       },
       "validation_issue": null,
       "validation_pointer": null
@@ -94,30 +94,30 @@
     "already_raised": [],
     "attempt_ledger": [
       {
-        "duration_ms": 50175,
+        "duration_ms": 69741,
         "engine": "codex",
         "failure_detail_excerpt": "",
         "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
         "outcome": "completed",
         "provider_duration_ms": null,
-        "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a02f72-8a49-7a70-9376-75c25f8b9d85\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"gate-class\\\":null},\\\"class_outcomes\\\":{\\\"gate-class\\\":{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"I’m inspecting the plan’s acceptance obligation against the repository’s public-handler surface before deciding whether the persistent gate can be closed or must be replaced.\\\"}],\\\"verdict\\\":\\\"satisfied\\\"}},\\\"debt_outcomes\\\":[],\\\"governing_findings\\\":[],\\\"role\\\":\\\"correction\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"repository/CLAUDE.md\\nrepository/README.md\\nrepository/AGENTS.md\\nrepository/pyproject.toml\\nrepository/LICENSE\\nrepository/scripts/run_class_persistence_acceptance.py\\nrepository/scripts/run_claim_discovery_timeout_acceptance.py\\nrepository/scripts/run_authoritative_capture_entrypoint_acceptance.py\\nrepository/scripts/run_authoritative_capture_acceptance.py\\nrepository/scripts/run_arbitration_steering_rejection_acceptance.py\\nrepository/scripts/run_arbitration_fallback_acceptance.py\\nrepository/scripts/run_arbitration_context_steering_rejection_acceptance.py\\nrepository/scripts/run_arbitration_consequence_acceptance.py\\nrepository/scripts/record_claim_discovery_timeout_acceptance.py\\nrepository/scripts/build_branch_plan_fidelity_acceptance.py\\nrepository/scripts/run_staged_protocol_mutation_checks.py\\nrepository/scripts/run_persistent_correction_gate_acceptance.py\\nrepository/scripts/run_keyed_handler_acceptance.py\\nrepository/scripts/run_keyed_class_provider_acceptance.py\\nrepository/scripts/run_cleaning_acceptance_checks.py\\nrepository/scripts/validate_arbitration_consequence_acceptance.py\\nrepository/scripts/validate_arbitration_acceptance.py\\nrepository/scripts/validate_arbitration_fallback_acceptance.py\\nrepository/scripts/validate_cleaning_attestation_acceptance.py\\nrepository/tests/test_handlers.py\\nrepository/tests/test_external_sources.py\\nrepository/tests/test_evidence.py\\nrepository/tests/test_engines.py\\nrepository/tests/test_converge.py\\nrepository/tests/test_config_logs.py\\nrepository/tests/test_class_closure_integration.py\\nrepository/tests/test_class_closure.py\\nrepository/tests/test_branch_plan_fidelity.py\\nrepository/tests/test_arbitration_research.py\\nrepository/tests/test_arbitration_fallback_acceptance.py\\nrepository/tests/test_arbitration_consequence_acceptance.py\\nrepository/tests/test_arbitration.py\\nrepository/tests/test_arbitrate_handler.py\\nrepository/tests/test_acceptance_validator.py\\nrepository/tests/conftest.py\\nrepository/tests/test_progress.py\\nrepository/tests/test_plan_class_closure.py\\nrepository/tests/test_plan_claims.py\\nrepository/tests/test_packet.py\\nrepository/tests/test_orientation.py\\nrepository/tests/test_integration.py\\nrepository/tests/test_instrumentation.py\\nrepository/tests/test_inert_tree.py\\nrepository/tests/test_snapshot.py\\nrepository/tests/test_server.py\\nrepository/tests/test_review_census.py\\nrepository/tests/test_prompts.py\\nrepository/tests/test_worktree.py\\nrepository/tests/test_staged_protocol.py\\nrepository/tests/__init__.py\\nrepository/docs/claim_binding_acceptance_2026-08-14.json\\nrepository/docs/arbitration_consequence_acceptance_2026-08-22.json\\nrepository/docs/exhaustive_census_prototype_evidence.md\\nrepository/docs/branch_plan_fidelity_plan.md\\nrepository/docs/branch_plan_fidelity_acceptance_2026-08-22.json\\nrepository/docs/authoritative_capture_segmentation_plan.md\\nrepository/docs/authoritative_capture_acceptance_2026-08-20.json\\nrepository/doc",
-        "raw_sha256": "1585717993380e953a1161907dd559a272ccc60d4e8bc4f0581b17c9408c464e",
+        "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"01a03414-da03-7303-b13d-9c6236eb6f5f\"}\n{\"type\":\"turn.started\"}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_0\",\"type\":\"agent_message\",\"text\":\"{\\\"class_actions\\\":{\\\"gate-class\\\":null},\\\"class_outcomes\\\":{\\\"gate-class\\\":{\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The plan explicitly requires tests to exercise the correction gate through its public handler, which directly satisfies the class invariant at plan phase.\\\"}],\\\"verdict\\\":\\\"satisfied\\\"}},\\\"debt_outcomes\\\":[{\\\"debt_id\\\":\\\"D1\\\",\\\"evidence\\\":[{\\\"anchor\\\":\\\"plan:4\\\",\\\"rationale\\\":\\\"The current plan now contains the required public-handler acceptance obligation; plan review does not require the future implementation test to have already run.\\\"}],\\\"status\\\":\\\"closed\\\"}],\\\"governing_findings\\\":[],\\\"role\\\":\\\"correction\\\"}\"}}\n{\"type\":\"item.started\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"\",\"exit_code\":null,\"status\":\"in_progress\"}}\n{\"type\":\"item.completed\",\"item\":{\"id\":\"item_1\",\"type\":\"command_execution\",\"command\":\"/bin/bash -lc 'rg --files repository && rg -n \\\"correction|gate|handler|public\\\" repository'\",\"aggregated_output\":\"repository/CLAUDE.md\\nrepository/AGENTS.md\\nrepository/llms.txt\\nrepository/docs/arbitration_fallback_acceptance_2026-08-16.json\\nrepository/docs/claim_binding_acceptance_2026-08-14.json\\nrepository/docs/arbitrate_original_neutrality_fallback_plan.md\\nrepository/scripts/run_cleaning_acceptance_checks.py\\nrepository/scripts/run_arbitration_consequence_acceptance.py\\nrepository/scripts/run_keyed_class_provider_acceptance.py\\nrepository/scripts/validate_arbitration_fallback_acceptance.py\\nrepository/scripts/run_claim_discovery_timeout_acceptance.py\\nrepository/scripts/validate_arbitration_acceptance.py\\nrepository/scripts/run_arbitration_context_steering_rejection_acceptance.py\\nrepository/scripts/run_class_persistence_acceptance.py\\nrepository/scripts/build_branch_plan_fidelity_acceptance.py\\nrepository/scripts/run_arbitration_fallback_acceptance.py\\nrepository/scripts/validate_cleaning_attestation_acceptance.py\\nrepository/scripts/run_persistent_correction_gate_acceptance.py\\nrepository/scripts/run_authoritative_capture_entrypoint_acceptance.py\\nrepository/scripts/run_authoritative_capture_acceptance.py\\nrepository/scripts/run_arbitration_steering_rejection_acceptance.py\\nrepository/scripts/validate_arbitration_consequence_acceptance.py\\nrepository/scripts/run_staged_protocol_mutation_checks.py\\nrepository/scripts/run_keyed_handler_acceptance.py\\nrepository/scripts/record_claim_discovery_timeout_acceptance.py\\nrepository/README.md\\nrepository/LICENSE\\nrepository/tests/test_review_census.py\\nrepository/tests/__init__.py\\nrepository/tests/test_external_sources.py\\nrepository/tests/test_server.py\\nrepository/tests/test_arbitration_consequence_acceptance.py\\nrepository/tests/test_engines.py\\nrepository/tests/test_arbitration_research.py\\nrepository/tests/test_orientation.py\\nrepository/tests/test_branch_plan_fidelity.py\\nrepository/tests/test_instrumentation.py\\nrepository/tests/test_config_logs.py\\nrepository/tests/test_inert_tree.py\\nrepository/tests/test_evidence.py\\nrepository/tests/test_integration.py\\nrepository/tests/conftest.py\\nrepository/tests/test_prompts.py\\nrepository/tests/test_class_closure.py\\nrepository/tests/test_arbitration_fallback_acceptance.py\\nrepository/tests/test_arbitrate_handler.py\\nrepository/tests/test_arbitration.py\\nrepository/tests/test_staged_protocol.py\\nrepository/tests/test_packet.py\\nrepository/tests/test_plan_claims.py\\nrepository/tests/test_progress.py\\nrepository/tests/test_converge.py\\nrepository/tests/test_worktree.py\\nrepository/tests/test_class_closure_integration.py\\nrepository/tests/test_plan_class_closure.py\\nrepository/tests/test_acceptance_validator.py\\nrepository/tests/test_handlers.py\\nrepository/tests/test_snapshot.py\\nrepository/d",
+        "raw_sha256": "2e3327fc8d1891a330b84c4d80693cd7d14b1d0aa0ed76bca1d6d4e37d07770e",
         "rejected_reply_excerpt": null,
         "rejected_reply_sha256": null,
         "requested_timeout_sec": 2400,
-        "response_excerpt": "{\"class_actions\":{\"gate-class\":{\"kind\":\"close\"}},\"class_outcomes\":{\"gate-class\":{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan expressly requires tests to exercise the correction gate through its public handler.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:24-31\",\"rationale\":\"The acceptance runner binds the exact class, four-line plan, and review stakes supplied for this correction.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:589-594\",\"rationale\":\"The executable acceptance invokes the bound plan through the public critique_plan handler.\"}],\"verdict\":\"satisfied\"}},\"debt_outcomes\":[{\"debt_id\":\"D1\",\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The current plan contains the previously missing public-handler acceptance obligation.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:589-594\",\"rationale\":\"The repository acceptance runner exercises that obligation through the public plan handler.\"},{\"anchor\":\"repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-148\",\"rationale\":\"The retained acceptance audit records the parsed class closure and resulting closed class register.\"}],\"status\":\"closed\"}],\"governing_findings\":[],\"role\":\"correction\"}",
-        "response_sha256": "ee25b0755d60ea927595b185f460e51509d5792b16c8cc1d656499092996bb23",
+        "response_excerpt": "{\"class_actions\":{\"gate-class\":{\"kind\":\"close\"}},\"class_outcomes\":{\"gate-class\":{\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The plan expressly requires tests to exercise the correction gate through its public handler.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:677-682\",\"rationale\":\"The executable acceptance invokes the bound plan through the public critique_plan handler.\"}],\"verdict\":\"satisfied\"}},\"debt_outcomes\":[{\"debt_id\":\"D1\",\"evidence\":[{\"anchor\":\"plan:4\",\"rationale\":\"The current plan contains the required public-handler acceptance obligation.\"},{\"anchor\":\"repository/scripts/run_persistent_correction_gate_acceptance.py:677-682\",\"rationale\":\"The repository acceptance runner exercises that obligation through the public plan handler.\"},{\"anchor\":\"repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-149\",\"rationale\":\"The retained acceptance audit records the parsed CLOSE disposition and successful closed-class trailer.\"}],\"status\":\"closed\"}],\"governing_findings\":[],\"role\":\"correction\"}",
+        "response_sha256": "92ab1f86b05d3330149f5de33cf2b41dfe09b5c34b889b43a1be8e9fce3b3ca5",
         "returncode": 0,
         "role": "correction",
         "sequence": 1,
-        "session_ref": "01a02f72-8a49-7a70-9376-75c25f8b9d85",
-        "stderr_excerpt": "2026-08-23T16:27:10.332294Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-23T16:27:59.373247Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
-        "stderr_sha256": "fcca81252cdca55e6d8e7d3b82fbc6626594478e2494a172c949903d815ab9aa",
+        "session_ref": "01a03414-da03-7303-b13d-9c6236eb6f5f",
+        "stderr_excerpt": "2026-08-24T14:02:56.487640Z ERROR codex_models_manager::cache: failed to load models cache: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:25.436230Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:32.389262Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:03:37.221279Z ERROR codex_models_manager::manager: failed to renew cache TTL: missing field `base_instructions` at line 95 column 5\n2026-08-24T14:04:05.174312Z  WARN codex_file_watcher: failed to unwatch /mnt/c/Users/andy/.codex/skills/.system: No watch was found. about [\"/mnt/c/Users/andy/.codex/skills/.system\"]\n",
+        "stderr_sha256": "04ce4f66af68433cd754e33e9a830232880f4e67a4955d8502ff459f91dbb6f2",
         "usage": {
-          "cached_input_tokens": 61696,
-          "input_tokens": 95719,
-          "output_tokens": 1916,
-          "reasoning_output_tokens": 1135
+          "cached_input_tokens": 126720,
+          "input_tokens": 165579,
+          "output_tokens": 2667,
+          "reasoning_output_tokens": 1666
         },
         "validation_issue": null,
         "validation_pointer": null
@@ -150,7 +150,7 @@
     "retry_register": null,
     "returncode": 0,
     "round": 7,
-    "session_ref": "01a02f72-8a49-7a70-9376-75c25f8b9d85",
+    "session_ref": "01a03414-da03-7303-b13d-9c6236eb6f5f",
     "staged_manifests": null,
     "staged_settlement": {
       "_class_record_pointers": [
@@ -168,8 +168,7 @@
           "class_id": "gate-class",
           "evidence": [
             "plan:4",
-            "repository/scripts/run_persistent_correction_gate_acceptance.py:24-31",
-            "repository/scripts/run_persistent_correction_gate_acceptance.py:589-594"
+            "repository/scripts/run_persistent_correction_gate_acceptance.py:677-682"
           ],
           "finding_id": null,
           "verdict": "satisfied"
@@ -187,8 +186,8 @@
         {
           "evidence": [
             "plan:4",
-            "repository/scripts/run_persistent_correction_gate_acceptance.py:589-594",
-            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-148"
+            "repository/scripts/run_persistent_correction_gate_acceptance.py:677-682",
+            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-149"
           ],
           "id": "D1",
           "status": "closed"
@@ -199,7 +198,7 @@
       "source_dispositions": []
     },
     "text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\nNothing notable.\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\nNothing notable.",
-    "timestamp": "20260823T172759",
+    "timestamp": "20260824T150405",
     "tool": "critique_plan"
   },
   "before_lineage": {
@@ -253,7 +252,7 @@
       ],
       "last_round": 6,
       "phase": "correction",
-      "snapshot_digest": "824ebf9ffdd4cf974aa0a6911de3863896fca7e66c7b8cfdfbacb55eff5c13f3",
+      "snapshot_digest": "8afaa9aeead1c46e8e6aa66574db7accd72e13849b80d672eedcbea170af0349",
       "stakes": "One trusted operator and OS; repository and plan bytes are untrusted data; no hostile local race or repository execution; one class and one claim-free plan; false clearance is high impact and recoverable blocking is acceptable.",
       "stakes_digest": "241252a03212adae7708447f4c05289e76185a7eb363b024b25d3f101dd78fea",
       "version": 1
@@ -268,7 +267,7 @@
       "span": 7
     }
   ],
-  "date": "2026-08-23",
+  "date": "2026-08-24",
   "durable_reload_lineage": {
     "claim_reverify_required": false,
     "claim_state": {},
@@ -305,8 +304,8 @@
           ],
           "evidence": [
             "plan:4",
-            "repository/scripts/run_persistent_correction_gate_acceptance.py:589-594",
-            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-148"
+            "repository/scripts/run_persistent_correction_gate_acceptance.py:677-682",
+            "repository/docs/persistent_correction_gate_acceptance_2026-08-23.json:146-149"
           ],
           "finding_id": "G1",
           "first_round": 1,
@@ -321,22 +320,22 @@
       ],
       "last_round": 7,
       "phase": "final",
-      "snapshot_digest": "824ebf9ffdd4cf974aa0a6911de3863896fca7e66c7b8cfdfbacb55eff5c13f3",
+      "snapshot_digest": "8afaa9aeead1c46e8e6aa66574db7accd72e13849b80d672eedcbea170af0349",
       "stakes": "One trusted operator and OS; repository and plan bytes are untrusted data; no hostile local race or repository execution; one class and one claim-free plan; false clearance is high impact and recoverable blocking is acceptable.",
       "stakes_digest": "241252a03212adae7708447f4c05289e76185a7eb363b024b25d3f101dd78fea",
       "version": 1
     },
     "rounds": 7
   },
-  "elapsed_seconds": 53.65,
+  "elapsed_seconds": 71.308,
   "fixture": {
     "class_id": "gate-class",
     "lineage": "persistent-correction-gate-acceptance-20260823",
     "plan": "# Change\n\nImplement the correction gate.\nTests must exercise its public handler.",
     "plan_sha256": "c2e9f84aed58a3e7a31a4b4c596349df226d5aa678e087d9d26ca65c34a7f9c0",
     "round": 7,
-    "snapshot_commit": "0bec23b77513e2ded704411daf7ea870397d2735",
-    "structural_snapshot": "824ebf9ffdd4cf974aa0a6911de3863896fca7e66c7b8cfdfbacb55eff5c13f3"
+    "snapshot_commit": "e929b6459bcda31905f4c15035cba15e43c28f2a",
+    "structural_snapshot": "8afaa9aeead1c46e8e6aa66574db7accd72e13849b80d672eedcbea170af0349"
   },
   "outcome": "closed-or-replaced",
   "provider": {
@@ -434,22 +433,244 @@
       "state_sha256_before": "ddf1681909f701a1b26be7a464c16a762cc6117555faf84ea867a967410bf021"
     }
   ],
+  "public_provider_failure_route": {
+    "attempt_ledger": [
+      {
+        "duration_ms": 12,
+        "engine": "codex",
+        "failure_detail_excerpt": "Selected model is at capacity",
+        "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+        "outcome": "failed",
+        "provider_duration_ms": null,
+        "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+        "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+        "rejected_reply_excerpt": null,
+        "rejected_reply_sha256": null,
+        "requested_timeout_sec": 1800,
+        "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+        "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+        "returncode": 0,
+        "role": "census-behaviour",
+        "sequence": 1,
+        "session_ref": "capacity-fixture",
+        "stderr_excerpt": "",
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "usage": null,
+        "validation_issue": null,
+        "validation_pointer": null
+      },
+      {
+        "duration_ms": 12,
+        "engine": "codex",
+        "failure_detail_excerpt": "Selected model is at capacity",
+        "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+        "outcome": "failed",
+        "provider_duration_ms": null,
+        "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+        "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+        "rejected_reply_excerpt": null,
+        "rejected_reply_sha256": null,
+        "requested_timeout_sec": 1800,
+        "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+        "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+        "returncode": 0,
+        "role": "census-execution",
+        "sequence": 2,
+        "session_ref": "capacity-fixture",
+        "stderr_excerpt": "",
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "usage": null,
+        "validation_issue": null,
+        "validation_pointer": null
+      },
+      {
+        "duration_ms": 11,
+        "engine": "codex",
+        "failure_detail_excerpt": "Selected model is at capacity",
+        "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+        "outcome": "failed",
+        "provider_duration_ms": null,
+        "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+        "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+        "rejected_reply_excerpt": null,
+        "rejected_reply_sha256": null,
+        "requested_timeout_sec": 1800,
+        "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+        "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+        "returncode": 0,
+        "role": "census-integrity",
+        "sequence": 3,
+        "session_ref": "capacity-fixture",
+        "stderr_excerpt": "",
+        "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+        "usage": null,
+        "validation_issue": null,
+        "validation_pointer": null
+      }
+    ],
+    "audit": {
+      "already_raised": [],
+      "attempt_ledger": [
+        {
+          "duration_ms": 12,
+          "engine": "codex",
+          "failure_detail_excerpt": "Selected model is at capacity",
+          "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+          "outcome": "failed",
+          "provider_duration_ms": null,
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+          "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+          "rejected_reply_excerpt": null,
+          "rejected_reply_sha256": null,
+          "requested_timeout_sec": 1800,
+          "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+          "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+          "returncode": 0,
+          "role": "census-behaviour",
+          "sequence": 1,
+          "session_ref": "capacity-fixture",
+          "stderr_excerpt": "",
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "usage": null,
+          "validation_issue": null,
+          "validation_pointer": null
+        },
+        {
+          "duration_ms": 12,
+          "engine": "codex",
+          "failure_detail_excerpt": "Selected model is at capacity",
+          "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+          "outcome": "failed",
+          "provider_duration_ms": null,
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+          "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+          "rejected_reply_excerpt": null,
+          "rejected_reply_sha256": null,
+          "requested_timeout_sec": 1800,
+          "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+          "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+          "returncode": 0,
+          "role": "census-execution",
+          "sequence": 2,
+          "session_ref": "capacity-fixture",
+          "stderr_excerpt": "",
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "usage": null,
+          "validation_issue": null,
+          "validation_pointer": null
+        },
+        {
+          "duration_ms": 11,
+          "engine": "codex",
+          "failure_detail_excerpt": "Selected model is at capacity",
+          "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+          "outcome": "failed",
+          "provider_duration_ms": null,
+          "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+          "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+          "rejected_reply_excerpt": null,
+          "rejected_reply_sha256": null,
+          "requested_timeout_sec": 1800,
+          "response_excerpt": "[paranoia-local error] codex exited 0: Selected model is at capacity",
+          "response_sha256": "3b4f2ba19b1a9cb431cff474e8dec5aee0fd7d037dcc0274a7357d43c31f43c9",
+          "returncode": 0,
+          "role": "census-integrity",
+          "sequence": 3,
+          "session_ref": "capacity-fixture",
+          "stderr_excerpt": "",
+          "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+          "usage": null,
+          "validation_issue": null,
+          "validation_pointer": null
+        }
+      ],
+      "base_id": "7777b559da2609b30352268b2ab590db97676db3",
+      "correction_gates": [],
+      "duration_ms": null,
+      "engine": "codex",
+      "error": true,
+      "failure_detail_excerpt": "",
+      "failure_detail_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "head_id": "5af2a35fc8ed809b42ec26f399f9a67c445f7a7a",
+      "lineage": "staged-provider-failure-acceptance",
+      "mode": "converge-packet",
+      "model": "gpt-5.6-sol",
+      "plan_contract_reused": false,
+      "plan_digest": null,
+      "plan_digest_assertion": null,
+      "plan_path": null,
+      "plan_text": null,
+      "raw_excerpt": "Selected model is at capacity",
+      "raw_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+      "rejected_payloads": [],
+      "rendered_trailer": "LINEAGE: staged-provider-failure-acceptance (rounds recorded: 0)\nCLASS-REGISTER: engine failed (provider): Selected model is at capacity\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nSTRUCTURAL-PHASE: census\nSTRUCTURAL-DEBT: 0 blocking open\nSTRUCTURAL-ERROR: Selected model is at capacity\nSTRUCTURAL-FAILURE: role=census-behaviour kind=provider\nCONVERGENCE: BLOCKED — staged provider failure did not settle.\nSTAGED-ATTEMPTS: total=3 validation-retries=0 validation-invalid=0 execution-failed=3",
+      "retry_register": null,
+      "returncode": 2,
+      "round": 1,
+      "session_ref": null,
+      "staged_manifests": [],
+      "staged_settlement": null,
+      "stderr_excerpt": "",
+      "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855",
+      "structural_snapshot": "2566ad5db75c5ab23a785d98e0a3a30fbdde260e1ed97316069c7702f012e697",
+      "target": "committed diff main...HEAD in paranoia-local-staged-failure-taxonomy",
+      "text": "# STAGED REVIEW FAILED\n\nThe staged structural review did not complete settlement. No durable structural verdict is available.\n\n## Diagnostic\n\n    [paranoia-local error] staged engine failed (provider): Selected model is at capacity",
+      "timestamp": "20260824T150405",
+      "tool": "critique_branch",
+      "usage": null
+    },
+    "durable_lineage": {
+      "claim_reverify_required": false,
+      "claim_state": {},
+      "classes": [],
+      "debt": null,
+      "exemptions": [],
+      "mode": "branch",
+      "next_seq": 1,
+      "review_state": {
+        "debt": [],
+        "phase": "census",
+        "snapshot_digest": "2566ad5db75c5ab23a785d98e0a3a30fbdde260e1ed97316069c7702f012e697",
+        "staged_failure": {
+          "engine_failure": {
+            "failure_detail_excerpt": "Selected model is at capacity",
+            "failure_detail_sha256": "1cf0c9eff159c2d19fcae2037e6aa2853ad6f54bb6e9cfa5589c9fab66b0582a",
+            "raw_excerpt": "{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}\n{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}\n",
+            "raw_sha256": "e6d7fee3625d8cf13f40b8884338c076868f5ce254f6e1083988728a6ddd7f5f",
+            "returncode": 0,
+            "stderr_excerpt": "",
+            "stderr_sha256": "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+          },
+          "kind": "provider",
+          "message": "Selected model is at capacity",
+          "role": "census-behaviour"
+        },
+        "stakes": "One trusted operator and OS; repository and plan bytes are untrusted data; no hostile local race or repository execution; one class and one claim-free plan; false clearance is high impact and recoverable blocking is acceptable.",
+        "stakes_digest": "241252a03212adae7708447f4c05289e76185a7eb363b024b25d3f101dd78fea",
+        "version": 1
+      },
+      "rounds": 0
+    },
+    "rendered_trailer": "LINEAGE: staged-provider-failure-acceptance (rounds recorded: 0)\nCLASS-REGISTER: engine failed (provider): Selected model is at capacity\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nSTRUCTURAL-PHASE: census\nSTRUCTURAL-DEBT: 0 blocking open\nSTRUCTURAL-ERROR: Selected model is at capacity\nSTRUCTURAL-FAILURE: role=census-behaviour kind=provider\nCONVERGENCE: BLOCKED — staged provider failure did not settle.\nSTAGED-ATTEMPTS: total=3 validation-retries=0 validation-invalid=0 execution-failed=3",
+    "result_sha256": "41296a0c411d73fa2252b696bcf5080741126808820b7abd7f043d699e54ef6e",
+    "result_text": "⚠️ REVIEW FAILED (engine=codex, exit=2) — treat the output below as an error, not a completed review.\n\n# STAGED REVIEW FAILED\n\nThe staged structural review did not complete settlement. No durable structural verdict is available.\n\n## Diagnostic\n\n    [paranoia-local error] staged engine failed (provider): Selected model is at capacity\n\n---\n_paranoia-local · engine=codex_\n\nLINEAGE: staged-provider-failure-acceptance (rounds recorded: 0)\nCLASS-REGISTER: engine failed (provider): Selected model is at capacity\nCLASS-CLOSURE: 0 open, 0 closed, 0 surviving matches, 0 exempt, 0 unmechanized\nSTRUCTURAL-PHASE: census\nSTRUCTURAL-DEBT: 0 blocking open\nSTRUCTURAL-ERROR: Selected model is at capacity\nSTRUCTURAL-FAILURE: role=census-behaviour kind=provider\nCONVERGENCE: BLOCKED — staged provider failure did not settle.\nSTAGED-ATTEMPTS: total=3 validation-retries=0 validation-invalid=0 execution-failed=3"
+  },
   "rendered_trailer": "LINEAGE: persistent-correction-gate-acceptance-20260823 (rounds recorded: 7)\nCLASS-REGISTER: staged correction parsed — CLOSE gate-class\nCLASS-CLOSURE: 0 open, 1 closed, 0 surviving matches, 0 exempt, 1 unmechanized\nSTRUCTURAL-PHASE: final\nSTRUCTURAL-DEBT: 0 blocking open\nCORRECTION-GATE: gate-class reason=persistence span=7 reopen-count=0 — load-bearing this round\nFINAL-REGRESSION: required\nCONVERGENCE: BLOCKED — cold final regression is required.\nSTAGED-ATTEMPTS: total=1 validation-retries=0 validation-invalid=0 execution-failed=0",
-  "result_sha256": "e36bc9516d1206d1d39537ef132bc556555c8e85839b5884171e5a8e35890283",
-  "result_text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\nNothing notable.\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\nNothing notable.\n\n---\n_paranoia-local · engine=codex · session_ref=`01a02f72-8a49-7a70-9376-75c25f8b9d85` — to dispute a finding, call `rebut` with this session_ref and your counter-evidence._\n\nLINEAGE: persistent-correction-gate-acceptance-20260823 (rounds recorded: 7)\nCLASS-REGISTER: staged correction parsed — CLOSE gate-class\nCLASS-CLOSURE: 0 open, 1 closed, 0 surviving matches, 0 exempt, 1 unmechanized\nSTRUCTURAL-PHASE: final\nSTRUCTURAL-DEBT: 0 blocking open\nCORRECTION-GATE: gate-class reason=persistence span=7 reopen-count=0 — load-bearing this round\nFINAL-REGRESSION: required\nCONVERGENCE: BLOCKED — cold final regression is required.\nSTAGED-ATTEMPTS: total=1 validation-retries=0 validation-invalid=0 execution-failed=0",
-  "source_revision": "1fddd33d1a4d9d1d513d34cbbef626198cdc5e03",
+  "result_sha256": "1c4fca4e9e8486cd63db89088f495ed8d20ed6240c613f71046f1b680620da40",
+  "result_text": "## What works\n\nNothing notable.\n\n## What doesn't work\n\nNothing notable.\n\n## Risks\n\nNothing notable.\n\n## Gaps\n\nNothing notable.\n\n## Improvements\n\nNothing notable.\n\n---\n_paranoia-local · engine=codex · session_ref=`01a03414-da03-7303-b13d-9c6236eb6f5f` — to dispute a finding, call `rebut` with this session_ref and your counter-evidence._\n\nLINEAGE: persistent-correction-gate-acceptance-20260823 (rounds recorded: 7)\nCLASS-REGISTER: staged correction parsed — CLOSE gate-class\nCLASS-CLOSURE: 0 open, 1 closed, 0 surviving matches, 0 exempt, 1 unmechanized\nSTRUCTURAL-PHASE: final\nSTRUCTURAL-DEBT: 0 blocking open\nCORRECTION-GATE: gate-class reason=persistence span=7 reopen-count=0 — load-bearing this round\nFINAL-REGRESSION: required\nCONVERGENCE: BLOCKED — cold final regression is required.\nSTAGED-ATTEMPTS: total=1 validation-retries=0 validation-invalid=0 execution-failed=0",
+  "source_revision": "5af2a35fc8ed809b42ec26f399f9a67c445f7a7a",
   "source_sha256": {
     "AGENTS.md": "6ae2038717c507a4ee5fd985edb2c19db28aa2d8de40f77950ee27acf8840de2",
-    "README.md": "2d7882b6fc8d90653c8dbe8d634196a4477817e0d6883317d49229ecec3a7b10",
-    "scripts/run_persistent_correction_gate_acceptance.py": "1482849a2bf4715fc84923791451f85d27dc6e521ed945e56388fa0c912bd4d9",
-    "src/paranoia_local/handlers.py": "f240165ea9a02fddb117cfaf0d722839e3fe022a75139feb10d4c52bab08f814",
+    "docs/how-it-works.md": "b7183ca3135c199bf8eef09cdc6fe5a623ebf90de3a8aafb1d080379ada7f6fb",
+    "scripts/run_persistent_correction_gate_acceptance.py": "6a288658be87ce599948e1fb11861ab90e361e1b5a4112b1e8051e1cfbfbe3c3",
+    "src/paranoia_local/handlers.py": "adff845658817d8c0a93fef736c1f412edb2612c16a20d7cc22da62d031eab62",
     "src/paranoia_local/prompts.py": "9f14214af5c21c61cad0b195c37ddd589730d0aaa218bf7cd70bfa28508c9490",
     "src/paranoia_local/review_census.py": "5bf5cf939d52fe358bf5f77045b3336188e81ee3d138187a006bb7e2b2da9ea7",
     "src/paranoia_local/server.py": "47d813cc9ffc356e7efdad4cb08e06c70ae515f07aec585858907657eb00996f",
     "tests/test_handlers.py": "8a7dc6aba3bb10789ac6c6e170ab9d5784bf1d183e24793868a5291ba15bb2f1",
     "tests/test_plan_claims.py": "7756961aeed1f11e3ffb864b137dbe0f7ca33eeb2164a07a1d0b7e53df9f5db2",
     "tests/test_plan_class_closure.py": "ccd1df2a080b74b69f40f85adb0e6ef9d411a688eb7fec4c71bff9f66ed7e76b",
-    "tests/test_review_census.py": "df9145fe2dabaffd03393c94c14040e14ffed64bdbd941079e34cca6bb8bf034"
+    "tests/test_review_census.py": "146967f7ba1ab4b969d87b390e7bfd7e5a87a89e341c0ae94edd1e44e0768a27"
   },
-  "version": 1
+  "version": 2
 }

--- a/scripts/run_persistent_correction_gate_acceptance.py
+++ b/scripts/run_persistent_correction_gate_acceptance.py
@@ -184,7 +184,7 @@ def _replay_terminal_lineage(before: dict, audit: dict) -> tuple[dict, str]:
     if session is not None:
         state["correction_control"]["classes"][CLASS_ID]["last_session_ref"] = session
     lineage = cc._from_json(LINEAGE, deepcopy(expected))
-    status = f"staged rejected: {rc.trailer_diagnostic(message)}"
+    status = f"staged rejected (validation): {rc.trailer_diagnostic(message)}"
     trailer = "\n".join((
         cc.render_trailer(lineage, register_status=status, include_verdict=False),
         rc.trailer(
@@ -208,7 +208,7 @@ def _public_result(*, audit: dict, settlement: dict | None, after: dict, trailer
     else:
         message = audit["raw_excerpt"]
         text = rc.render_error_review(
-            f"[paranoia-local error] staged review rejected: {message}"
+            f"[paranoia-local error] staged review rejected (validation): {message}"
         )
         review = engines.Review(
             text=text, session_ref=None, raw=message, returncode=2, error=True,
@@ -322,6 +322,53 @@ def _preflight_matrix(root: Path) -> list[dict]:
     return rows
 
 
+def _provider_failure_route(root: Path) -> dict:
+    """Exercise a provider failure through public critique_branch and a real process."""
+    runtime = Path(tempfile.mkdtemp(prefix="paranoia-provider-failure-"))
+    state_root = runtime / "state"
+    log_root = runtime / "logs"
+    fake = runtime / "codex"
+    fake.write_text(
+        "#!/bin/sh\n"
+        "if [ \"$1\" = \"--version\" ]; then echo 'codex-cli 0.144.6'; exit 0; fi\n"
+        "cat >/dev/null\n"
+        "printf '%s\\n' '{\"type\":\"thread.started\",\"thread_id\":\"capacity-fixture\"}'\n"
+        "printf '%s\\n' '{\"type\":\"turn.failed\",\"error\":{\"message\":\"Selected model is at capacity\"}}'\n",
+        encoding="utf-8",
+    )
+    fake.chmod(0o755)
+    previous = os.environ.get(cc.STATE_ROOT_ENV)
+    os.environ[cc.STATE_ROOT_ENV] = str(state_root)
+    engine = engines.CodexEngine()
+    engine.binary = str(fake)
+    try:
+        result = handlers.critique_branch({
+            "repo_path":str(root), "base_ref":"main", "head_ref":"HEAD",
+            "lineage":"staged-provider-failure-acceptance", "round":1,
+            "class_closure":True, "converge":True, "stakes":STAKES,
+            "model":"gpt-5.6-sol", "effort":"high", "web_search":False,
+        }, engine=engine, log_dir=log_root)
+    finally:
+        if previous is None:
+            os.environ.pop(cc.STATE_ROOT_ENV, None)
+        else:
+            os.environ[cc.STATE_ROOT_ENV] = previous
+    audits = list(log_root.glob("*.json"))
+    if len(audits) != 1:
+        raise RuntimeError(f"expected one provider-failure audit, got {len(audits)}")
+    audit = _state(audits[0])
+    lineage = cc.load_lineage(
+        state_root, "staged-provider-failure-acceptance",
+        stamp="provider-failure-reload", mode=cc.BRANCH_MODE,
+    )
+    return {
+        "result_text":result, "result_sha256":_sha(result),
+        "rendered_trailer":audit.get("rendered_trailer"), "audit":audit,
+        "durable_lineage":cc._to_json(lineage),
+        "attempt_ledger":audit.get("attempt_ledger"),
+    }
+
+
 def validate_artifact(
     artifact: dict, root: Path = ROOT, *, require_committed: bool = True,
 ) -> None:
@@ -339,14 +386,14 @@ def validate_artifact(
         "attempt_ledger", "provider_call_count", "elapsed_seconds", "result_text",
         "result_sha256", "rendered_trailer", "correction_gates",
         "durable_reload_lineage",
-        "outcome", "public_preflight_matrix",
+        "outcome", "public_preflight_matrix", "public_provider_failure_route",
     }
     if set(artifact) != expected_keys:
         raise ValueError("acceptance fields are not closed and exact")
     if artifact["acceptance_kind"] != "persistent-correction-gate-public-plan-handler":
         raise ValueError("wrong acceptance kind")
     surfaces = {
-        "README.md": (
+        "docs/how-it-works.md": (
             "reset_round", "reopen_count", "last_session_ref", "CORRECTION-GATE",
             "correction_gates", "rendered_trailer", "validation-invalid terminal retry",
         ),
@@ -368,7 +415,7 @@ def validate_artifact(
     expected_sources = {
         "src/paranoia_local/handlers.py", "src/paranoia_local/review_census.py",
         "src/paranoia_local/prompts.py", "scripts/run_persistent_correction_gate_acceptance.py",
-        "src/paranoia_local/server.py", "README.md", "AGENTS.md",
+        "src/paranoia_local/server.py", "docs/how-it-works.md", "AGENTS.md",
         "tests/test_review_census.py", "tests/test_handlers.py",
         "tests/test_plan_class_closure.py", "tests/test_plan_claims.py",
     }
@@ -527,7 +574,8 @@ def validate_artifact(
     expected_text = (
         rc.render_review(settlement, after["review_state"])
         if settlement is not None else rc.render_error_review(
-            f"[paranoia-local error] staged review rejected: {audit['raw_excerpt']}"
+            "[paranoia-local error] staged review rejected (validation): "
+            f"{audit['raw_excerpt']}"
         )
     )
     if (
@@ -562,6 +610,46 @@ def validate_artifact(
         for row in matrix
     ):
         raise ValueError("strict-round preflight did work or mutated durable state")
+    failure_route = artifact["public_provider_failure_route"]
+    if set(failure_route) != {
+        "result_text", "result_sha256", "rendered_trailer", "audit",
+        "durable_lineage", "attempt_ledger",
+    }:
+        raise ValueError("provider-failure route fields are not closed and exact")
+    failure_result = failure_route["result_text"]
+    failure_trailer = failure_route["rendered_trailer"]
+    failure_audit = failure_route["audit"]
+    failure_state = failure_route["durable_lineage"]["review_state"]
+    failure_attempts = failure_route["attempt_ledger"]
+    if (
+        not isinstance(failure_result, str)
+        or failure_route["result_sha256"] != _sha(failure_result)
+        or not isinstance(failure_trailer, str)
+        or not failure_result.endswith(failure_trailer)
+        or failure_audit.get("tool") != "critique_branch"
+        or failure_audit.get("rendered_trailer") != failure_trailer
+        or failure_audit.get("error") is not True
+        or failure_state.get("staged_failure", {}).get("kind") != "provider"
+        or failure_state.get("staged_failure", {}).get("message")
+        != "Selected model is at capacity"
+        or failure_state.get("validation_debt") is not None
+        or not isinstance(failure_attempts, list) or not failure_attempts
+        or failure_audit.get("attempt_ledger") != failure_attempts
+        or any(
+            row.get("engine") != "codex" or row.get("returncode") != 0
+            or row.get("outcome") != "execution-failed"
+            or row.get("failure_detail_excerpt") != "Selected model is at capacity"
+            for row in failure_attempts
+        )
+        or "staged engine failed (provider): Selected model is at capacity"
+        not in failure_result
+        or "CLASS-REGISTER: engine failed (provider): Selected model is at capacity"
+        not in failure_trailer
+        or "STRUCTURAL-FAILURE:" not in failure_trailer
+        or "kind=provider" not in failure_trailer
+        or "CONVERGENCE: BLOCKED" not in failure_trailer
+    ):
+        raise ValueError("public provider-failure route is not exact and source-bound")
 
 
 def main() -> int:
@@ -625,13 +713,13 @@ def main() -> int:
     source_paths = [
         "src/paranoia_local/handlers.py", "src/paranoia_local/review_census.py",
         "src/paranoia_local/prompts.py", "scripts/run_persistent_correction_gate_acceptance.py",
-        "src/paranoia_local/server.py", "README.md", "AGENTS.md",
+        "src/paranoia_local/server.py", "docs/how-it-works.md", "AGENTS.md",
         "tests/test_review_census.py", "tests/test_handlers.py",
         "tests/test_plan_class_closure.py", "tests/test_plan_claims.py",
     ]
     artifact = {
         "acceptance_kind":"persistent-correction-gate-public-plan-handler",
-        "version":1, "date":"2026-08-23", "source_revision":revision,
+        "version":2, "date":"2026-08-24", "source_revision":revision,
         "source_sha256":{
             path:hashlib.sha256(_git_bytes("show", f"{revision}:{path}")).hexdigest()
             for path in source_paths
@@ -655,6 +743,7 @@ def main() -> int:
         "durable_reload_lineage":cc._to_json(durable),
         "outcome":"closed-or-replaced" if closed_or_replaced else "terminal-gate-rejection",
         "public_preflight_matrix":_preflight_matrix(ROOT),
+        "public_provider_failure_route":_provider_failure_route(ROOT),
     }
     validate_artifact(artifact, ROOT, require_committed=False)
     Path(args.output).write_text(

--- a/scripts/run_persistent_correction_gate_acceptance.py
+++ b/scripts/run_persistent_correction_gate_acceptance.py
@@ -637,7 +637,7 @@ def validate_artifact(
         or failure_audit.get("attempt_ledger") != failure_attempts
         or any(
             row.get("engine") != "codex" or row.get("returncode") != 0
-            or row.get("outcome") != "execution-failed"
+            or row.get("outcome") != "failed"
             or row.get("failure_detail_excerpt") != "Selected model is at capacity"
             for row in failure_attempts
         )

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -464,6 +464,27 @@ def _staged_class_trailer(closure: "_ClosureRound", status: str) -> str:
     )
 
 
+def _staged_failure_surface(error: rc.CensusError) -> tuple[str, str]:
+    """Keep the primary operator surface aligned with durable failure taxonomy."""
+    kind = getattr(error, "failure_kind", "unknown")
+    diagnostic = rc.trailer_diagnostic(error)
+    if kind in {
+        "timeout", "unavailable", "cancellation", "provider", "execution",
+    }:
+        headline = f"engine failed ({kind})"
+        body = f"staged engine failed ({kind})"
+    elif kind == "validation":
+        headline = "staged rejected (validation)"
+        body = "staged review rejected (validation)"
+    elif kind == "deadline":
+        headline = "staged blocked (deadline)"
+        body = "staged review blocked (deadline)"
+    else:
+        headline = f"staged failed ({kind})"
+        body = f"staged review failed ({kind})"
+    return f"{headline}: {diagnostic}", f"[paranoia-local error] {body}: {error}"
+
+
 def _staged_error(message: str, *, role: str, kind: str) -> rc.CensusError:
     error = rc.CensusError(message)
     error.stage_role = role  # type: ignore[attr-defined]
@@ -711,17 +732,19 @@ def _settle_staged_failure(
     closure.lineage.review_state = state
     closure.staged_manifests = getattr(error, "manifests", [])
     closure.rejected_payloads = deepcopy(rejected_payloads)
+    register_status, error_body = _staged_failure_surface(error)
     try:
         cc.save_lineage(closure.state_root, closure.lineage)
     except cc.StateUnavailable as exc:
         closure.unavailable = str(exc)
         message = f"lineage state unavailable after staged failure: {exc}"
         review = Review(
-            text=rc.render_error_review(f"[paranoia-local error] {message}"),
+            text=rc.render_error_review(f"{error_body}; {message}"),
             session_ref=None, raw=message, returncode=2, error=True,
         )
         trailer = (
-            "CLASS-REGISTER: staged rejected; failure state persistence unavailable\n"
+            f"CLASS-REGISTER: {register_status}; "
+            "failure state persistence unavailable\n"
             f"CLASS-CLOSURE: STATE-UNAVAILABLE — {exc}\n"
             f"{rc.attempt_trailer(getattr(error, 'attempts', []))}\n"
             "CONVERGENCE: BLOCKED — staged failure state may not have persisted."
@@ -730,14 +753,10 @@ def _settle_staged_failure(
             trailer = f"{pc.render_trailer(closure.lineage.claim_state)}\n{trailer}"
         return review, trailer, [a.json() for a in attempts]
     closure._settled = True
-    closure.register_status = (
-        f"staged rejected: {rc.trailer_diagnostic(error)}"
-    )
+    closure.register_status = register_status
     attempts = [a.json() for a in attempts]
     review = Review(
-        text=rc.render_error_review(
-            f"[paranoia-local error] staged review rejected: {error}"
-        ),
+        text=rc.render_error_review(error_body),
         session_ref=None, raw=str(error), returncode=2, error=True,
     )
     trailer = "\n".join((

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -1380,7 +1380,7 @@ def test_untrusted_failure_diagnostic_cannot_forge_review_or_trailer_structure(t
     error = rc.CensusError(message)
     error.stage_role = "consolidation"  # type: ignore[attr-defined]
     error.failure_kind = "provider"  # type: ignore[attr-defined]
-    _, combined, _ = handlers._settle_staged_failure(
+    review, combined, _ = handlers._settle_staged_failure(
         closure, stakes="s", snapshot="p", error=error, mode=cc.PLAN_MODE,
     )
     closure.release()
@@ -1388,8 +1388,30 @@ def test_untrusted_failure_diagnostic_cannot_forge_review_or_trailer_structure(t
         line for line in combined.splitlines()
         if line.startswith("CONVERGENCE:")
     ]) == 1
-    assert f"CLASS-REGISTER: staged rejected: {rc.trailer_diagnostic(message)}" in combined
+    assert (
+        f"CLASS-REGISTER: engine failed (provider): {rc.trailer_diagnostic(message)}"
+        in combined
+    )
+    assert "staged engine failed (provider)" in review.text
     assert closure.lineage.review_state["staged_failure"]["message"] == message
+
+
+@pytest.mark.parametrize(("kind", "headline", "body"), [
+    ("timeout", "engine failed (timeout)", "staged engine failed (timeout)"),
+    ("unavailable", "engine failed (unavailable)", "staged engine failed (unavailable)"),
+    ("cancellation", "engine failed (cancellation)", "staged engine failed (cancellation)"),
+    ("provider", "engine failed (provider)", "staged engine failed (provider)"),
+    ("execution", "engine failed (execution)", "staged engine failed (execution)"),
+    ("validation", "staged rejected (validation)", "staged review rejected (validation)"),
+    ("deadline", "staged blocked (deadline)", "staged review blocked (deadline)"),
+])
+def test_primary_staged_failure_surface_preserves_failure_kind(kind, headline, body):
+    error = handlers._staged_error("bounded detail", role="fixture", kind=kind)
+
+    status, rendered = handlers._staged_failure_surface(error)
+
+    assert status == f"{headline}: bounded detail"
+    assert rendered == f"[paranoia-local error] {body}: bounded detail"
 
 
 def test_trailer_surfaces_persistent_class_and_rebut_session() -> None:
@@ -1947,7 +1969,7 @@ def test_structural_pending_settles_zero_attempt_round_and_releases_latch(tmp_pa
     assert review.error and attempts == []
     assert review.text.startswith("# STAGED REVIEW FAILED")
     assert "## Diagnostic" in review.text
-    assert "CLASS-REGISTER: staged rejected: not enough bounded time" in trailer
+    assert "CLASS-REGISTER: staged blocked (deadline): not enough bounded time" in trailer
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
     assert "STRUCTURAL-ERROR: not enough bounded time" in trailer
     assert "STRUCTURAL-FAILURE: role=structural-reserve-preflight kind=deadline" in trailer
@@ -1989,7 +2011,8 @@ def test_staged_generic_failure_clears_old_cache_and_uses_matching_debt(tmp_path
     )
     closure.release()
     assert review.error and attempts == []
-    assert "CLASS-REGISTER: staged rejected: provider exited" in trailer
+    assert "CLASS-REGISTER: engine failed (execution): provider exited" in trailer
+    assert "staged engine failed (execution): provider exited" in review.text
     assert "CLASS-CLOSURE: 0 open, 0 closed" in trailer
     assert "STRUCTURAL-ERROR: provider exited" in trailer
     assert "STRUCTURAL-FAILURE: role=correction kind=execution" in trailer
@@ -2225,7 +2248,8 @@ def test_staged_format_debt_save_failure_also_retains_latch(tmp_path, monkeypatc
     assert review.error and attempts == []
     assert review.text.startswith("# STAGED REVIEW FAILED")
     assert "## Diagnostic" in review.text
-    assert "CLASS-REGISTER: staged rejected; failure state persistence unavailable" in trailer
+    assert "CLASS-REGISTER: staged rejected (validation): bad format; " \
+        "failure state persistence unavailable" in trailer
     assert "STATE-UNAVAILABLE" in trailer
     assert closure.rejected_payloads == error.rejected_payloads
     assert (cc.lineage_dir(tmp_path) / "format-save-fail.pending").exists()

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -73,6 +73,16 @@ def test_persistent_correction_gate_acceptance_is_source_and_route_bound() -> No
     assert 1 <= artifact["provider_call_count"] <= 2
     assert artifact["provider_call_count"] == len(artifact["attempt_ledger"])
     assert artifact["result_text"].endswith(artifact["rendered_trailer"])
+    failure_route = artifact["public_provider_failure_route"]
+    assert "staged engine failed (provider): Selected model is at capacity" in (
+        failure_route["result_text"]
+    )
+    assert "CLASS-REGISTER: engine failed (provider): Selected model is at capacity" in (
+        failure_route["rendered_trailer"]
+    )
+    assert failure_route["durable_lineage"]["review_state"]["staged_failure"][
+        "kind"
+    ] == "provider"
     assert artifact["audit"]["rendered_trailer"] == artifact["rendered_trailer"]
     assert artifact["audit"]["correction_gates"] == artifact["correction_gates"]
     assert artifact["durable_reload_lineage"] == artifact["after_lineage"]


### PR DESCRIPTION
## Summary
- render provider, timeout, unavailable, cancellation, and execution outcomes as engine failed with their exact kind
- render validation rejection and deadline blocking with distinct operator headlines in both the failure body and CLASS-REGISTER
- preserve the same durable structured failure state, bounded diagnostics, and settlement behavior
- fix the PR #70 baseline acceptance regression by binding correction-gate documentation to docs/how-it-works.md
- add a source-bound public critique_branch capacity-failure route through the real Codex subprocess engine

## Validation
- 1,355 tests passed with no exclusions
- fresh real Codex class-persistence acceptance completed
- fresh real Codex persistent-correction acceptance completed in one provider call
- deterministic subprocess capacity route preserves kind=provider, the failure-only body, durable state, and blocking trailer
- CODE paranoia-local Codex convergence: round 3 CONVERGENCE: NOT-BLOCKED

## Acceptance note
One initial class-persistence acceptance attempt did not complete and was not retained; its diagnostic retry completed without an intervening code change. The first regenerated correction-gate artifact was rejected by a new validator expectation using the wrong attempt label; that acceptance-only validator was corrected and the artifact regenerated against the corrected source revision.