### PR TITLE
Settle rebut concessions and phase plan classes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -525,6 +525,8 @@ class-bound rebut against the stored current session and exact open debt. Bound 
 closed CONCEDE/HOLD disposition: HOLD is audit-only; CONCEDE closes only the named debt and closes
 the class only when no sibling blocker remains. It never grants clearance. Preserve this state
 atomically with the lineage and store the exact returned trailer in plan and branch audit records.
+Mechanized branch classes remain owned by the canonical predicate sweep: refuse their bound rebut
+before provider spend and require `critique_branch` to decide closure.
 The durable row is exactly `reset_round`, `reopen_count`, and `last_session_ref`. Current-attempt
 session authority replaces stale authority even when it is null; a terminal gate bootstrap may
 use only the exact validation-invalid terminal retry and only for a previously sessionless row.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -521,17 +521,21 @@ real acceptance, tests, implementation convergence, or documented stakes remain 
 Persistent staged correction is a gate, not merely a trailer warning. After six unresolved
 caller-supplied round labels or three undisposed reopen waves, reject another correction that
 leaves the same class canonically blocking. Admit only a canonical close/replacement or a durable
-class-bound rebut reset against the stored current session. Rebut resets never change verdict,
-debt, or severity. Preserve this control state atomically with the lineage and store the exact
-returned trailer in plan and branch audit records.
+class-bound rebut against the stored current session and exact open debt. Bound rebut output is a
+closed CONCEDE/HOLD disposition: HOLD is audit-only; CONCEDE closes only the named debt and closes
+the class only when no sibling blocker remains. It never grants clearance. Preserve this state
+atomically with the lineage and store the exact returned trailer in plan and branch audit records.
 The durable row is exactly `reset_round`, `reopen_count`, and `last_session_ref`. Current-attempt
 session authority replaces stale authority even when it is null; a terminal gate bootstrap may
 use only the exact validation-invalid terminal retry and only for a previously sessionless row.
 Clear session authority when a class becomes closed or advisory, and accept a bound rebut only for
-a currently blocking class. Repeated/backward caller labels refuse before provider, cache, snapshot,
+a currently blocking class in correction phase whose named open debt binds only that class. Refuse
+settlement while staged/format/validation failure or an unbound blocker exists. Repeated/backward caller labels refuse before provider, cache, snapshot,
 or worktree work, returning a zero-attempt blocked review whose exact trailer is audited; forward
-jumps count and failed labels may retry. Provider/validation failure does
-not advance substantive state, and ambiguous lineage or rebut saves retain the pending latch.
+jumps count and failed labels may retry. Provider/validation failure does not advance substantive
+state, and ambiguous lineage or rebut saves retain the pending latch. The rebut audit retains the
+complete prior target debt row separately while current closed-debt evidence records the concession
+citations.
 Keep `rendered_trailer` as the exact returned suffix and `correction_gates` as its ordered pre-call
 server-owned audit projection.
 Bind bounded attempt-channel digests and exact retained response evidence to the acceptance

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -538,6 +538,8 @@ jumps count and failed labels may retry. Provider/validation failure does not ad
 state, and ambiguous lineage or rebut saves retain the pending latch. The rebut audit retains the
 complete prior target debt row separately while current closed-debt evidence records the concession
 citations.
+Persist the reviewed plan line count in staged plan state and resolve repeated plan rebut anchors
+against that bound; absence of a trustworthy bound refuses plan-anchor settlement.
 Keep `rendered_trailer` as the exact returned suffix and `correction_gates` as its ordered pre-call
 server-owned audit projection.
 Bind bounded attempt-channel digests and exact retained response evidence to the acceptance

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ The unbound form is non-mutating. For a persistently gated class, optional
 to one current durable target. `HOLD` is audit-only. A validated `CONCEDE`
 closes that debt and closes its class only when no sibling blocker remains; it
 never grants clearance, and the next critique still performs the normal final.
+Mechanized branch classes remain predicate-owned and must be closed by a normal
+`critique_branch` sweep rather than a bound rebut.
 
 ### Arbitrate a decision
 

--- a/README.md
+++ b/README.md
@@ -209,6 +209,8 @@ The unbound form is non-mutating. For a persistently gated class, optional
 to one current durable target. `HOLD` is audit-only. A validated `CONCEDE`
 closes that debt and closes its class only when no sibling blocker remains; it
 never grants clearance, and the next critique still performs the normal final.
+Bound citations use the staged anchor grammar and must resolve before settlement;
+tracked plan reviews retain their line count so repeated `plan:` anchors remain bounded.
 Mechanized branch classes remain predicate-owned and must be closed by a normal
 `critique_branch` sweep rather than a bound rebut.
 

--- a/README.md
+++ b/README.md
@@ -204,9 +204,11 @@ counter-evidence:
 ```
 
 The same reviewer session responds `CONCEDE` or `HOLD` with fresh citations.
-For a persistently gated class, optional `lineage`, `class_id`, and
-`lineage_mode` arguments can reset its bounded correction window after a
-successful rebuttal. They do not close debt or grant clearance.
+The unbound form is non-mutating. For a persistently gated class, optional
+`lineage`, `class_id`, `debt_id`, and `lineage_mode` arguments bind the result
+to one current durable target. `HOLD` is audit-only. A validated `CONCEDE`
+closes that debt and closes its class only when no sibling blocker remains; it
+never grants clearance, and the next critique still performs the normal final.
 
 ### Arbitrate a decision
 

--- a/docs/arbitration_consequence_acceptance_2026-08-22.json
+++ b/docs/arbitration_consequence_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and consequence framing are unchanged.",
-      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
     }
   },
   "audit": {

--- a/docs/arbitration_consequence_acceptance_2026-08-22.json
+++ b/docs/arbitration_consequence_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and consequence framing are unchanged.",
-      "sha256": "11a70da28bb040cda5e77f182bb0e0e43e24f82c8a72e33ebed2875d3979cc31"
+      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
     }
   },
   "audit": {

--- a/docs/arbitration_consequence_acceptance_2026-08-22.json
+++ b/docs/arbitration_consequence_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and consequence framing are unchanged.",
-      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
+      "sha256": "f8af0227fa44727a774a5f413c51a013ffbde316641a5a08ee663cf61b0eee4a"
     }
   },
   "audit": {

--- a/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and context-steering rejection are unchanged.",
-      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
     }
   },
   "audit": {

--- a/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and context-steering rejection are unchanged.",
-      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
+      "sha256": "f8af0227fa44727a774a5f413c51a013ffbde316641a5a08ee663cf61b0eee4a"
     }
   },
   "audit": {

--- a/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_context_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and context-steering rejection are unchanged.",
-      "sha256": "11a70da28bb040cda5e77f182bb0e0e43e24f82c8a72e33ebed2875d3979cc31"
+      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
     }
   },
   "audit": {

--- a/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and stakes-steering rejection are unchanged.",
-      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
+      "sha256": "f8af0227fa44727a774a5f413c51a013ffbde316641a5a08ee663cf61b0eee4a"
     }
   },
   "audit": {

--- a/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and stakes-steering rejection are unchanged.",
-      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
     }
   },
   "audit": {

--- a/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
+++ b/docs/arbitration_steering_rejection_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/prompts.py": {
       "scope": "Shared staged-review co-asserting-site and class-occurrence aggregation guidance; arbitration prompts and stakes-steering rejection are unchanged.",
-      "sha256": "11a70da28bb040cda5e77f182bb0e0e43e24f82c8a72e33ebed2875d3979cc31"
+      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
     }
   },
   "audit": {

--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -103,7 +103,7 @@
     "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
     "source_commit": "20464241b5838dbac30f2df5c44897b1e7075f2e",
     "allowed_later_handlers_diff": {
-      "sha256": "d1d8799bd783705824e61545785fb5efeeb749b0eba59bfdd0f7773b63b2bbef",
+      "sha256": "c76647c1bb700f75daeecaa38645f77525f7683c5c99d25f8ae5a202f66f02c1",
       "additions": 1813,
       "deletions": 175,
       "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, operator-facing failure taxonomy, plan-only closure-candidate correction, closed shared staged-state validation, bounded evidence-bound mechanized-class registration, exact mode/gate inputs to server-authored class-action guidance, server-owned evidence-phase labels, aggregate capture/pre-binding deadline classification, field-bounded capture-group retrieval debt with identity hashes, and ordered terminal retry diagnostics through this revision; does not alter capture, binding, cold-attestation success behavior, prompt-size, or source-admission semantics proved by this record."

--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -103,14 +103,14 @@
     "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
     "source_commit": "20464241b5838dbac30f2df5c44897b1e7075f2e",
     "allowed_later_handlers_diff": {
-      "sha256": "a72e7d73cd1500231f82b5ee4cbed2ac03ef0d4d44545b44969fb92e5d08a4b2",
-      "additions": 1623,
-      "deletions": 166,
+      "sha256": "32b77f94bda37ff893ad0229ac4b70c845944c13abd7c820fc6439c19dbadc82",
+      "additions": 1760,
+      "deletions": 175,
       "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, operator-facing failure taxonomy, plan-only closure-candidate correction, closed shared staged-state validation, bounded evidence-bound mechanized-class registration, exact mode/gate inputs to server-authored class-action guidance, server-owned evidence-phase labels, aggregate capture/pre-binding deadline classification, field-bounded capture-group retrieval debt with identity hashes, and ordered terminal retry diagnostics through this revision; does not alter capture, binding, cold-attestation success behavior, prompt-size, or source-admission semantics proved by this record."
     },
     "allowed_later_review_census_diff": {
-      "sha256": "165fcba5baa53a2ce84c1f5f566cd289bb7d72b261a1b183b1cd0ec5598b2821",
-      "additions": 482,
+      "sha256": "8db97530d9c015d3e2ffe337ba86a57ed83cb928c88e092fef6e6ede80c06b48",
+      "additions": 550,
       "deletions": 12,
       "scope": "Adds requested timeout, separate provider duration, diagnostic class persistence/reopen rendering, the plan-correction blocking-unit classifier, one closed staged-state validator, and a shared parser for already-accepted evidence coordinates; does not alter capture, binding, cold-attestation, prompt-size, or source-admission semantics."
     },

--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -103,14 +103,14 @@
     "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
     "source_commit": "20464241b5838dbac30f2df5c44897b1e7075f2e",
     "allowed_later_handlers_diff": {
-      "sha256": "32b77f94bda37ff893ad0229ac4b70c845944c13abd7c820fc6439c19dbadc82",
-      "additions": 1760,
+      "sha256": "60df8ea5fbb701027fc353335442ba3aad208df116f70f70ce20c0903b263739",
+      "additions": 1804,
       "deletions": 175,
       "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, operator-facing failure taxonomy, plan-only closure-candidate correction, closed shared staged-state validation, bounded evidence-bound mechanized-class registration, exact mode/gate inputs to server-authored class-action guidance, server-owned evidence-phase labels, aggregate capture/pre-binding deadline classification, field-bounded capture-group retrieval debt with identity hashes, and ordered terminal retry diagnostics through this revision; does not alter capture, binding, cold-attestation success behavior, prompt-size, or source-admission semantics proved by this record."
     },
     "allowed_later_review_census_diff": {
-      "sha256": "8db97530d9c015d3e2ffe337ba86a57ed83cb928c88e092fef6e6ede80c06b48",
-      "additions": 550,
+      "sha256": "fb79470b9c0d228255f090791945d5a8bd6f921c383066c648c86c9b837fd7ee",
+      "additions": 555,
       "deletions": 12,
       "scope": "Adds requested timeout, separate provider duration, diagnostic class persistence/reopen rendering, the plan-correction blocking-unit classifier, one closed staged-state validator, and a shared parser for already-accepted evidence coordinates; does not alter capture, binding, cold-attestation, prompt-size, or source-admission semantics."
     },

--- a/docs/authoritative_capture_acceptance_2026-08-20.json
+++ b/docs/authoritative_capture_acceptance_2026-08-20.json
@@ -103,14 +103,14 @@
     "base_commit": "18fb074e3066e91602b99931e58da41f99cee06e",
     "source_commit": "20464241b5838dbac30f2df5c44897b1e7075f2e",
     "allowed_later_handlers_diff": {
-      "sha256": "60df8ea5fbb701027fc353335442ba3aad208df116f70f70ce20c0903b263739",
-      "additions": 1804,
+      "sha256": "d1d8799bd783705824e61545785fb5efeeb749b0eba59bfdd0f7773b63b2bbef",
+      "additions": 1813,
       "deletions": 175,
       "scope": "Plan structural protocol, correction-control, exact audit-trailer, branch plan-contract, operator-facing failure taxonomy, plan-only closure-candidate correction, closed shared staged-state validation, bounded evidence-bound mechanized-class registration, exact mode/gate inputs to server-authored class-action guidance, server-owned evidence-phase labels, aggregate capture/pre-binding deadline classification, field-bounded capture-group retrieval debt with identity hashes, and ordered terminal retry diagnostics through this revision; does not alter capture, binding, cold-attestation success behavior, prompt-size, or source-admission semantics proved by this record."
     },
     "allowed_later_review_census_diff": {
-      "sha256": "fb79470b9c0d228255f090791945d5a8bd6f921c383066c648c86c9b837fd7ee",
-      "additions": 555,
+      "sha256": "b7fdcf91dcc4e0e7f9be2bccf3b258841a94f8fb9398efcf3a4d230ef4503109",
+      "additions": 559,
       "deletions": 12,
       "scope": "Adds requested timeout, separate provider duration, diagnostic class persistence/reopen rendering, the plan-correction blocking-unit classifier, one closed staged-state validator, and a shared parser for already-accepted evidence coordinates; does not alter capture, binding, cold-attestation, prompt-size, or source-admission semantics."
     },

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -11,7 +11,7 @@
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
+      "sha256": "f8af0227fa44727a774a5f413c51a013ffbde316641a5a08ee663cf61b0eee4a"
     },
     "src/paranoia_local/server.py": {
       "scope": "The public rebut schema now requires an exact debt target for bound settlement; this does not alter branch plan-contract binding, authority, capture, or propagation.",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -7,11 +7,15 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Operator-facing staged failure taxonomy and plan-only closure-candidate correction, plus closed shared staged-state validation, bounded evidence-bound mechanized-class registration, source-local/aggregate capture claim failure classification, ordered terminal claim-attempt projection, and exact mode/gate inputs to server-authored action guidance through this revision; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "595616b7a2a8b99c79758b8227ae8d3af4e9509d241fa57d02843e0d0c9e7d83"
+      "sha256": "e093f4bbce55fb815b3078e0f67cff73b854d21c2811387067ed94202f3b735f"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "11a70da28bb040cda5e77f182bb0e0e43e24f82c8a72e33ebed2875d3979cc31"
+      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+    },
+    "src/paranoia_local/server.py": {
+      "scope": "The public rebut schema now requires an exact debt target for bound settlement; this does not alter branch plan-contract binding, authority, capture, or propagation.",
+      "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"
     },
     "src/paranoia_local/staged_protocol.py": {
       "scope": "Server-authored class-action guidance and correction-only aggregate-occurrence reconciliation changed; this does not alter branch plan-contract binding, authority, capture, or propagation, and the retained fidelity routes do not contain a fresh existing-class correction finding.",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -7,7 +7,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Operator-facing staged failure taxonomy and plan-only closure-candidate correction, plus closed shared staged-state validation, bounded evidence-bound mechanized-class registration, source-local/aggregate capture claim failure classification, ordered terminal claim-attempt projection, and exact mode/gate inputs to server-authored action guidance through this revision; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "4f3ddc540e34b59f78d52254fabe40678746619c8d0a934c90074f97d2a80dab"
+      "sha256": "1c3f9162aac93684915faa0a505e1ec621a8a2958341500286b351c224dfc36b"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -7,7 +7,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Operator-facing staged failure taxonomy and plan-only closure-candidate correction, plus closed shared staged-state validation, bounded evidence-bound mechanized-class registration, source-local/aggregate capture claim failure classification, ordered terminal claim-attempt projection, and exact mode/gate inputs to server-authored action guidance through this revision; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "dc86e9a78da76243a1e10b132e06494c6d18800a261e9b1aba464635708dae36"
+      "sha256": "cee67efafed4d844792b7ab24e8fa4b497f89d26daf0eeb861f4e89d2f322f3a"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -7,7 +7,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Operator-facing staged failure taxonomy and plan-only closure-candidate correction, plus closed shared staged-state validation, bounded evidence-bound mechanized-class registration, source-local/aggregate capture claim failure classification, ordered terminal claim-attempt projection, and exact mode/gate inputs to server-authored action guidance through this revision; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "1c3f9162aac93684915faa0a505e1ec621a8a2958341500286b351c224dfc36b"
+      "sha256": "dc86e9a78da76243a1e10b132e06494c6d18800a261e9b1aba464635708dae36"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",

--- a/docs/branch_plan_fidelity_acceptance_2026-08-22.json
+++ b/docs/branch_plan_fidelity_acceptance_2026-08-22.json
@@ -7,15 +7,15 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Operator-facing staged failure taxonomy and plan-only closure-candidate correction, plus closed shared staged-state validation, bounded evidence-bound mechanized-class registration, source-local/aggregate capture claim failure classification, ordered terminal claim-attempt projection, and exact mode/gate inputs to server-authored action guidance through this revision; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "e093f4bbce55fb815b3078e0f67cff73b854d21c2811387067ed94202f3b735f"
+      "sha256": "4f3ddc540e34b59f78d52254fabe40678746619c8d0a934c90074f97d2a80dab"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
     },
     "src/paranoia_local/server.py": {
       "scope": "The public rebut schema now requires an exact debt target for bound settlement; this does not alter branch plan-contract binding, authority, capture, or propagation.",
-      "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"
+      "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"
     },
     "src/paranoia_local/staged_protocol.py": {
       "scope": "Server-authored class-action guidance and correction-only aggregate-occurrence reconciliation changed; this does not alter branch plan-contract binding, authority, capture, or propagation, and the retained fidelity routes do not contain a fresh existing-class correction finding.",

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -6,7 +6,7 @@
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
     "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "8e2e2fc54a1fcb69e2eb8463510fa03fd06bf791d3be7030a03d4837e344fde6"}
   },
   "version": 1,
   "date": "2026-08-30",

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -2,7 +2,7 @@
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
   "allowed_later_source_diffs": {
     "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "2c6b287ae547a45c862567bf004d0d12a53cb617e70255f83cc43f0d4e250214"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
     "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -2,11 +2,11 @@
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
   "allowed_later_source_diffs": {
     "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "ccc480bae6bddc74d4799e70c406af022c3e529ce0189379502b049d372836bd"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
-    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
     "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}
   },
   "version": 1,
   "date": "2026-08-30",

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -2,7 +2,7 @@
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
   "allowed_later_source_diffs": {
     "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "ccc480bae6bddc74d4799e70c406af022c3e529ce0189379502b049d372836bd"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
     "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
-    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "a5898079e1ca3c06839d2765685d70b1055210a9c53bc9691b4e4d772fc1112a"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
     "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},
     "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -2,11 +2,11 @@
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
   "allowed_later_source_diffs": {
     "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
-    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
-    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},
-    "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "aa41739ced35a2926f493a2039ed28bc2f27814b61aee3f729a9a8586dfdef33"}
+    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "a5898079e1ca3c06839d2765685d70b1055210a9c53bc9691b4e4d772fc1112a"},
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
+    "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"},
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}
   },
   "version": 1,
   "date": "2026-08-30",

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -1,7 +1,7 @@
 {
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
   "allowed_later_source_diffs": {
-    "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "86474d04857544d6d27314ff36182a68bd076c446a3e7a5ec9b2c14e9c9cd93c"},
+    "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "d07453bc04f33ceb34ff0acc62533a5557f642add3dac7350db6862d48d0b36c"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},

--- a/docs/class_occurrence_batch_acceptance_2026-08-30.json
+++ b/docs/class_occurrence_batch_acceptance_2026-08-30.json
@@ -1,5 +1,13 @@
 {
   "acceptance_kind": "class-occurrence-batch-public-branch-handler-v1",
+  "allowed_later_source_diffs": {
+    "scripts/run_class_occurrence_batch_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "86474d04857544d6d27314ff36182a68bd076c446a3e7a5ec9b2c14e9c9cd93c"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-only phase projection and debt-targeted rebut settlement; branch occurrence aggregation is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; branch occurrence aggregation instructions are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and trailer guidance; branch occurrence materialization is unchanged.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},
+    "src/paranoia_local/server.py": {"scope": "Public bound-rebut debt identity; branch occurrence handling is unchanged.", "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"},
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "aa41739ced35a2926f493a2039ed28bc2f27814b61aee3f729a9a8586dfdef33"}
+  },
   "version": 1,
   "date": "2026-08-30",
   "source_revision": "60fd22a9f78b01763d487b5898300143e9a92899",

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence source-local and aggregate capture failure-phase classification, completed-capture metadata, and ordered terminal claim-debt attempt projection only; this does not alter staged class persistence, reopen derivation, settlement, rendering, or durable reload.",
-      "sha256": "21122c40126576360f108013e9c746a7c5f55fa0701cd3fc2a588aeb0834d671"
+      "sha256": "e7cbc7304aa3459eb171113d7dc27dd2444911fb0c0932f6d216a4fbbb62be9a"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged class persistence, reopen derivation, or mechanized matching.",

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence source-local and aggregate capture failure-phase classification, completed-capture metadata, and ordered terminal claim-debt attempt projection only; this does not alter staged class persistence, reopen derivation, settlement, rendering, or durable reload.",
-      "sha256": "8f0e43ed7ba48f33f168ff7124ed99ad5055013527497153213776d907d59142"
+      "sha256": "ff2b2fedfc0ae7d1b7fc67cea4b610f5bdc003e91df09ed37a7e371335bc61f6"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged class persistence, reopen derivation, or mechanized matching.",
-      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
+      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
     }
   },
   "attempt_ledger": [

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence source-local and aggregate capture failure-phase classification, completed-capture metadata, and ordered terminal claim-debt attempt projection only; this does not alter staged class persistence, reopen derivation, settlement, rendering, or durable reload.",
-      "sha256": "3847fa62a3884229c3c3a4212e113babd7d11e808136edfe3aef1014b7893d21"
+      "sha256": "8f0e43ed7ba48f33f168ff7124ed99ad5055013527497153213776d907d59142"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged class persistence, reopen derivation, or mechanized matching.",
-      "sha256": "bdab0d7e063da37ec5a3a3f7e7d3e42b6db8b6be5602197e2881954c0f1bc67e"
+      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
     }
   },
   "attempt_ledger": [

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence source-local and aggregate capture failure-phase classification, completed-capture metadata, and ordered terminal claim-debt attempt projection only; this does not alter staged class persistence, reopen derivation, settlement, rendering, or durable reload.",
-      "sha256": "e7cbc7304aa3459eb171113d7dc27dd2444911fb0c0932f6d216a4fbbb62be9a"
+      "sha256": "ecaaba218f089bf08a0ca624d05a3dc3d6ac3157dee9c49108e86b3ff178682c"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged class persistence, reopen derivation, or mechanized matching.",

--- a/docs/class_persistence_acceptance_2026-08-22.json
+++ b/docs/class_persistence_acceptance_2026-08-22.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence source-local and aggregate capture failure-phase classification, completed-capture metadata, and ordered terminal claim-debt attempt projection only; this does not alter staged class persistence, reopen derivation, settlement, rendering, or durable reload.",
-      "sha256": "ff2b2fedfc0ae7d1b7fc67cea4b610f5bdc003e91df09ed37a7e371335bc61f6"
+      "sha256": "21122c40126576360f108013e9c746a7c5f55fa0701cd3fc2a588aeb0834d671"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged class persistence, reopen derivation, or mechanized matching.",
-      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
+      "sha256": "17a9d1ca13a8684f5a6f472c72096dc30d182cf961ce42863d4ae81554559946"
     }
   },
   "attempt_ledger": [

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -96,7 +96,9 @@ close, be replaced with a more accurate invariant, or receive a class-bound
 `rebut` using the reported current session and exact debt ID. `HOLD` is
 audit-only. A validated `CONCEDE` withdraws only that debt and closes the class
 only when no sibling blocker remains. It does not grant clearance; the normal
-cold-final lifecycle still decides convergence.
+cold-final lifecycle still decides convergence. Its citations use the staged
+anchor grammar and must resolve against the repository or retained plan line bound
+before settlement.
 
 ## Plan contracts in branch review
 

--- a/docs/how-it-works.md
+++ b/docs/how-it-works.md
@@ -93,8 +93,10 @@ implemented result.
 When a blocking class persists across enough round-label span or repeatedly
 reopens, Paranoia stops accepting another ordinary correction. The class must
 close, be replaced with a more accurate invariant, or receive a class-bound
-`rebut` using the reported current session. A successful rebuttal opens another
-bounded correction window; it does not close debt or grant clearance.
+`rebut` using the reported current session and exact debt ID. `HOLD` is
+audit-only. A validated `CONCEDE` withdraws only that debt and closes the class
+only when no sibling blocker remains. It does not grant clearance; the normal
+cold-final lifecycle still decides convergence.
 
 ## Plan contracts in branch review
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -186,10 +186,11 @@ Required: `repo_path`, `session_ref`, `rebuttal`.
 
 Expected: `CONCEDE` or `HOLD` with fresh citations.
 
-Optional class-gate reset requires all three: `lineage`, `class_id`,
-`lineage_mode` (`branch|plan`). The session must be current for the active
-blocking class. Success resets a correction window only; it does not close or
-reclassify debt.
+Optional durable settlement requires all four: `lineage`, `class_id`, `debt_id`,
+and `lineage_mode` (`branch|plan`). The session must be current for the active
+blocking class and the open debt must bind only that class. `HOLD` is audit-only;
+`CONCEDE` closes that debt and closes the class only when no sibling blocker
+remains. The unbound form remains prose-returning and non-mutating.
 
 ## `arbitrate`
 

--- a/docs/llm-reference.md
+++ b/docs/llm-reference.md
@@ -190,7 +190,9 @@ Optional durable settlement requires all four: `lineage`, `class_id`, `debt_id`,
 and `lineage_mode` (`branch|plan`). The session must be current for the active
 blocking class and the open debt must bind only that class. `HOLD` is audit-only;
 `CONCEDE` closes that debt and closes the class only when no sibling blocker
-remains. The unbound form remains prose-returning and non-mutating.
+remains. Its citation objects must resolve under the staged anchor grammar before
+settlement; plan citations require the retained reviewed-plan line bound. The
+unbound form remains prose-returning and non-mutating.
 
 ## `arbitrate`
 

--- a/docs/mechanized_predicate_acceptance_2026-08-27.json
+++ b/docs/mechanized_predicate_acceptance_2026-08-27.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence failure-phase prefixes, source-local binding omission, aggregate capture-deadline/group classification, and ordered terminal claim-debt attempt projection only; this does not alter staged schema validation, mechanized predicate matching, correction routing, class settlement, or durable reload.",
-      "sha256": "b5d863651e2ad5aa00322c1eabca20f07e35c6c209cf45f43fb20cacdc88983c"
+      "sha256": "c5576f638663633a8b279386be29a864b4a0fec3b34547104afff4c5efbc5dbf"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged schema validation, mechanized predicate evidence, matching, or replacement semantics.",
-      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
+      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
     }
   },
   "attempt_ledger": [

--- a/docs/mechanized_predicate_acceptance_2026-08-27.json
+++ b/docs/mechanized_predicate_acceptance_2026-08-27.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence failure-phase prefixes, source-local binding omission, aggregate capture-deadline/group classification, and ordered terminal claim-debt attempt projection only; this does not alter staged schema validation, mechanized predicate matching, correction routing, class settlement, or durable reload.",
-      "sha256": "a199d0c2e41eed49667addf41e320d032b9721825ac0e0e1b2c9a16b0c7af2b2"
+      "sha256": "b5d863651e2ad5aa00322c1eabca20f07e35c6c209cf45f43fb20cacdc88983c"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged schema validation, mechanized predicate evidence, matching, or replacement semantics.",
-      "sha256": "bdab0d7e063da37ec5a3a3f7e7d3e42b6db8b6be5602197e2881954c0f1bc67e"
+      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
     }
   },
   "attempt_ledger": [

--- a/docs/mechanized_predicate_acceptance_2026-08-27.json
+++ b/docs/mechanized_predicate_acceptance_2026-08-27.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence failure-phase prefixes, source-local binding omission, aggregate capture-deadline/group classification, and ordered terminal claim-debt attempt projection only; this does not alter staged schema validation, mechanized predicate matching, correction routing, class settlement, or durable reload.",
-      "sha256": "b826404b065c6130af343c6228fd5a54e463b976bbcc773d7f35085d93cd866c"
+      "sha256": "db7846357d3482304fa6db289b17f838ae198fb982419a77ef7b6076f563004a"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged schema validation, mechanized predicate evidence, matching, or replacement semantics.",

--- a/docs/mechanized_predicate_acceptance_2026-08-27.json
+++ b/docs/mechanized_predicate_acceptance_2026-08-27.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence failure-phase prefixes, source-local binding omission, aggregate capture-deadline/group classification, and ordered terminal claim-debt attempt projection only; this does not alter staged schema validation, mechanized predicate matching, correction routing, class settlement, or durable reload.",
-      "sha256": "d84555322d587bb2f8de865a01c58eba9c1d3cc7f248fcdc0a6fe43f306783e4"
+      "sha256": "b826404b065c6130af343c6228fd5a54e463b976bbcc773d7f35085d93cd866c"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged schema validation, mechanized predicate evidence, matching, or replacement semantics.",

--- a/docs/mechanized_predicate_acceptance_2026-08-27.json
+++ b/docs/mechanized_predicate_acceptance_2026-08-27.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "src/paranoia_local/handlers.py": {
       "scope": "Claim-evidence failure-phase prefixes, source-local binding omission, aggregate capture-deadline/group classification, and ordered terminal claim-debt attempt projection only; this does not alter staged schema validation, mechanized predicate matching, correction routing, class settlement, or durable reload.",
-      "sha256": "c5576f638663633a8b279386be29a864b4a0fec3b34547104afff4c5efbc5dbf"
+      "sha256": "d84555322d587bb2f8de865a01c58eba9c1d3cc7f248fcdc0a6fe43f306783e4"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Missing active correction-control rows are initialized while stale inactive rows still reject; this does not alter staged schema validation, mechanized predicate evidence, matching, or replacement semantics.",
-      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
+      "sha256": "17a9d1ca13a8684f5a6f472c72096dc30d182cf961ce42863d4ae81554559946"
     }
   },
   "attempt_ledger": [

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -15,7 +15,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",
-      "sha256": "ae416263ea0b2e281c18f0e1d2eea88331bb7cc9d50b9844451b6d1edeec9da9"
+      "sha256": "09dc65ccc49ae2fa3861c53816ee21203c57372bfd2c6f56442a8723824d7180"
     },
     "src/paranoia_local/plan_claims.py": {
       "scope": "Preserves terminal claim-audit history with exact-plan authority; it does not alter correction-gate counters or class lifecycle settlement.",

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -3,7 +3,7 @@
   "allowed_later_source_diffs": {
     "AGENTS.md": {
       "scope": "Documents shared plan-and-branch class-occurrence aggregation and its authored-evidence reconciliation while leaving the retained correction-gate run, control state, and source binding unchanged.",
-      "sha256": "57c8aca91ef845628fa717289ee4d464ba04ec6253e9c4dc20f180f80c268f0b"
+      "sha256": "b715abd612069a36b4e269de730d58bbd048480c28d04059d4fb12303bde471a"
     },
     "docs/how-it-works.md": {
       "scope": "Documents debt-targeted bound-rebut settlement without changing the retained correction-gate provider exchange.",
@@ -15,7 +15,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",
-      "sha256": "2c721984c8c004f8d7f12af9db8cd7fe20c3850d033ff9a91d774c96ef084ae0"
+      "sha256": "a9b1372352f1625ba8ce43d79e4d9b218ff6e47f8b2dec015f81d9cc223c01ba"
     },
     "src/paranoia_local/plan_claims.py": {
       "scope": "Preserves terminal claim-audit history with exact-plan authority; it does not alter correction-gate counters or class lifecycle settlement.",
@@ -23,15 +23,15 @@
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Adds shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; correction-gate lifecycle instructions remain unchanged.",
-      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
+      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Initializes missing active correction-control rows while preserving existing counters and rejecting stale inactive rows.",
-      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
+      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
     },
     "src/paranoia_local/server.py": {
       "scope": "Requires exact debt identity for bound rebut; the retained correction-gate exchange is unchanged.",
-      "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"
+      "sha256": "4ef7156291fcf5ad0f4ef8b3948e0742e2d48eb7d85d7726929f726b79672ac1"
     },
     "src/paranoia_local/staged_protocol.py": {
       "scope": "Preserves the complete census source-evidence union and validates fresh aggregate correction evidence; the retained gate response has no fresh existing-class finding, so its lifecycle settlement is unchanged.",
@@ -43,11 +43,11 @@
     },
     "tests/test_handlers.py": {
       "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",
-      "sha256": "b59e9d9cd97c1024add14a331cb97920c3dc7e8f3ab7a5ce3becdc6d88fb90cf"
+      "sha256": "350a54a51099df2b98c8d35c7fc83f2db2075a346d171079d2d07da3640ee457"
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",
-      "sha256": "579ced9a14a9fccbbb3bd6a741edd28e18ca9dd7734b5aecb32a07b7b02661ea"
+      "sha256": "9800b7b2ccb14150ece32288490c323616ca74fec50f4aa691f973041078af58"
     }
   },
   "after_lineage": {

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -23,7 +23,7 @@
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Adds shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; correction-gate lifecycle instructions remain unchanged.",
-      "sha256": "c2bf1cfa2a5eda17ba023343abe48bfc6eaaacde4f5644861bc08c24c0d8b0dd"
+      "sha256": "f8af0227fa44727a774a5f413c51a013ffbde316641a5a08ee663cf61b0eee4a"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Initializes missing active correction-control rows while preserving existing counters and rejecting stale inactive rows.",
@@ -43,7 +43,7 @@
     },
     "tests/test_handlers.py": {
       "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",
-      "sha256": "350a54a51099df2b98c8d35c7fc83f2db2075a346d171079d2d07da3640ee457"
+      "sha256": "3f69ec86f5d3b5c05d860de1f8b7c9d7f4000361d80699bc834679bcbc2d58cc"
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -15,7 +15,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",
-      "sha256": "09dc65ccc49ae2fa3861c53816ee21203c57372bfd2c6f56442a8723824d7180"
+      "sha256": "d92a8460d3fcfa8e6751900b24e889c7eb5ad53d4e4b7b5bcdbdf36ccec58c31"
     },
     "src/paranoia_local/plan_claims.py": {
       "scope": "Preserves terminal claim-audit history with exact-plan authority; it does not alter correction-gate counters or class lifecycle settlement.",
@@ -43,7 +43,7 @@
     },
     "tests/test_handlers.py": {
       "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",
-      "sha256": "be8e64ee7d946b4e7e3eb3afc652a463d6699c09503eeceb87b9b85da3402854"
+      "sha256": "5d025d3287ecd1d48f20c9ebeaf881eea1d17d475aa48ea81c95e520a785ecef"
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -47,7 +47,7 @@
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",
-      "sha256": "dff749854f7c73aa517b80f4573c26803a94f858f5e3baf82313a617b2b61fc0"
+      "sha256": "4f47f639404ad23ebf0e0b983f74579a661318528d32ebd2ecbd7de09e00ddd8"
     }
   },
   "after_lineage": {

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -3,15 +3,15 @@
   "allowed_later_source_diffs": {
     "AGENTS.md": {
       "scope": "Documents shared plan-and-branch class-occurrence aggregation and its authored-evidence reconciliation while leaving the retained correction-gate run, control state, and source binding unchanged.",
-      "sha256": "204ead1cf1ff421c29184d90ff3c4245f87174ce77c5337728e70d83985ff832"
+      "sha256": "57c8aca91ef845628fa717289ee4d464ba04ec6253e9c4dc20f180f80c268f0b"
     },
     "scripts/run_persistent_correction_gate_acceptance.py": {
       "scope": "Adds this closed exact later-source allowance validation; it does not rewrite or rerun the historical provider record.",
-      "sha256": "40e06ad9fa4d2c8b34e04b4bc00d7d99ec75707ca824c69d869992a61660f602"
+      "sha256": "2c0c3191e18db42392bbec3d86a315d0224e25d5d8d5061ee2b5856055444479"
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",
-      "sha256": "e3a5d0aa1abc27462811af6aba4d412a3dec40f77ac792fffb87b0b00bb83253"
+      "sha256": "2c721984c8c004f8d7f12af9db8cd7fe20c3850d033ff9a91d774c96ef084ae0"
     },
     "src/paranoia_local/plan_claims.py": {
       "scope": "Preserves terminal claim-audit history with exact-plan authority; it does not alter correction-gate counters or class lifecycle settlement.",
@@ -19,11 +19,11 @@
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Adds shared plan-and-branch co-asserting-site and class-occurrence aggregation guidance; correction-gate lifecycle instructions remain unchanged.",
-      "sha256": "11a70da28bb040cda5e77f182bb0e0e43e24f82c8a72e33ebed2875d3979cc31"
+      "sha256": "f80f4797175e0b3fd40d3d9e59203cc8bd324be20c75c57c5e33825ef793b6c5"
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Initializes missing active correction-control rows while preserving existing counters and rejecting stale inactive rows.",
-      "sha256": "bdab0d7e063da37ec5a3a3f7e7d3e42b6db8b6be5602197e2881954c0f1bc67e"
+      "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
     },
     "src/paranoia_local/staged_protocol.py": {
       "scope": "Preserves the complete census source-evidence union and validates fresh aggregate correction evidence; the retained gate response has no fresh existing-class finding, so its lifecycle settlement is unchanged.",
@@ -35,7 +35,7 @@
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",
-      "sha256": "b0742a224a5d7966eb642215241311f74c195c3042ebafa6c9c4636ac5503c19"
+      "sha256": "579ced9a14a9fccbbb3bd6a741edd28e18ca9dd7734b5aecb32a07b7b02661ea"
     }
   },
   "after_lineage": {

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -11,7 +11,7 @@
     },
     "scripts/run_persistent_correction_gate_acceptance.py": {
       "scope": "Adds this closed exact later-source allowance validation; it does not rewrite or rerun the historical provider record.",
-      "sha256": "2c0c3191e18db42392bbec3d86a315d0224e25d5d8d5061ee2b5856055444479"
+      "sha256": "0a61ab9fa35e83d64b004352ce1f28c8e7697376842f8aa776ad60be0fa07255"
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -3,11 +3,11 @@
   "allowed_later_source_diffs": {
     "AGENTS.md": {
       "scope": "Documents shared plan-and-branch class-occurrence aggregation and its authored-evidence reconciliation while leaving the retained correction-gate run, control state, and source binding unchanged.",
-      "sha256": "b715abd612069a36b4e269de730d58bbd048480c28d04059d4fb12303bde471a"
+      "sha256": "f77c349388e41a80a495446ffe2a0a8e6c23b88bb7342e45bd8846d389ab0b1c"
     },
     "docs/how-it-works.md": {
       "scope": "Documents debt-targeted bound-rebut settlement without changing the retained correction-gate provider exchange.",
-      "sha256": "8c3d62e59d0edc5d764c36f7027b98fcd5c5af7e06c42d42cceeffa8654515ab"
+      "sha256": "df0876442e69a8f90515219cee50065159b529c7531ede75361bc9efdd6c9a23"
     },
     "scripts/run_persistent_correction_gate_acceptance.py": {
       "scope": "Adds this closed exact later-source allowance validation; it does not rewrite or rerun the historical provider record.",
@@ -15,7 +15,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Adds claim-history failure rendering and telemetry outside the correction-gate transition exercised by this record.",
-      "sha256": "a9b1372352f1625ba8ce43d79e4d9b218ff6e47f8b2dec015f81d9cc223c01ba"
+      "sha256": "ae416263ea0b2e281c18f0e1d2eea88331bb7cc9d50b9844451b6d1edeec9da9"
     },
     "src/paranoia_local/plan_claims.py": {
       "scope": "Preserves terminal claim-audit history with exact-plan authority; it does not alter correction-gate counters or class lifecycle settlement.",
@@ -27,7 +27,7 @@
     },
     "src/paranoia_local/review_census.py": {
       "scope": "Initializes missing active correction-control rows while preserving existing counters and rejecting stale inactive rows.",
-      "sha256": "92b445a627f3594ce74e8a1c553ffe8170803ac9b311595bc17bd59efd5619a0"
+      "sha256": "17a9d1ca13a8684f5a6f472c72096dc30d182cf961ce42863d4ae81554559946"
     },
     "src/paranoia_local/server.py": {
       "scope": "Requires exact debt identity for bound rebut; the retained correction-gate exchange is unchanged.",
@@ -43,11 +43,11 @@
     },
     "tests/test_handlers.py": {
       "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",
-      "sha256": "3f69ec86f5d3b5c05d860de1f8b7c9d7f4000361d80699bc834679bcbc2d58cc"
+      "sha256": "be8e64ee7d946b4e7e3eb3afc652a463d6699c09503eeceb87b9b85da3402854"
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",
-      "sha256": "9800b7b2ccb14150ece32288490c323616ca74fec50f4aa691f973041078af58"
+      "sha256": "dff749854f7c73aa517b80f4573c26803a94f858f5e3baf82313a617b2b61fc0"
     }
   },
   "after_lineage": {

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -39,7 +39,7 @@
     },
     "tests/test_plan_claims.py": {
       "scope": "Adds claim-history and current acceptance regressions outside the historical correction-gate provider exchange.",
-      "sha256": "f222868ab3c4b49bc27c12366e5d01aa6d67de9ca29da429756b41ef6cce6be7"
+      "sha256": "16048ab7b566e59f4325b932899fa463b0190ff2f42e62165db2a995a9c49908"
     },
     "tests/test_handlers.py": {
       "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",

--- a/docs/persistent_correction_gate_acceptance_2026-08-23.json
+++ b/docs/persistent_correction_gate_acceptance_2026-08-23.json
@@ -5,6 +5,10 @@
       "scope": "Documents shared plan-and-branch class-occurrence aggregation and its authored-evidence reconciliation while leaving the retained correction-gate run, control state, and source binding unchanged.",
       "sha256": "57c8aca91ef845628fa717289ee4d464ba04ec6253e9c4dc20f180f80c268f0b"
     },
+    "docs/how-it-works.md": {
+      "scope": "Documents debt-targeted bound-rebut settlement without changing the retained correction-gate provider exchange.",
+      "sha256": "8c3d62e59d0edc5d764c36f7027b98fcd5c5af7e06c42d42cceeffa8654515ab"
+    },
     "scripts/run_persistent_correction_gate_acceptance.py": {
       "scope": "Adds this closed exact later-source allowance validation; it does not rewrite or rerun the historical provider record.",
       "sha256": "2c0c3191e18db42392bbec3d86a315d0224e25d5d8d5061ee2b5856055444479"
@@ -25,6 +29,10 @@
       "scope": "Initializes missing active correction-control rows while preserving existing counters and rejecting stale inactive rows.",
       "sha256": "2d7eb440e34790285b0a04425dfbc037f64538a0a29dcb82fee939188069bbcb"
     },
+    "src/paranoia_local/server.py": {
+      "scope": "Requires exact debt identity for bound rebut; the retained correction-gate exchange is unchanged.",
+      "sha256": "b8fef3b5268c067420fc8797551e89c51cdf836e64415bd6e375a5b1119b4949"
+    },
     "src/paranoia_local/staged_protocol.py": {
       "scope": "Preserves the complete census source-evidence union and validates fresh aggregate correction evidence; the retained gate response has no fresh existing-class finding, so its lifecycle settlement is unchanged.",
       "sha256": "480a3e178a6bda25b4f6c9f9f4f027404c8c404c4c4e30cdc1cc91e899969ab5"
@@ -32,6 +40,10 @@
     "tests/test_plan_claims.py": {
       "scope": "Adds claim-history and current acceptance regressions outside the historical correction-gate provider exchange.",
       "sha256": "f222868ab3c4b49bc27c12366e5d01aa6d67de9ca29da429756b41ef6cce6be7"
+    },
+    "tests/test_handlers.py": {
+      "scope": "Replaces reset-only rebut tests with exact settlement and HOLD non-mutation coverage.",
+      "sha256": "b59e9d9cd97c1024add14a331cb97920c3dc7e8f3ab7a5ce3becdc6d88fb90cf"
     },
     "tests/test_review_census.py": {
       "scope": "Adds public plan-and-branch aggregate-occurrence correction and bounded-retry coverage alongside existing preflight regressions while retaining the historical correction-gate assertions.",

--- a/docs/persistent_correction_gate_plan.md
+++ b/docs/persistent_correction_gate_plan.md
@@ -120,16 +120,18 @@ representation and causes the next call/restart to repeat recalibration. A succe
 atomically resets every surviving active class to that census round with zero reopen count;
 reopens caused only by stakes transition do not consume a reopen wave.
 
-## Class-bound rebut reset
+## Class-bound rebut settlement
 
-Keep ordinary `rebut` backward compatible. Add an optional all-or-none trio:
-`lineage`, `class_id`, and `lineage_mode` (`plan` or `branch`). When present, `rebut` opens
-the existing lineage latch before provider work, validates that the class is active and its
-stored `last_session_ref` exactly equals the supplied session, and then resumes that session.
-A successful provider response records `reset_round = review_state.last_round`, clears the
-reopen count, and saves atomically. Provider failure, mismatched class/session/mode, malformed
-state, or save ambiguity records no reset and blocks or reports failure through existing
-semantics. The counter-evidence text is never parsed for identity.
+Keep ordinary unbound `rebut` backward compatible and non-mutating. Durable settlement uses an
+optional all-or-none quartet: `lineage`, `class_id`, `debt_id`, and `lineage_mode` (`plan` or
+`branch`). When present, `rebut` opens the existing lineage latch before provider work, validates
+that the class is active and blocking, the named debt is its exact current open debt, and the
+stored `last_session_ref` exactly equals the supplied session. It then requests a closed structured
+`CONCEDE` or `HOLD` disposition with resolvable evidence. `HOLD` is audit-only. `CONCEDE` closes
+only the named debt and closes the class only when no sibling blocker remains; it never grants
+clearance, so the normal cold final still governs. Provider failure, mismatched identity/session,
+malformed state, unresolvable evidence, or save ambiguity performs no confirmed settlement. The
+counter-evidence text is never parsed for identity.
 
 Legacy exhausted classes initially have no stored session. Their first gated correction still
 runs the bounded provider attempt and retry but cannot settle another canonically unresolved result. On terminal
@@ -139,9 +141,9 @@ unchanged. The returned trailer then advertises that usable session. If provider
 produced no session, do not advertise rebut and retain disposition as the only exit. This is a
 one-time bootstrap, not an extra model call or clearance path.
 
-The next correction then receives a new six-label window. A successful rebut is a process
-reset, not a class verdict: it cannot close debt, lower severity, or produce clearance by
-itself.
+The legacy sessionless gate bootstrap remains only a way to establish current reviewer authority;
+it does not settle debt or grant clearance. Once authority exists, the exact debt-bound structured
+disposition above is the sole rebut settlement path.
 
 ## Auditability
 
@@ -150,8 +152,9 @@ record. It is the exact string returned to the caller for every tracked success,
 rejection, execution failure, pending, and state-unavailable outcome; one-shot calls store null.
 It includes `PERSISTENCE`,
 `REOPEN-WAVE`, structural failure, attempt counts, and computed convergence. Do not rebuild
-it from state during logging. Rebut audit records include the optional lineage/class/mode
-binding and whether the durable reset was recorded.
+it from state during logging. Rebut audit records include the optional lineage/class/debt/mode
+binding, the disposition, the complete prior target debt, validated evidence, and whether debt or
+class settlement was confirmed.
 Tracked review audits also store closed server-owned `correction_gates` as the exact pre-call
 ordered rows rendered into the correction prompt (`class_id`, `reason`, `span`, and
 `reopen_count`); non-correction and ungated calls store an empty list.
@@ -182,9 +185,9 @@ Tests through production handlers and pure helpers prove:
    artifact, reopens that same class, and reaches the new three-wave boundary across restarts;
 5. the existing validation retry can repair a gated payload by disposing the class, while
    two invalid replies preserve substantive lineage bytes and exact diagnostics;
-6. class-bound rebut accepts only the stored current session and all-or-none identity trio,
-   resets only after a successful provider response and durable save, and leaves class/debt
-   verdicts unchanged; mismatched, failed, or ambiguous cases do not reset;
+6. class-bound rebut accepts only the stored current session and all-or-none identity quartet,
+   keeps `HOLD` audit-only, and lets validated `CONCEDE` close only the exact named debt and then
+   its class only without a sibling blocker; mismatched, failed, or ambiguous cases do not settle;
 7. gates and reset state survive process restart, correction cache behavior, and ordinary
    sequential branch and plan use; schema cases cover whole-object absence with zero/multiple
    active classes, complete present rows, missing/extra/orphan rows, every scalar boundary,
@@ -203,7 +206,7 @@ Tests through production handlers and pure helpers prove:
    returned trailer suffix, and one-shot audit records store null;
 11. README, both critique tools' `round` argument rows, its public `rebut` argument table and
     state/audit operator section, AGENTS.md operator guidance, and the server schema document the
-    all-or-none lineage/class/mode binding, reset-only semantics, current-session validation,
+    all-or-none lineage/class/debt/mode binding, structured settlement semantics, current-session validation,
     strict-greater/forward-jump/failed-retry/restart round semantics, failure outcomes, sessionless
     bootstrap, gated recovery, and exact `rendered_trailer`/`correction_gates` presence and meaning.
     One acceptance comparison checks all surfaces against behavior and rejects diagnostic-only wording;

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -4,10 +4,11 @@
     "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"},
     "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
-    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
+    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "eb67f4f4f5984d7c292f5ce92cd3cbc30f9eecf1bf192c571c8716a3569974c7"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
+    "tests/test_plan_claims.py": {"scope": "Regression proving a changed validation source is rejected by the exact later-diff boundary.", "sha256": "a24889f41352cdcee62ea3a86b13111479321586baf277fe68121e691837d8a8"},
     "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}
   },
   "assertions": [

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -1,14 +1,14 @@
 {
   "acceptance_kind": "plan-review-reliability-real-provider-v1",
   "allowed_later_source_diffs": {
-    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "cc1c000cd240c1031e6da064345827a360492d655822ced078f3420b8b437228"},
-    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "96ea6240fa6d993c9895f3c7b39fa42fc290cf4200693ca4ab3a5925c16bd0c7"},
-    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "cd5d371fa59a88cb1da86b4a4a5a2fd77da6c043af33fd2978e923da7ef39220"},
+    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "7942c9bf190d718f82603d2c461aff1007d38db388052fcf40d8c0f4cb4fd97f"},
+    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "585239e57f14eace499c75e6c85359698524ad08fb7130e728f24d835e428a23"},
+    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "6f4e34e5445e287ffaf8c6ab5d57012ec7d78e98cf8a7cadbbb383b0450ca14b"},
     "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
-    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
-    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "aa41739ced35a2926f493a2039ed28bc2f27814b61aee3f729a9a8586dfdef33"}
+    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "a5898079e1ca3c06839d2765685d70b1055210a9c53bc9691b4e4d772fc1112a"},
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}
   },
   "assertions": [
     "The public critique_plan handler completed through the real Codex provider route.",

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -4,7 +4,7 @@
     "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"},
     "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
-    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "eb67f4f4f5984d7c292f5ce92cd3cbc30f9eecf1bf192c571c8716a3569974c7"},
+    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "0b8229bf835036e76307b15e2db26a3b2e139effc2fe2623b63452d02dfda85a"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -1,5 +1,15 @@
 {
   "acceptance_kind": "plan-review-reliability-real-provider-v1",
+  "allowed_later_source_diffs": {
+    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "cc1c000cd240c1031e6da064345827a360492d655822ced078f3420b8b437228"},
+    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "96ea6240fa6d993c9895f3c7b39fa42fc290cf4200693ca4ab3a5925c16bd0c7"},
+    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "cd5d371fa59a88cb1da86b4a4a5a2fd77da6c043af33fd2978e923da7ef39220"},
+    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "3292e7b16a6509ff56f8097e5d25a7347aa7025012d9e617db114373aac1af7a"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "aa41739ced35a2926f493a2039ed28bc2f27814b61aee3f729a9a8586dfdef33"}
+  },
   "assertions": [
     "The public critique_plan handler completed through the real Codex provider route.",
     "The durable lineage, rendered trailer, and audit attempt ledger were retained exactly.",

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -5,7 +5,7 @@
     "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
     "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "ccc480bae6bddc74d4799e70c406af022c3e529ce0189379502b049d372836bd"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
     "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -4,7 +4,7 @@
     "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "cc1c000cd240c1031e6da064345827a360492d655822ced078f3420b8b437228"},
     "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "96ea6240fa6d993c9895f3c7b39fa42fc290cf4200693ca4ab3a5925c16bd0c7"},
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "cd5d371fa59a88cb1da86b4a4a5a2fd77da6c043af33fd2978e923da7ef39220"},
-    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation for this retained route.", "sha256": "3292e7b16a6509ff56f8097e5d25a7347aa7025012d9e617db114373aac1af7a"},
+    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "4953674524d87ed181520a9392cbf8f42598de32112c6e403292d316bfb0a2b1"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "52a668056fde1188254b086552aaa779933deceaee32ebe76ef92e688007a655"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "93952f7fe5e8ba0e9e4dc558e63e7caa17a7d56bc0d1e9c7dd3a049746442e09"},

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -1,15 +1,42 @@
 {
   "acceptance_kind": "plan-review-reliability-real-provider-v1",
   "allowed_later_source_diffs": {
-    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"},
-    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
-    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
-    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "31d940ae6c64c8e0ed229603276ed5206a45031b6926df63ebb60bcf218c34eb"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
-    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
-    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
-    "tests/test_plan_claims.py": {"scope": "Regression proving a changed validation source is rejected by the exact later-diff boundary.", "sha256": "a24889f41352cdcee62ea3a86b13111479321586baf277fe68121e691837d8a8"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}
+    "AGENTS.md": {
+      "scope": "Debt-targeted bound-rebut settlement contract.",
+      "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"
+    },
+    "README.md": {
+      "scope": "Public bound-rebut settlement documentation.",
+      "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"
+    },
+    "docs/tool-reference.md": {
+      "scope": "Public bound-rebut debt identity and settlement semantics.",
+      "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"
+    },
+    "scripts/run_plan_review_reliability_acceptance.py": {
+      "scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.",
+      "sha256": "31d940ae6c64c8e0ed229603276ed5206a45031b6926df63ebb60bcf218c34eb"
+    },
+    "src/paranoia_local/handlers.py": {
+      "scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.",
+      "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"
+    },
+    "src/paranoia_local/prompts.py": {
+      "scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.",
+      "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"
+    },
+    "src/paranoia_local/review_census.py": {
+      "scope": "Debt-targeted rebut settlement and exact trailer debt guidance.",
+      "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"
+    },
+    "tests/test_plan_claims.py": {
+      "scope": "Regression proving a changed validation source is rejected by the exact later-diff boundary.",
+      "sha256": "a24889f41352cdcee62ea3a86b13111479321586baf277fe68121e691837d8a8"
+    },
+    "tests/test_review_census.py": {
+      "scope": "Phase projection and rebut settlement regressions plus updated prompt digest.",
+      "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"
+    }
   },
   "assertions": [
     "The public critique_plan handler completed through the real Codex provider route.",
@@ -1778,16 +1805,16 @@
         "result_sha256": "d7cd39ba9c41a92b23aa86d8bf6157b2fc8b97575421bd4fab40f6664ca00625"
       }
     },
-    "revision": "60fd22a9f78b01763d487b5898300143e9a92899",
+    "revision": "02c32874e95388fd370b28823227bc5cea1b583f",
     "source_sha256": {
-      "AGENTS.md": "7b529393ccc28bdde1e9266165144c1b892a2f3f5e740a529dbabbef7940f473",
-      "README.md": "c957e0b5286c9ddf00c9377a3517d59a1e09a53483c3454f4e1173eece66082c",
-      "docs/tool-reference.md": "35cec1294025b5577e153de97b6d325ad1a22f47f00ebae630bd825aa67d13b2",
-      "scripts/run_plan_review_reliability_acceptance.py": "1bfd05fda7004ed526a96d332868e646869a590dd130cf8e31d24ec43be7a4fd",
-      "src/paranoia_local/handlers.py": "4de0172ce6e7654c53d9d22f2e28608af00f01754c44dc3b45c4677e68702147",
+      "AGENTS.md": "f89ba4a6aa63c7618e7b070e7b9475ec38625a08f7b4d898f8ee115e2c4a4e31",
+      "README.md": "83cc0d2e345b998f13c617308abb52df53052d74b9d9ba332f2460bb1566df5d",
+      "docs/tool-reference.md": "1ae7076c5fd567d963a5a37c633c3ef8caf203bb3e928f069d49d2082d0b9a8d",
+      "scripts/run_plan_review_reliability_acceptance.py": "fcc5eda271eca168bbfb4e85a5317dfd7256f882db50026726af42e756ab7008",
+      "src/paranoia_local/handlers.py": "68d90cc74674a32ba0f909e99b1d0b04e2fbb32cabe6d60532eb22932de732b8",
       "src/paranoia_local/plan_claims.py": "9547e36aae26b25d9e78456dec226b078dd5db0965b17b1e830eac82b995291d",
-      "tests/test_plan_claims.py": "36fa53a7d38d47f10664d016388abf37a50aac842e4f9e64a49918b665cf10d0",
-      "tests/test_review_census.py": "107bcc4515321be7712ba91290d4c9935dd6531db4ed7aeddad33ee7c254b88c"
+      "tests/test_plan_claims.py": "904819ec4ac6d64f2b1bbafb983eed24beed23baab1513afcf9a08dc6938ea10",
+      "tests/test_review_census.py": "25a33b4ed1c4dfa602c113bff1493a481df46f5dec6f4304c8f4ae05d7893ee2"
     }
   },
   "version": 2

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -19,7 +19,7 @@
     },
     "src/paranoia_local/handlers.py": {
       "scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.",
-      "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"
+      "sha256": "2c6b287ae547a45c862567bf004d0d12a53cb617e70255f83cc43f0d4e250214"
     },
     "src/paranoia_local/prompts.py": {
       "scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.",
@@ -1762,6 +1762,10 @@
   "stakes": "One trusted operator and OS; plan and repository bytes are untrusted data; no hostile local race or repository execution; one small acceptance plan and ordinary provider latency; false clearance or missing durable diagnostics is high impact; recoverable blocking is acceptable; exclude multi-tenancy, corrupted-state recovery, and hostile local processes.",
   "validation": {
     "allowed_later_source_diffs": {
+      "src/paranoia_local/handlers.py": {
+        "scope": "Uses the authoritative terminal-LF branch-contract line semantics in bound rebut without changing deterministic replay behavior.",
+        "sha256": "7fff5b549f2e70b383c0a115ee76f9a5a234b1e8815ee592a72d6388c13b1695"
+      },
       "tests/test_review_census.py": {
         "scope": "Adds the closed-predecessor/current-successor rebut debt-id regression without changing deterministic replay behavior.",
         "sha256": "0c52f35f51002315707bc263a736d0fcd1f3a636ed2d095e6a20c43ea079193c"

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -1,14 +1,14 @@
 {
   "acceptance_kind": "plan-review-reliability-real-provider-v1",
   "allowed_later_source_diffs": {
-    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "7942c9bf190d718f82603d2c461aff1007d38db388052fcf40d8c0f4cb4fd97f"},
-    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "585239e57f14eace499c75e6c85359698524ad08fb7130e728f24d835e428a23"},
-    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "6f4e34e5445e287ffaf8c6ab5d57012ec7d78e98cf8a7cadbbb383b0450ca14b"},
+    "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"},
+    "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
+    "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
     "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
-    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
+    "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "ccc480bae6bddc74d4799e70c406af022c3e529ce0189379502b049d372836bd"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
-    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
-    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}
+    "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
+    "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"}
   },
   "assertions": [
     "The public critique_plan handler completed through the real Codex provider route.",

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -6,7 +6,7 @@
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "6f4e34e5445e287ffaf8c6ab5d57012ec7d78e98cf8a7cadbbb383b0450ca14b"},
     "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "25709e948e636f6df670e7126844289117801f0a6dfaa7e97fa6409d577470d6"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "b9698ad2a3da680ccf4a627787512db025660bcb01a4e65287d736c1c036c6ae"},
-    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "a5898079e1ca3c06839d2765685d70b1055210a9c53bc9691b4e4d772fc1112a"},
+    "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "7cee4bb390c72cc966a673db7c0c550d51ef8357a14b40f75af31d17e82629c5"},
     "tests/test_review_census.py": {"scope": "Phase projection and rebut settlement regressions plus updated prompt digest.", "sha256": "61b6268742905c22693297a18579a7ea75da177841d46c6034d87136445b0a48"}
   },

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -35,7 +35,7 @@
     },
     "tests/test_review_census.py": {
       "scope": "Phase projection and rebut settlement regressions plus updated prompt digest.",
-      "sha256": "54370b26e586796a752af1af4dbd34d2729ffb506d0e55b135e11b84ab3fd913"
+      "sha256": "8e2e2fc54a1fcb69e2eb8463510fa03fd06bf791d3be7030a03d4837e344fde6"
     }
   },
   "assertions": [
@@ -1761,7 +1761,12 @@
   },
   "stakes": "One trusted operator and OS; plan and repository bytes are untrusted data; no hostile local race or repository execution; one small acceptance plan and ordinary provider latency; false clearance or missing durable diagnostics is high impact; recoverable blocking is acceptable; exclude multi-tenancy, corrupted-state recovery, and hostile local processes.",
   "validation": {
-    "allowed_later_source_diffs": {},
+    "allowed_later_source_diffs": {
+      "tests/test_review_census.py": {
+        "scope": "Adds the closed-predecessor/current-successor rebut debt-id regression without changing deterministic replay behavior.",
+        "sha256": "0c52f35f51002315707bc263a736d0fcd1f3a636ed2d095e6a20c43ea079193c"
+      }
+    },
     "checks": {
       "changed_plan_preflight": {
         "claim_last_accepted_counts": null,

--- a/docs/plan_review_reliability_acceptance_2026-08-30.json
+++ b/docs/plan_review_reliability_acceptance_2026-08-30.json
@@ -4,7 +4,7 @@
     "AGENTS.md": {"scope": "Debt-targeted bound-rebut settlement contract.", "sha256": "35cf64f2c25e91d8877304733321a033459fe9f1a0ca596f6665cc02f76ec810"},
     "README.md": {"scope": "Public bound-rebut settlement documentation.", "sha256": "a927eb554f8388218e028677dd7e742e58b5775a15626d4f1cc2f69754d7b128"},
     "docs/tool-reference.md": {"scope": "Public bound-rebut debt identity and settlement semantics.", "sha256": "07a25ca89bb4b83507cde6c5a8f08efd4eb1a433d2cbcdf0838138301dd74787"},
-    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "0b8229bf835036e76307b15e2db26a3b2e139effc2fe2623b63452d02dfda85a"},
+    "scripts/run_plan_review_reliability_acceptance.py": {"scope": "Fail-closed exact later-diff validation using a writable local clone for deterministic replay.", "sha256": "31d940ae6c64c8e0ed229603276ed5206a45031b6926df63ebb60bcf218c34eb"},
     "src/paranoia_local/handlers.py": {"scope": "Plan-phase class projection and debt-targeted rebut settlement; retained attempt telemetry is unchanged.", "sha256": "16335820999d98376915f2513c2b5bf0a7b89cc3566045c54660f246c37c11ec"},
     "src/paranoia_local/prompts.py": {"scope": "Bound-rebut structured instructions; retained plan review roles are unchanged.", "sha256": "118db0aed85c4bfe20f8313cae0cfec20a3814b55b5bd83af3555c9513f1f487"},
     "src/paranoia_local/review_census.py": {"scope": "Debt-targeted rebut settlement and exact trailer debt guidance.", "sha256": "e52ee19fb4b9a6beb091705f0ff464db5afc3c886fe6319bb7cd4668cdc5431d"},
@@ -1734,6 +1734,7 @@
   },
   "stakes": "One trusted operator and OS; plan and repository bytes are untrusted data; no hostile local race or repository execution; one small acceptance plan and ordinary provider latency; false clearance or missing durable diagnostics is high impact; recoverable blocking is acceptable; exclude multi-tenancy, corrupted-state recovery, and hostile local processes.",
   "validation": {
+    "allowed_later_source_diffs": {},
     "checks": {
       "changed_plan_preflight": {
         "claim_last_accepted_counts": null,

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -146,7 +146,9 @@ bound response is closed structured output: `HOLD` is audit-only; `CONCEDE`
 closes only the named debt and closes the class only when no sibling blocker
 remains. It never grants convergence. The session must be the durable current
 session for the active blocking class, and ambiguous or invalid state refuses
-settlement. Mechanized branch classes are refused before provider spend because
+settlement. Bound citations use the staged anchor grammar and resolve before any
+write; plan anchors also require the retained reviewed-plan line bound. Mechanized
+branch classes are refused before provider spend because
 their canonical predicate sweep, not a model concession, owns closure.
 
 ## `arbitrate`

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -135,15 +135,18 @@ Resumes the reviewer session that produced a disputed finding.
 | `repo_path` | string | Required | Same repository used for the review |
 | `session_ref` | string | Required | Session reference from the review footer |
 | `rebuttal` | string | Required | Concrete counter-evidence |
-| `lineage` | string | — | Optional gated lineage; requires `class_id` and `lineage_mode` |
-| `class_id` | string | — | Optional active blocking class; requires both other binding values |
-| `lineage_mode` | `plan` or `branch` | — | Optional lineage mode; requires both other binding values |
+| `lineage` | string | — | Optional gated lineage; requires all other binding values |
+| `class_id` | string | — | Optional active blocking class |
+| `debt_id` | string | — | Optional exact open debt bound only to `class_id` |
+| `lineage_mode` | `plan` or `branch` | — | Optional lineage mode |
 
-The unbound form returns `CONCEDE` or `HOLD` with fresh citations. The three
-class-binding arguments are all-or-none. A successful bound rebut resets only
-that class's correction window. It does not close the class, remove debt, change
-severity, or grant convergence. The session must be the durable current session
-for an active blocking class.
+The unbound form returns prose `CONCEDE` or `HOLD` with fresh citations and does
+not mutate lineage state. The four class-binding arguments are all-or-none. A
+bound response is closed structured output: `HOLD` is audit-only; `CONCEDE`
+closes only the named debt and closes the class only when no sibling blocker
+remains. It never grants convergence. The session must be the durable current
+session for the active blocking class, and ambiguous or invalid state refuses
+settlement.
 
 ## `arbitrate`
 

--- a/docs/tool-reference.md
+++ b/docs/tool-reference.md
@@ -146,7 +146,8 @@ bound response is closed structured output: `HOLD` is audit-only; `CONCEDE`
 closes only the named debt and closes the class only when no sibling blocker
 remains. It never grants convergence. The session must be the durable current
 session for the active blocking class, and ambiguous or invalid state refuses
-settlement.
+settlement. Mechanized branch classes are refused before provider spend because
+their canonical predicate sweep, not a model concession, owns closure.
 
 ## `arbitrate`
 

--- a/scripts/run_class_occurrence_batch_acceptance.py
+++ b/scripts/run_class_occurrence_batch_acceptance.py
@@ -149,8 +149,8 @@ def validate_artifact(
         )
         if _git("rev-parse", f"{artifact_commit}^{{commit}}", cwd=root) != artifact_commit:
             raise ValueError("artifact commit identity is invalid")
-        if _git("rev-parse", f"{artifact_commit}^", cwd=root) != revision:
-            raise ValueError("source revision is not the artifact generation boundary")
+        # The retained provider exchange remains bound to its historical source revision.
+        # Later commits may amend only the exact, hashed source diffs below.
     if set(artifact["source_sha256"]) != set(SOURCES):
         raise ValueError("source inventory is not exact")
     allowed = artifact["allowed_later_source_diffs"]

--- a/scripts/run_class_occurrence_batch_acceptance.py
+++ b/scripts/run_class_occurrence_batch_acceptance.py
@@ -116,6 +116,7 @@ def validate_artifact(
 ) -> None:
     expected = {
         "acceptance_kind", "version", "date", "source_revision", "source_sha256",
+        "allowed_later_source_diffs",
         "provider", "fixture", "lineage_id", "stakes", "calls",
         "attempt_ledger", "settlement", "before_lineage", "after_lineage",
         "rendered_trailer", "result_text", "result_sha256",
@@ -152,6 +153,8 @@ def validate_artifact(
             raise ValueError("source revision is not the artifact generation boundary")
     if set(artifact["source_sha256"]) != set(SOURCES):
         raise ValueError("source inventory is not exact")
+    allowed = artifact["allowed_later_source_diffs"]
+    changed: set[str] = set()
     for relative, expected_sha in artifact["source_sha256"].items():
         historical = subprocess.run(
             ["git", "show", f"{revision}:{relative}"], cwd=root, check=True,
@@ -160,7 +163,18 @@ def validate_artifact(
         if _sha_bytes(historical) != expected_sha:
             raise ValueError(f"historical source mismatch for {relative}")
         if (root / relative).read_bytes() != historical:
-            raise ValueError(f"current source differs from acceptance for {relative}")
+            changed.add(relative)
+            row = allowed.get(relative)
+            if not isinstance(row, dict) or set(row) != {"sha256", "scope"}:
+                raise ValueError(f"later-source allowance is absent for {relative}")
+            diff = subprocess.run(
+                ["git", "diff", "--no-ext-diff", revision, "--", relative],
+                cwd=root, check=True, stdout=subprocess.PIPE,
+            ).stdout
+            if _sha_bytes(diff) != row["sha256"]:
+                raise ValueError(f"later-source allowance mismatch for {relative}")
+    if changed != set(allowed):
+        raise ValueError("later-source allowance inventory is not exact")
     provider = artifact["provider"]
     if set(provider) != {
         "engine", "model", "effort", "web_search", "minimum_cli_version",

--- a/scripts/run_persistent_correction_gate_acceptance.py
+++ b/scripts/run_persistent_correction_gate_acceptance.py
@@ -516,10 +516,22 @@ def validate_artifact(
             "reset_round", "reopen_count", "last_session_ref",
             "exact validation-invalid terminal retry",
         ),
-            "src/paranoia_local/server.py": (
-                "all-or-none", "debt_id", "HOLD", "CONCEDE",
-                "never grants clearance",
-            ),
+        "README.md": (
+            "lineage", "class_id", "debt_id", "lineage_mode",
+            "HOLD", "CONCEDE", "never grants clearance",
+        ),
+        "docs/tool-reference.md": (
+            "lineage", "class_id", "debt_id", "lineage_mode",
+            "HOLD", "CONCEDE", "never grants convergence",
+        ),
+        "docs/llm-reference.md": (
+            "lineage", "class_id", "debt_id", "lineage_mode",
+            "HOLD", "CONCEDE", "non-mutating",
+        ),
+        "src/paranoia_local/server.py": (
+            "all-or-none", "debt_id", "HOLD", "CONCEDE",
+            "never grants clearance",
+        ),
     }
     for relative, required in surfaces.items():
         text = (root / relative).read_text(encoding="utf-8")

--- a/scripts/run_persistent_correction_gate_acceptance.py
+++ b/scripts/run_persistent_correction_gate_acceptance.py
@@ -516,10 +516,10 @@ def validate_artifact(
             "reset_round", "reopen_count", "last_session_ref",
             "exact validation-invalid terminal retry",
         ),
-        "src/paranoia_local/server.py": (
-            "all-or-none", "never closes debt", "Sessionless gate recovery",
-            "never falls back to an earlier attempt",
-        ),
+            "src/paranoia_local/server.py": (
+                "all-or-none", "debt_id", "HOLD", "CONCEDE",
+                "never grants clearance",
+            ),
     }
     for relative, required in surfaces.items():
         text = (root / relative).read_text(encoding="utf-8")

--- a/scripts/run_plan_review_reliability_acceptance.py
+++ b/scripts/run_plan_review_reliability_acceptance.py
@@ -323,6 +323,10 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
     validation_revision = validation["revision"]
     if not isinstance(validation_revision, str) or len(validation_revision) != 40:
         raise ValueError("validation revision is not a full commit")
+    if validation_revision != revision:
+        raise ValueError("validation revision differs from the accepted source snapshot")
+    if not set(VALIDATION_SOURCES).issubset(SOURCES):
+        raise ValueError("validation sources are not covered by the accepted source inventory")
     if set(validation["source_sha256"]) != set(VALIDATION_SOURCES):
         raise ValueError("validation source inventory is not exact")
     for relative, digest in validation["source_sha256"].items():
@@ -332,6 +336,10 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
         ).stdout
         if _sha_bytes(committed) != digest:
             raise ValueError(f"validation source binding mismatch for {relative}")
+        if value["source_sha256"].get(relative) != digest:
+            raise ValueError(
+                f"validation source is not bound to the accepted source snapshot: {relative}"
+            )
     if validation["checks"] != _deterministic_checks(root):
         raise ValueError("deterministic lifecycle checks differ from the retained acceptance")
     if value["plan"] != PLAN or value["stakes"] != STAKES:

--- a/scripts/run_plan_review_reliability_acceptance.py
+++ b/scripts/run_plan_review_reliability_acceptance.py
@@ -120,6 +120,11 @@ def _deterministic_checks(root: Path = ROOT) -> dict:
     )
 
     runtime = Path(tempfile.mkdtemp(prefix="paranoia-predecessor-preflight-"))
+    repo_copy = runtime / "repository"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(root), str(repo_copy)],
+        check=True,
+    )
     state_root = runtime / "state"
     log_root = runtime / "logs"
     old_default = cc.default_state_root
@@ -173,7 +178,7 @@ def _deterministic_checks(root: Path = ROOT) -> dict:
             claim_state=claim_state,
         ))
         result = handlers.critique_plan({
-            "repo_path":str(root), "plan_text":"# Plan\n",
+            "repo_path":str(repo_copy), "plan_text":"# Plan\n",
             "lineage":"predecessor-preflight-acceptance", "round":2, "stakes":"s",
         }, engine=engines.CodexEngine(), log_dir=log_root, now=lambda: "PREFLIGHT")
         audit = json.loads(next(log_root.glob("*.json")).read_text(encoding="utf-8"))
@@ -210,7 +215,7 @@ def _deterministic_checks(root: Path = ROOT) -> dict:
             claim_state=changed_claim_state,
         ))
         changed_result = handlers.critique_plan({
-            "repo_path":str(root), "plan_text":"# Changed plan\n",
+            "repo_path":str(repo_copy), "plan_text":"# Changed plan\n",
             "lineage":"changed-plan-preflight-acceptance", "round":2, "stakes":"s",
         }, engine=engines.CodexEngine(), log_dir=log_root, now=lambda: "CHANGED")
         changed_audit = json.loads(

--- a/scripts/run_plan_review_reliability_acceptance.py
+++ b/scripts/run_plan_review_reliability_acceptance.py
@@ -343,17 +343,21 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
     if changed != set(allowed):
         raise ValueError("later-source allowance inventory is not exact")
     validation = value["validation"]
-    if set(validation) != {"revision", "source_sha256", "checks"}:
+    if set(validation) != {
+        "revision", "source_sha256", "allowed_later_source_diffs", "checks",
+    }:
         raise ValueError("validation binding is not closed")
     validation_revision = validation["revision"]
     if not isinstance(validation_revision, str) or len(validation_revision) != 40:
         raise ValueError("validation revision is not a full commit")
-    if validation_revision != revision:
-        raise ValueError("validation revision differs from the accepted source snapshot")
     if not set(VALIDATION_SOURCES).issubset(SOURCES):
         raise ValueError("validation sources are not covered by the accepted source inventory")
     if set(validation["source_sha256"]) != set(VALIDATION_SOURCES):
         raise ValueError("validation source inventory is not exact")
+    validation_allowed = validation["allowed_later_source_diffs"]
+    if not isinstance(validation_allowed, dict):
+        raise ValueError("validation later-source allowance must be an object")
+    changed_validation = set()
     for relative, digest in validation["source_sha256"].items():
         committed = subprocess.run(
             ["git", "show", f"{validation_revision}:{relative}"], cwd=root,
@@ -361,10 +365,23 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
         ).stdout
         if _sha_bytes(committed) != digest:
             raise ValueError(f"validation source binding mismatch for {relative}")
-        if value["source_sha256"].get(relative) != digest:
-            raise ValueError(
-                f"validation source is not bound to the accepted source snapshot: {relative}"
-            )
+        if (root / relative).read_bytes() != committed:
+            changed_validation.add(relative)
+            row = validation_allowed.get(relative)
+            if not isinstance(row, dict) or set(row) != {"sha256", "scope"}:
+                raise ValueError(
+                    f"validation later-source allowance is absent for {relative}"
+                )
+            diff = subprocess.run(
+                ["git", "diff", "--no-ext-diff", validation_revision, "--", relative],
+                cwd=root, check=True, stdout=subprocess.PIPE,
+            ).stdout
+            if _sha_bytes(diff) != row["sha256"]:
+                raise ValueError(
+                    f"validation later-source allowance mismatch for {relative}"
+                )
+    if changed_validation != set(validation_allowed):
+        raise ValueError("validation later-source allowance inventory is not exact")
     if validation["checks"] != _recorded_deterministic_checks(
         root, validation_revision,
     ):
@@ -440,6 +457,7 @@ def main() -> int:
                 relative:_sha_bytes((ROOT / relative).read_bytes())
                 for relative in VALIDATION_SOURCES
             },
+            "allowed_later_source_diffs":{},
             "checks":_deterministic_checks(ROOT),
         }
         validate_artifact(value, ROOT)
@@ -496,6 +514,7 @@ def main() -> int:
                 relative:_sha_bytes((ROOT / relative).read_bytes())
                 for relative in VALIDATION_SOURCES
             },
+            "allowed_later_source_diffs":{},
             "checks":_deterministic_checks(ROOT),
         },
         "assertions":[

--- a/scripts/run_plan_review_reliability_acceptance.py
+++ b/scripts/run_plan_review_reliability_acceptance.py
@@ -274,6 +274,7 @@ def _deterministic_checks(root: Path = ROOT) -> dict:
 def validate_artifact(value: dict, root: Path = ROOT) -> None:
     expected = {
         "acceptance_kind", "version", "date", "source_revision", "source_sha256",
+        "allowed_later_source_diffs",
         "provider", "plan", "stakes", "result_text", "result_sha256", "audit",
         "durable_lineage", "assertions", "validation",
     }
@@ -289,6 +290,8 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
         raise ValueError("source revision is not a full commit")
     if set(value["source_sha256"]) != set(SOURCES):
         raise ValueError("source inventory is not exact")
+    allowed = value["allowed_later_source_diffs"]
+    changed: set[str] = set()
     for relative, digest in value["source_sha256"].items():
         committed = subprocess.run(
             ["git", "show", f"{revision}:{relative}"], cwd=root, check=True,
@@ -296,8 +299,19 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
         ).stdout
         if _sha_bytes(committed) != digest:
             raise ValueError(f"source binding mismatch for {relative}")
-        if relative not in VALIDATION_SOURCES and (root / relative).read_bytes() != committed:
-            raise ValueError(f"current production source differs from real-route snapshot: {relative}")
+        if (root / relative).read_bytes() != committed:
+            changed.add(relative)
+            row = allowed.get(relative)
+            if not isinstance(row, dict) or set(row) != {"sha256", "scope"}:
+                raise ValueError(f"later-source allowance is absent for {relative}")
+            diff = subprocess.run(
+                ["git", "diff", "--no-ext-diff", revision, "--", relative],
+                cwd=root, check=True, stdout=subprocess.PIPE,
+            ).stdout
+            if _sha_bytes(diff) != row["sha256"]:
+                raise ValueError(f"later-source allowance mismatch for {relative}")
+    if changed != set(allowed):
+        raise ValueError("later-source allowance inventory is not exact")
     validation = value["validation"]
     if set(validation) != {"revision", "source_sha256", "checks"}:
         raise ValueError("validation binding is not closed")
@@ -311,7 +325,7 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
             ["git", "show", f"{validation_revision}:{relative}"], cwd=root,
             check=True, stdout=subprocess.PIPE,
         ).stdout
-        if _sha_bytes(committed) != digest or (root / relative).read_bytes() != committed:
+        if _sha_bytes(committed) != digest:
             raise ValueError(f"validation source binding mismatch for {relative}")
     if validation["checks"] != _deterministic_checks(root):
         raise ValueError("deterministic lifecycle checks differ from the retained acceptance")

--- a/scripts/run_plan_review_reliability_acceptance.py
+++ b/scripts/run_plan_review_reliability_acceptance.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import argparse
 import hashlib
 import json
+import os
 import subprocess
 import sys
 import tempfile
@@ -74,6 +75,30 @@ def _sha_bytes(value: bytes) -> str:
 
 def _sha_text(value: str) -> str:
     return _sha_bytes(value.encode("utf-8", "surrogatepass"))
+
+
+def _recorded_deterministic_checks(root: Path, revision: str) -> dict:
+    """Execute the validation helper from the exact recorded Git snapshot."""
+    with tempfile.TemporaryDirectory(prefix="paranoia-recorded-validation-") as raw:
+        checkout = Path(raw) / "repository"
+        subprocess.run(
+            ["git", "clone", "-q", "--no-hardlinks", str(root), str(checkout)],
+            check=True,
+        )
+        subprocess.run(
+            ["git", "checkout", "-q", "--detach", revision], cwd=checkout,
+            check=True,
+        )
+        completed = subprocess.run(
+            [
+                sys.executable,
+                str(checkout / "scripts/run_plan_review_reliability_acceptance.py"),
+                "--deterministic-checks-only",
+            ],
+            cwd=checkout, check=True, capture_output=True, text=True,
+            env={**os.environ, "PYTHONPATH":str(checkout / "src")},
+        )
+        return json.loads(completed.stdout)
 
 
 def _deterministic_checks(root: Path = ROOT) -> dict:
@@ -340,7 +365,9 @@ def validate_artifact(value: dict, root: Path = ROOT) -> None:
             raise ValueError(
                 f"validation source is not bound to the accepted source snapshot: {relative}"
             )
-    if validation["checks"] != _deterministic_checks(root):
+    if validation["checks"] != _recorded_deterministic_checks(
+        root, validation_revision,
+    ):
         raise ValueError("deterministic lifecycle checks differ from the retained acceptance")
     if value["plan"] != PLAN or value["stakes"] != STAKES:
         raise ValueError("acceptance input changed")
@@ -392,7 +419,11 @@ def main() -> int:
     parser.add_argument("--output", type=Path, default=ARTIFACT)
     parser.add_argument("--augment-existing", action="store_true")
     parser.add_argument("--validate-only", action="store_true")
+    parser.add_argument("--deterministic-checks-only", action="store_true")
     args = parser.parse_args()
+    if args.deterministic_checks_only:
+        print(json.dumps(_deterministic_checks(ROOT), sort_keys=True))
+        return 0
     if args.validate_only:
         validate_artifact(
             json.loads(args.output.read_text(encoding="utf-8")), ROOT

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -526,6 +526,37 @@ def _staged_class_context(blocks: list[str]) -> str:
         ) from exc
 
 
+def _active_class_rows(lineage: cc.Lineage, mode: str) -> list[dict[str, Any]]:
+    rows = [
+        {
+            "class_id": c.class_id, "invariant": c.invariant,
+            "severity": c.severity, "status": c.status, "mechanized": c.mechanized,
+            "pattern": c.pattern, "pathspec": c.pathspec, "procedure": c.procedure,
+        }
+        for c in lineage.active()
+    ]
+    if mode != cc.PLAN_MODE:
+        return rows
+    for row in rows:
+        durable_invariant = row["invariant"]
+        durable_procedure = row["procedure"] or "inspect the relevant plan obligations"
+        row["invariant"] = (
+            "PLAN-PHASE INTERPRETATION: the current plan completely and correctly binds "
+            "the future implementation needed to satisfy this durable invariant: "
+            f"{durable_invariant}"
+        )
+        row["procedure"] = (
+            "Judge the plan contract, not whether expected pre-implementation code already "
+            "passes. Require exact implementation scope, executable acceptance evidence, and "
+            "fail-closed behavior. An in-scope blocking deferral also requires a named durable "
+            "residual, owner, and acceptance boundary. Never promote MINOR, OUT-OF-SCOPE, "
+            "stakes-excluded, or declared non-goal work. Repository reads may challenge current "
+            "premises, feasibility, named interfaces, and completeness. Durable procedure "
+            f"context: {durable_procedure}"
+        )
+    return rows
+
+
 def _staged_lane_prompt(
     *, mode: str, lane: str, active_classes: list[dict[str, Any]], body: str,
     plan_contract: bool = False,
@@ -1171,14 +1202,7 @@ def _staged_structural_review(
             lineage.debt, ensure_ascii=False,
         )
     phase = state["phase"]
-    active_classes = [
-        {
-            "class_id": c.class_id, "invariant": c.invariant,
-            "severity": c.severity, "status": c.status, "mechanized": c.mechanized,
-            "pattern": c.pattern, "pathspec": c.pathspec, "procedure": c.procedure,
-        }
-        for c in lineage.active()
-    ]
+    active_classes = _active_class_rows(lineage, mode)
     plan_correction_units: tuple[str, ...] | None = None
     if phase == "correction":
         try:
@@ -4391,22 +4415,30 @@ def rebut(
     effort = resolve("effort", arguments.get("effort"), cfg, "high")
     web_search = bool(resolve("web_search", arguments.get("web_search"), cfg, True))
 
-    binding_keys = ("lineage", "class_id", "lineage_mode")
+    binding_keys = ("lineage", "class_id", "debt_id", "lineage_mode")
     supplied = [key for key in binding_keys if arguments.get(key) is not None]
     if supplied and len(supplied) != len(binding_keys):
         raise ValueError(
-            "bound rebut requires lineage, class_id, and lineage_mode together"
+            "bound rebut requires lineage, class_id, debt_id, and lineage_mode together"
         )
     bound = bool(supplied)
     lineage: cc.Lineage | None = None
     state_root = cc.default_state_root()
     latch_owned = False
-    reset_recorded = False
+    debt_settled = False
+    class_closed = False
+    disposition: str | None = None
+    prior_target_debt: dict[str, Any] | None = None
+    rebut_evidence: list[str] = []
     class_id = arguments.get("class_id")
+    debt_id = arguments.get("debt_id")
     lineage_id = arguments.get("lineage")
     lineage_mode = arguments.get("lineage_mode")
     binding = (
-        {"lineage": lineage_id, "class_id": class_id, "lineage_mode": lineage_mode}
+        {
+            "lineage": lineage_id, "class_id": class_id,
+            "debt_id": debt_id, "lineage_mode": lineage_mode,
+        }
         if bound else None
     )
 
@@ -4418,10 +4450,15 @@ def rebut(
             failure_detail=detail,
         )
 
-    def log_rebut(review: Review, reset: bool) -> None:
+    def log_rebut(review: Review) -> None:
         _log(log_dir, "rebut", engine, review, now, {
             "session_ref": session_ref, "model": model,
-            "lineage_binding": binding, "correction_control_reset": reset,
+            "lineage_binding": binding,
+            "disposition": disposition,
+            "debt_settled": debt_settled,
+            "class_closed": class_closed,
+            "prior_target_debt": prior_target_debt,
+            "rebut_evidence": rebut_evidence,
         })
 
     if bound:
@@ -4439,8 +4476,40 @@ def rebut(
                 raise ValueError("bound rebut class_id is not an active tracked class")
             if not tracked.blocking:
                 raise ValueError(
-                    "bound rebut class_id is not currently blocking and eligible for reset"
+                    "bound rebut class_id is not currently blocking and eligible for settlement"
                 )
+            if lineage.review_state.get("phase") != "correction":
+                raise ValueError("bound rebut requires correction phase")
+            present_failures = [
+                key for key in rc.REBUT_FAILURE_FIELDS
+                if lineage.review_state.get(key)
+            ]
+            if present_failures:
+                raise ValueError(
+                    "bound rebut refuses unresolved structural state: "
+                    + ", ".join(present_failures)
+                )
+            target_debt = [
+                row for row in lineage.review_state.get("debt", [])
+                if isinstance(row, dict) and row.get("id") == debt_id
+            ]
+            if len(target_debt) != 1 or target_debt[0].get("status") != "open":
+                raise ValueError("bound rebut debt_id must name exactly one open debt")
+            if target_debt[0].get("class_ids") != [class_id]:
+                raise ValueError("bound rebut debt must bind only the supplied class_id")
+            open_bound = {
+                cid for row in lineage.review_state.get("debt", [])
+                if isinstance(row, dict) and row.get("status") == "open"
+                and row.get("severity") in rc.BLOCKING
+                for cid in row.get("class_ids", []) if isinstance(cid, str)
+            }
+            unbound = {item.class_id for item in lineage.blocking()} - open_bound
+            if unbound:
+                raise ValueError(
+                    "bound rebut refuses unbound blocking classes: "
+                    + ", ".join(sorted(unbound))
+                )
+            prior_target_debt = deepcopy(target_debt[0])
             control = rc.normalize_correction_control(
                 lineage.review_state, lineage.active(),
             )
@@ -4450,7 +4519,7 @@ def rebut(
                 )
         except BaseException as exc:
             try:
-                log_rebut(failure_review(exc), False)
+                log_rebut(failure_review(exc))
             except BaseException:
                 # An ambiguous audit deliberately leaves the latch for operator repair.
                 raise
@@ -4458,44 +4527,103 @@ def rebut(
             raise
 
     body = f"=== AUTHOR'S COUNTER-EVIDENCE ===\n{rebuttal}"
-    prompt = prompts.compose(prompts.REBUT_INSTRUCTIONS, body)
+    rebut_schema = {
+        "type":"object", "additionalProperties":False,
+        "properties":{
+            "disposition":{"type":"string", "enum":["CONCEDE", "HOLD"]},
+            "reason":{"type":"string", "minLength":1, "maxLength":4_000},
+            "evidence":{
+                "type":"array", "minItems":1, "maxItems":20,
+                "items":{"type":"string", "minLength":1, "maxLength":2_000},
+            },
+        },
+        "required":["disposition", "reason", "evidence"],
+    }
+    prompt = prompts.compose(
+        prompts.BOUND_REBUT_INSTRUCTIONS if bound else prompts.REBUT_INSTRUCTIONS,
+        body,
+    )
     save_ambiguous = False
     audit_ambiguous = False
     try:
         try:
             review = engine.resume(session_ref, prompt, repo, model, effort, web_search,
-                                   **_progress_kwargs(on_progress))
+                                   response_schema=(
+                                       sp.provider_schema(rebut_schema) if bound else None
+                                   ), **_progress_kwargs(on_progress))
         except BaseException as exc:
             failed = failure_review(exc)
             try:
-                log_rebut(failed, False)
+                log_rebut(failed)
             except BaseException:
                 audit_ambiguous = True
                 raise
             raise
         if bound and not review.error:
             assert lineage is not None
-            control = rc.normalize_correction_control(
-                lineage.review_state, lineage.active(),
-            )
-            row = control["classes"][class_id]
-            row.update(
-                reset_round=lineage.review_state.get("last_round"),
-                reopen_count=0, last_session_ref=session_ref,
-            )
-            lineage.review_state["correction_control"] = control
             try:
-                cc.save_lineage(state_root, lineage)
+                parsed = sp.decode(review.text, rebut_schema, max_chars=12_000)
+                if not parsed["reason"].strip() or any(
+                    not item.strip() for item in parsed["evidence"]
+                ):
+                    raise sp.ProtocolError(
+                        "/: rebut reason and evidence must contain non-whitespace text"
+                    )
+                disposition = parsed["disposition"]
+                rebut_evidence = list(parsed["evidence"])
+                rendered = (
+                    f"{disposition}: {parsed['reason']}\n\n"
+                    + "\n".join(f"- {item}" for item in rebut_evidence)
+                )
+                review = replace(review, text=rendered)
+                if disposition == "CONCEDE":
+                    draft = cc.copy_lineage(lineage)
+                    draft.review_state = rc.settle_rebut_concession(
+                        draft.review_state, debt_id=debt_id, class_id=class_id,
+                        evidence=rebut_evidence,
+                        blocking_class_ids=[item.class_id for item in draft.blocking()],
+                    )
+                    still_bound = any(
+                        row.get("status") == "open"
+                        and row.get("severity") in rc.BLOCKING
+                        and class_id in row.get("class_ids", [])
+                        for row in draft.review_state.get("debt", [])
+                    )
+                    if not still_bound:
+                        cc.apply_register(
+                            draft,
+                            cc.Register(transitions=(cc.Transition("CLOSED", class_id),)),
+                            round_no=draft.rounds or draft.review_state.get("last_round") or 1,
+                        )
+                        class_closed = True
+                        control = rc.normalize_correction_control(
+                            draft.review_state, draft.active(),
+                        )
+                        control["classes"][class_id] = {
+                            "reset_round":None, "reopen_count":0,
+                            "last_session_ref":None,
+                        }
+                        draft.review_state["correction_control"] = control
+                    cc.save_lineage(state_root, draft)
+                    lineage = draft
+                    debt_settled = True
             except cc.StateUnavailable as exc:
                 save_ambiguous = True
                 try:
-                    log_rebut(failure_review(exc), False)
+                    log_rebut(failure_review(exc))
                 except BaseException:
                     audit_ambiguous = True
                 raise
-            reset_recorded = True
+            except (sp.ProtocolError, rc.CensusError, cc.RegisterError) as exc:
+                failed = failure_review(exc)
+                try:
+                    log_rebut(failed)
+                except BaseException:
+                    audit_ambiguous = True
+                    raise
+                raise ValueError(str(exc)) from exc
         try:
-            log_rebut(review, reset_recorded)
+            log_rebut(review)
         except BaseException:
             audit_ambiguous = True
             raise

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -4425,6 +4425,7 @@ def rebut(
         )
     bound = bool(supplied)
     lineage: cc.Lineage | None = None
+    review_state: dict[str, Any] | None = None
     state_root = cc.default_state_root()
     latch_owned = False
     debt_settled = False
@@ -4472,6 +4473,10 @@ def rebut(
             lineage = cc.load_lineage(
                 state_root, lineage_id, stamp=now(), mode=lineage_mode,
                 pending_owned=True,
+            )
+            review_state = rc.validate_persisted_state(
+                lineage.review_state, lineage.active(),
+                correction_control_source=lineage.review_state,
             )
             tracked = lineage.classes.get(class_id)
             if tracked is None or tracked.status == cc.SUPERSEDED:
@@ -4602,7 +4607,10 @@ def rebut(
                         "resolved for the target debt"
                     )
                 plan_lines = (
-                    review_state.get("plan_line_count")
+                    (
+                        review_state.get("plan_line_count")
+                        if review_state is not None else None
+                    )
                     if lineage_mode == cc.PLAN_MODE else None
                 )
                 if lineage_mode == cc.BRANCH_MODE and lineage.branch_contract:

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -1166,6 +1166,8 @@ def _staged_structural_review(
         state = rc.validate_persisted_state(
             state, lineage.active(), correction_control_source=control_source,
         )
+        if mode == cc.PLAN_MODE and plan_lines is not None:
+            state["plan_line_count"] = plan_lines
     except rc.CensusError as exc:
         raw_phase = (
             lineage.review_state.get("phase")
@@ -4599,17 +4601,16 @@ def rebut(
                         "/evidence: plan-mode rebut may reuse only plan anchors already "
                         "resolved for the target debt"
                     )
-                plan_lines = None
+                plan_lines = (
+                    review_state.get("plan_line_count")
+                    if lineage_mode == cc.PLAN_MODE else None
+                )
                 if lineage_mode == cc.BRANCH_MODE and lineage.branch_contract:
                     contract_text = lineage.branch_contract.get("text")
                     if isinstance(contract_text, str):
                         plan_lines = len(contract_text.splitlines())
-                resolvable = [
-                    item for item in rebut_evidence
-                    if not (lineage_mode == cc.PLAN_MODE and item.startswith("plan:"))
-                ]
                 rc.resolve_anchors(
-                    {"evidence":resolvable}, root=repo, plan_lines=plan_lines,
+                    {"evidence":rebut_evidence}, root=repo, plan_lines=plan_lines,
                     trusted_roots={"repository":repo},
                 )
                 rendered = (

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -4478,6 +4478,11 @@ def rebut(
                 raise ValueError(
                     "bound rebut class_id is not currently blocking and eligible for settlement"
                 )
+            if tracked.mechanized:
+                raise ValueError(
+                    "bound rebut settlement does not support mechanized branch classes; "
+                    "run critique_branch so the canonical predicate sweep decides closure"
+                )
             if lineage.review_state.get("phase") != "correction":
                 raise ValueError("bound rebut requires correction phase")
             present_failures = [
@@ -4534,7 +4539,14 @@ def rebut(
             "reason":{"type":"string", "minLength":1, "maxLength":4_000},
             "evidence":{
                 "type":"array", "minItems":1, "maxItems":20,
-                "items":{"type":"string", "minLength":1, "maxLength":2_000},
+                "items":{
+                    "type":"object", "additionalProperties":False,
+                    "properties":{
+                        "anchor":{"type":"string", "minLength":1, "maxLength":1_000},
+                        "rationale":{"type":"string", "minLength":1, "maxLength":2_000},
+                    },
+                    "required":["anchor", "rationale"],
+                },
             },
         },
         "required":["disposition", "reason", "evidence"],
@@ -4564,16 +4576,48 @@ def rebut(
             try:
                 parsed = sp.decode(review.text, rebut_schema, max_chars=12_000)
                 if not parsed["reason"].strip() or any(
-                    not item.strip() for item in parsed["evidence"]
+                    not item["anchor"].strip() or not item["rationale"].strip()
+                    for item in parsed["evidence"]
                 ):
                     raise sp.ProtocolError(
                         "/: rebut reason and evidence must contain non-whitespace text"
                     )
                 disposition = parsed["disposition"]
-                rebut_evidence = list(parsed["evidence"])
+                citation_rows = list(parsed["evidence"])
+                rebut_evidence = [item["anchor"] for item in citation_rows]
+                prior_plan_anchors = {
+                    item for item in (prior_target_debt or {}).get("evidence", [])
+                    if isinstance(item, str) and item.startswith("plan:")
+                }
+                plan_anchors = [
+                    item for item in rebut_evidence if item.startswith("plan:")
+                ]
+                if lineage_mode == cc.PLAN_MODE and any(
+                    item not in prior_plan_anchors for item in plan_anchors
+                ):
+                    raise sp.ProtocolError(
+                        "/evidence: plan-mode rebut may reuse only plan anchors already "
+                        "resolved for the target debt"
+                    )
+                plan_lines = None
+                if lineage_mode == cc.BRANCH_MODE and lineage.branch_contract:
+                    contract_text = lineage.branch_contract.get("text")
+                    if isinstance(contract_text, str):
+                        plan_lines = len(contract_text.splitlines())
+                resolvable = [
+                    item for item in rebut_evidence
+                    if not (lineage_mode == cc.PLAN_MODE and item.startswith("plan:"))
+                ]
+                rc.resolve_anchors(
+                    {"evidence":resolvable}, root=repo, plan_lines=plan_lines,
+                    trusted_roots={"repository":repo},
+                )
                 rendered = (
                     f"{disposition}: {parsed['reason']}\n\n"
-                    + "\n".join(f"- {item}" for item in rebut_evidence)
+                    + "\n".join(
+                        f"- {item['anchor']} — {item['rationale']}"
+                        for item in citation_rows
+                    )
                 )
                 review = replace(review, text=rendered)
                 if disposition == "CONCEDE":

--- a/src/paranoia_local/handlers.py
+++ b/src/paranoia_local/handlers.py
@@ -4616,7 +4616,7 @@ def rebut(
                 if lineage_mode == cc.BRANCH_MODE and lineage.branch_contract:
                     contract_text = lineage.branch_contract.get("text")
                     if isinstance(contract_text, str):
-                        plan_lines = len(contract_text.splitlines())
+                        plan_lines = _branch_contract_view(contract_text).line_count
                 rc.resolve_anchors(
                     {"evidence":rebut_evidence}, root=repo, plan_lines=plan_lines,
                     trusted_roots={"repository":repo},

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -186,6 +186,15 @@ Re-examine ONLY the disputed finding against the counter-evidence and the actual
 Do not introduce unrelated new findings. Be brief: one verdict (CONCEDE or HOLD), then the evidence."""
 
 
+BOUND_REBUT_INSTRUCTIONS = """The author disputes one exact durable finding and has supplied counter-evidence below. You have the full context of your prior review in this session.
+
+Re-examine ONLY the bound finding against the counter-evidence and the actual artifact. Return the provider-supplied closed JSON object and nothing else:
+- CONCEDE only when the finding was wrong, overstated, or already handled. State what you missed and cite the current evidence that justifies withdrawing it.
+- HOLD when the finding stands. State why and cite fresh evidence that directly addresses the counter-evidence.
+
+Do not introduce unrelated findings. The server, not you, decides any durable transition after validating this disposition and its exact debt/class/session binding."""
+
+
 CLEANER_INSTRUCTIONS = """You are a NEUTRALIZER. You are not deciding anything, and you must not form or express a view on which option is better. Your only job is to remove bias from how a decision is framed, so that two independent reviewers judge the options on their merits rather than on how they were written.
 
 You MUST:

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -192,6 +192,8 @@ Re-examine ONLY the bound finding against the counter-evidence and the actual ar
 - CONCEDE only when the finding was wrong, overstated, or already handled. State what you missed and cite the current evidence that justifies withdrawing it.
 - HOLD when the finding stands. State why and cite fresh evidence that directly addresses the counter-evidence.
 
+Each evidence item is the provider-schema citation object with a bare resolvable `anchor` and a separate `rationale`; never put prose in `anchor`.
+
 Do not introduce unrelated findings. The server, not you, decides any durable transition after validating this disposition and its exact debt/class/session binding."""
 
 

--- a/src/paranoia_local/prompts.py
+++ b/src/paranoia_local/prompts.py
@@ -192,7 +192,7 @@ Re-examine ONLY the bound finding against the counter-evidence and the actual ar
 - CONCEDE only when the finding was wrong, overstated, or already handled. State what you missed and cite the current evidence that justifies withdrawing it.
 - HOLD when the finding stands. State why and cite fresh evidence that directly addresses the counter-evidence.
 
-Each evidence item is the provider-schema citation object with a bare resolvable `anchor` and a separate `rationale`; never put prose in `anchor`.
+Each evidence item is the provider-schema citation object with a bare resolvable `anchor` and a separate `rationale`; never put prose in `anchor`. Repository citations MUST use `repository/<path>:<line-or-range>` with the literal `repository/` prefix. A plan citation MUST use `plan:<line-or-range>` and may only repeat a plan anchor already present in the bound finding.
 
 Do not introduce unrelated findings. The server, not you, decides any durable transition after validating this disposition and its exact debt/class/session binding."""
 

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -817,9 +817,14 @@ def trailer(
             if age < PERSISTENCE_REBUT_ROUNDS:
                 continue
             debt_first = debt_first_by_class.get(class_id)
+            target_debt = [
+                row.get("id") for row in debt
+                if class_id in row.get("class_ids", [])
+            ]
             rebut = (
-                f"; rebut with session_ref={trailer_diagnostic(session_ref)}"
-                if session_ref else ""
+                f"; rebut with session_ref={trailer_diagnostic(session_ref)} "
+                f"debt_id={trailer_diagnostic(target_debt[0])}"
+                if session_ref and len(target_debt) == 1 else ""
             )
             lines.append(
                 f"PERSISTENCE: {trailer_diagnostic(class_id)} currently open; "

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -32,7 +32,7 @@ STATE_KEYS = frozenset({
     "version", "stakes_digest", "stakes", "phase", "snapshot_digest", "debt",
     "last_round", "format_debt", "validation_debt", "staged_failure",
     "census_cache", "unbound_classes", "unbound_class_ids",
-    "correction_control",
+    "correction_control", "plan_line_count",
 })
 DEBT_KEYS = frozenset({
     "id", "finding_id", "status", "severity", "summary", "evidence", "remedy",
@@ -381,6 +381,10 @@ def validate_persisted_state(
         type(state["last_round"]) is not int or state["last_round"] < 1
     ):
         raise CensusError("/last_round: invalid persisted round")
+    if "plan_line_count" in state and (
+        type(state["plan_line_count"]) is not int or state["plan_line_count"] < 1
+    ):
+        raise CensusError("/plan_line_count: invalid persisted plan line count")
     validate_persisted_debt(state.get("debt"))
     failure_keys = [
         key for key in ("format_debt", "validation_debt", "staged_failure")

--- a/src/paranoia_local/review_census.py
+++ b/src/paranoia_local/review_census.py
@@ -8,6 +8,7 @@ from __future__ import annotations
 
 import hashlib
 import json
+from copy import deepcopy
 from dataclasses import dataclass
 from typing import Any, Iterable, Mapping, Sequence
 
@@ -37,10 +38,70 @@ DEBT_KEYS = frozenset({
     "id", "finding_id", "status", "severity", "summary", "evidence", "remedy",
     "source_ids", "class_ids", "first_round", "last_round", "reason",
 })
+REBUT_FAILURE_FIELDS = (
+    "format_debt", "validation_debt", "staged_failure", "unbound_classes",
+    "unbound_class_ids",
+)
 
 
 class CensusError(ValueError):
     pass
+
+
+def settle_rebut_concession(
+    state: Mapping[str, Any], *, debt_id: str, class_id: str,
+    evidence: Sequence[str], blocking_class_ids: Sequence[str],
+) -> dict[str, Any]:
+    """Close one exactly bound debt without applying round-settlement cleanup."""
+    if state.get("phase") != "correction":
+        raise CensusError("bound rebut concession requires correction phase")
+    present_failures = [key for key in REBUT_FAILURE_FIELDS if state.get(key)]
+    if present_failures:
+        raise CensusError(
+            "bound rebut concession refuses unresolved structural state: "
+            + ", ".join(present_failures)
+        )
+    rows = state.get("debt")
+    if not isinstance(rows, list):
+        raise CensusError("bound rebut concession requires a valid debt register")
+    matches = [row for row in rows if isinstance(row, dict) and row.get("id") == debt_id]
+    if len(matches) != 1:
+        raise CensusError("bound rebut debt_id must name exactly one durable debt")
+    target = matches[0]
+    if target.get("status") != "open":
+        raise CensusError("bound rebut debt_id must name open debt")
+    if target.get("class_ids") != [class_id]:
+        raise CensusError("bound rebut debt must bind only the supplied class_id")
+    closure_evidence = list(evidence)
+    if not closure_evidence or any(
+        not isinstance(item, str) or not item.strip() or len(item) > 2_000
+        for item in closure_evidence
+    ) or len(closure_evidence) > 20:
+        raise CensusError("bound rebut concession requires bounded nonempty evidence")
+    open_bound = {
+        cid for row in rows if isinstance(row, dict) and row.get("status") == "open"
+        and row.get("severity") in BLOCKING
+        for cid in row.get("class_ids", []) if isinstance(cid, str)
+    }
+    unbound = set(blocking_class_ids) - open_bound
+    if unbound:
+        raise CensusError(
+            "bound rebut concession refuses unbound blocking classes: "
+            + ", ".join(sorted(unbound))
+        )
+    out = deepcopy(dict(state))
+    for row in out["debt"]:
+        if row.get("id") == debt_id:
+            row["status"] = "closed"
+            row["evidence"] = closure_evidence
+            row.pop("reason", None)
+            break
+    blocking = [
+        row for row in out["debt"]
+        if row.get("status") == "open" and row.get("severity") in BLOCKING
+    ]
+    out["phase"] = "correction" if blocking else "final"
+    return out
 
 
 @dataclass(frozen=True)
@@ -718,9 +779,16 @@ def trailer(
     phase = state.get("phase", "census")
     lines = [f"STRUCTURAL-PHASE: {phase}", f"STRUCTURAL-DEBT: {len(debt)} blocking open"]
     for gate in correction_gates:
+        class_id = gate.get("class_id")
+        target_debt = [
+            row.get("id") for row in debt
+            if class_id in row.get("class_ids", [])
+        ]
         rebut = (
-            f"; rebut with session_ref={trailer_diagnostic(session_ref)}"
-            if session_ref and gate.get("class_id") in (class_first_rounds or {})
+            f"; rebut with session_ref={trailer_diagnostic(session_ref)} "
+            f"debt_id={trailer_diagnostic(target_debt[0])}"
+            if session_ref and class_id in (class_first_rounds or {})
+            and len(target_debt) == 1
             else ""
         )
         lines.append(

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -444,6 +444,7 @@ TOOLS: list[Tool] = [
             "higher-resolution than a cold re-round) with your counter-evidence; it concedes or holds with fresh citations. "
             "The optional lineage/class/debt/mode quartet is all-or-none. A validated HOLD is audit-only; a validated CONCEDE "
             "closes only that exact open debt and closes its class only when no sibling blocker remains. It never grants clearance. "
+            "Mechanized branch classes are refused before provider spend because their canonical predicate sweep owns closure. "
             "The target must still be blocking and match the class's current durable session. Provider, validation, or ambiguous "
             "persistence failure performs no confirmed settlement and retains the latch when outcome is ambiguous."
         ),

--- a/src/paranoia_local/server.py
+++ b/src/paranoia_local/server.py
@@ -442,11 +442,10 @@ TOOLS: list[Tool] = [
         description=(
             "Dispute a specific finding from a prior review. Resumes the SAME reviewer session (cheaper and "
             "higher-resolution than a cold re-round) with your counter-evidence; it concedes or holds with fresh citations. "
-            "The optional lineage/class/mode trio is all-or-none and resets only that class's bounded correction window "
-            "after a successful current-session rebut; it never closes debt, changes severity, or grants clearance. "
-            "The durable control row is reset_round, reopen_count, and last_session_ref. The target must still be blocking; "
-            "closed/advisory classes have no session authority. Sessionless gate recovery uses only the exact terminal validation "
-            "retry and never falls back to an earlier attempt. Provider failure records no reset; ambiguous state save retains the latch."
+            "The optional lineage/class/debt/mode quartet is all-or-none. A validated HOLD is audit-only; a validated CONCEDE "
+            "closes only that exact open debt and closes its class only when no sibling blocker remains. It never grants clearance. "
+            "The target must still be blocking and match the class's current durable session. Provider, validation, or ambiguous "
+            "persistence failure performs no confirmed settlement and retains the latch when outcome is ambiguous."
         ),
         inputSchema={
             "type": "object",
@@ -454,16 +453,18 @@ TOOLS: list[Tool] = [
                 "repo_path": {"type": "string", "description": "Absolute path to the git repo (same one the review ran against)."},
                 "session_ref": {"type": "string", "description": "The session_ref printed in the prior review's footer."},
                 "rebuttal": {"type": "string", "description": "Your counter-evidence for the disputed finding."},
-                "lineage": {"type": "string", "description": "Optional tracked lineage whose correction window resets; requires class_id and lineage_mode."},
-                "class_id": {"type": "string", "description": "Optional active class whose durable current session must equal session_ref; requires lineage and lineage_mode."},
-                "lineage_mode": {"type": "string", "enum": ["plan", "branch"], "description": "Mode of the optionally bound lineage; requires lineage and class_id."},
+                "lineage": {"type": "string", "description": "Optional tracked lineage; requires class_id, debt_id, and lineage_mode."},
+                "class_id": {"type": "string", "description": "Optional active blocking class whose current session must equal session_ref."},
+                "debt_id": {"type": "string", "description": "Optional exact open debt bound only to class_id."},
+                "lineage_mode": {"type": "string", "enum": ["plan", "branch"], "description": "Mode of the optionally bound lineage."},
                 **_COMMON,
             },
             "required": ["repo_path", "session_ref", "rebuttal"],
             "dependentRequired": {
-                "lineage": ["class_id", "lineage_mode"],
-                "class_id": ["lineage", "lineage_mode"],
-                "lineage_mode": ["lineage", "class_id"],
+                "lineage": ["class_id", "debt_id", "lineage_mode"],
+                "class_id": ["lineage", "debt_id", "lineage_mode"],
+                "debt_id": ["lineage", "class_id", "lineage_mode"],
+                "lineage_mode": ["lineage", "class_id", "debt_id"],
             },
         },
     ),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -295,7 +295,7 @@ class TestRebut:
         ))
         eng = FakeEngine(json.dumps({
             "disposition":"CONCEDE", "reason":"The finding used the wrong path.",
-            "evidence":["repository/app.py:1"],
+            "evidence":[{"anchor":"repository/app.py:1", "rationale":"current guard"}],
         }))
         result = handlers.rebut({
             "repo_path":str(repo), "session_ref":"sess-1",
@@ -370,7 +370,7 @@ class TestRebut:
         before = json.loads(json.dumps((tmp_path / "state" / "lineages" / "hold-rebut.json").read_text()))
         eng = FakeEngine(json.dumps({
             "disposition":"HOLD", "reason":"The counter-evidence misses the path.",
-            "evidence":["repository/app.py:1"],
+            "evidence":[{"anchor":"repository/app.py:1", "rationale":"current path"}],
         }))
         result = handlers.rebut({
             "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"counter",
@@ -384,6 +384,52 @@ class TestRebut:
         assert audit["disposition"] == "HOLD"
         assert audit["debt_settled"] is False
         assert audit["class_closed"] is False
+
+    @pytest.mark.parametrize(("mechanized", "evidence", "error"), [
+        (True, [{"anchor":"repository/app.py:1", "rationale":"current"}], "mechanized"),
+        (False, [{"anchor":"repository/missing.py:1", "rationale":"current"}], "unresolvable"),
+        (False, [{"anchor":"app.py:1", "rationale":"current"}], "requires repository/ prefix"),
+    ])
+    def test_bound_rebut_refuses_unsupported_or_unresolved_closure(
+        self, repo: Path, tmp_path: Path, monkeypatch, mechanized, evidence, error,
+    ) -> None:
+        monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
+        state = rc.normalize_state(None, stakes="s", snapshot="p")
+        state.update(phase="correction", last_round=2, debt=[{
+            "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
+            "summary":"finding", "evidence":["repository/app.py:1"],
+            "remedy":"repair", "source_ids":[], "class_ids":["class-a"],
+            "first_round":1, "last_round":2, "reason":"open",
+        }])
+        state["correction_control"] = {"version":1, "classes":{"class-a":{
+            "reset_round":None, "reopen_count":0, "last_session_ref":"sess-1",
+        }}}
+        tracked = cc.TrackedClass(
+            "class-a", "invariant", cc.MAJOR, 1, cc.OPEN,
+            pattern="unsafe" if mechanized else None,
+            pathspec="*.py" if mechanized else None,
+            procedure=None if mechanized else "inspect",
+        )
+        cc.save_lineage(cc.default_state_root(), cc.Lineage(
+            "refused-rebut", mode=cc.BRANCH_MODE if mechanized else cc.PLAN_MODE,
+            classes={"class-a":tracked}, review_state=state,
+        ))
+        eng = FakeEngine(json.dumps({
+            "disposition":"CONCEDE", "reason":"wrong", "evidence":evidence,
+        }))
+        with pytest.raises(ValueError, match=error):
+            handlers.rebut({
+                "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"counter",
+                "lineage":"refused-rebut", "class_id":"class-a", "debt_id":"D1",
+                "lineage_mode":"branch" if mechanized else "plan",
+            }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
+        if mechanized:
+            assert eng.calls == []
+        persisted = cc.load_lineage(
+            cc.default_state_root(), "refused-rebut", stamp="T",
+            mode=cc.BRANCH_MODE if mechanized else cc.PLAN_MODE,
+        )
+        assert persisted.review_state["debt"][0]["status"] == "open"
 
     def test_bound_rebut_ambiguous_save_is_audited_and_retains_latch(
         self, repo: Path, tmp_path: Path, monkeypatch,
@@ -418,7 +464,8 @@ class TestRebut:
                 "lineage":"ambiguous-rebut", "class_id":"class-a", "debt_id":"D1",
                 "lineage_mode":"plan",
             }, engine=FakeEngine(json.dumps({
-                "disposition":"CONCEDE", "reason":"wrong", "evidence":["app.py:1"],
+                "disposition":"CONCEDE", "reason":"wrong",
+                "evidence":[{"anchor":"repository/app.py:1", "rationale":"current path"}],
             })), log_dir=tmp_path / "logs", now=fixed_clock)
         pending = cc.lineage_dir(cc.default_state_root()) / "ambiguous-rebut.pending"
         assert pending.exists()

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -279,7 +279,7 @@ class TestRebut:
             "source_ids":[], "class_ids":["class-a"], "first_round":1,
             "last_round":7, "reason":"still present",
         }
-        state.update(phase="correction", last_round=7, debt=[debt])
+        state.update(phase="correction", last_round=7, debt=[debt], plan_line_count=1)
         tracked = cc.TrackedClass(
             "class-a", "invariant", cc.MAJOR, 1, cc.OPEN, procedure="inspect",
         )
@@ -295,7 +295,7 @@ class TestRebut:
         ))
         eng = FakeEngine(json.dumps({
             "disposition":"CONCEDE", "reason":"The finding used the wrong path.",
-            "evidence":[{"anchor":"repository/app.py:1", "rationale":"current guard"}],
+            "evidence":[{"anchor":"plan:1", "rationale":"current plan obligation"}],
         }))
         result = handlers.rebut({
             "repo_path":str(repo), "session_ref":"sess-1",
@@ -311,7 +311,7 @@ class TestRebut:
         assert reloaded.review_state["phase"] == "final"
         assert reloaded.review_state["last_round"] == 7
         assert reloaded.review_state["debt"][0]["status"] == "closed"
-        assert reloaded.review_state["debt"][0]["evidence"] == ["repository/app.py:1"]
+        assert reloaded.review_state["debt"][0]["evidence"] == ["plan:1"]
         assert "reason" not in reloaded.review_state["debt"][0]
         assert reloaded.classes["class-a"].status == cc.CLOSED
         assert reloaded.review_state["correction_control"]["classes"]["class-a"] == {
@@ -335,7 +335,7 @@ class TestRebut:
         successful = [row for row in audits if not row.get("error")][0]
         assert successful["disposition"] == "CONCEDE"
         assert successful["prior_target_debt"] == debt
-        assert successful["rebut_evidence"] == ["repository/app.py:1"]
+        assert successful["rebut_evidence"] == ["plan:1"]
         assert successful["debt_settled"] is True
         assert successful["class_closed"] is True
 
@@ -386,22 +386,25 @@ class TestRebut:
         assert audit["debt_settled"] is False
         assert audit["class_closed"] is False
 
-    @pytest.mark.parametrize(("mechanized", "evidence", "error"), [
-        (True, [{"anchor":"repository/app.py:1", "rationale":"current"}], "mechanized"),
-        (False, [{"anchor":"repository/missing.py:1", "rationale":"current"}], "unresolvable"),
-        (False, [{"anchor":"app.py:1", "rationale":"current"}], "requires repository/ prefix"),
+    @pytest.mark.parametrize(("mechanized", "prior_evidence", "evidence", "error"), [
+        (True, ["repository/app.py:1"], [{"anchor":"repository/app.py:1", "rationale":"current"}], "mechanized"),
+        (False, ["repository/app.py:1"], [{"anchor":"repository/missing.py:1", "rationale":"current"}], "unresolvable"),
+        (False, ["repository/app.py:1"], [{"anchor":"app.py:1", "rationale":"current"}], "requires repository/ prefix"),
+        (False, ["plan:2"], [{"anchor":"plan:2", "rationale":"current"}], "unresolvable plan anchor"),
     ])
     def test_bound_rebut_refuses_unsupported_or_unresolved_closure(
-        self, repo: Path, tmp_path: Path, monkeypatch, mechanized, evidence, error,
+        self, repo: Path, tmp_path: Path, monkeypatch, mechanized,
+        prior_evidence, evidence, error,
     ) -> None:
         monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
         state = rc.normalize_state(None, stakes="s", snapshot="p")
         state.update(phase="correction", last_round=2, debt=[{
             "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
-            "summary":"finding", "evidence":["repository/app.py:1"],
+            "summary":"finding", "evidence":prior_evidence,
             "remedy":"repair", "source_ids":[], "class_ids":["class-a"],
             "first_round":1, "last_round":2, "reason":"open",
         }])
+        state["plan_line_count"] = 1
         state["correction_control"] = {"version":1, "classes":{"class-a":{
             "reset_round":None, "reopen_count":0, "last_session_ref":"sess-1",
         }}}

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -25,11 +25,16 @@ class FakeEngine:
         )
         return Review(text=self._text, session_ref=self._session, raw="")
 
-    def resume(self, session_ref, prompt, cwd, model, effort, web_search, runner=None, timeout=None):
+    def resume(
+        self, session_ref, prompt, cwd, model, effort, web_search, runner=None,
+        timeout=None, response_schema=None,
+    ):
         self.calls.append(
-            {"kind": "resume", "session_ref": session_ref, "prompt": prompt, "cwd": cwd}
+            {"kind": "resume", "session_ref": session_ref, "prompt": prompt,
+             "cwd": cwd, "response_schema": response_schema}
         )
-        return Review(text="REBUTTAL VERDICT", session_ref=session_ref, raw="")
+        text = self._text if response_schema is not None else "REBUTTAL VERDICT"
+        return Review(text=text, session_ref=session_ref, raw=text)
 
 
 def fixed_clock() -> str:
@@ -263,12 +268,18 @@ class TestRebut:
                 engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock,
             )
 
-    def test_bound_rebut_resets_only_matching_durable_class_session(
+    def test_bound_rebut_concede_settles_exact_debt_and_closes_class(
         self, repo: Path, tmp_path: Path, monkeypatch,
     ) -> None:
         monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
         state = rc.normalize_state(None, stakes="s", snapshot="p")
-        state.update(phase="correction", last_round=7, debt=[])
+        debt = {
+            "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
+            "summary":"wrong finding", "evidence":["plan:1"], "remedy":"withdraw",
+            "source_ids":[], "class_ids":["class-a"], "first_round":1,
+            "last_round":7, "reason":"still present",
+        }
+        state.update(phase="correction", last_round=7, debt=[debt])
         tracked = cc.TrackedClass(
             "class-a", "invariant", cc.MAJOR, 1, cc.OPEN, procedure="inspect",
         )
@@ -282,61 +293,109 @@ class TestRebut:
             "bound-rebut", mode=cc.PLAN_MODE,
             classes={tracked.class_id:tracked}, review_state=state,
         ))
-        eng = FakeEngine()
-        handlers.rebut({
+        eng = FakeEngine(json.dumps({
+            "disposition":"CONCEDE", "reason":"The finding used the wrong path.",
+            "evidence":["repository/app.py:1"],
+        }))
+        result = handlers.rebut({
             "repo_path":str(repo), "session_ref":"sess-1",
             "rebuttal":"The scope disposition is explicit.",
-            "lineage":"bound-rebut", "class_id":"class-a",
+            "lineage":"bound-rebut", "class_id":"class-a", "debt_id":"D1",
             "lineage_mode":"plan",
         }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
         reloaded = cc.load_lineage(
             cc.default_state_root(), "bound-rebut", stamp="T", mode=cc.PLAN_MODE,
         )
-        row = reloaded.review_state["correction_control"]["classes"]["class-a"]
-        assert row == {
-            "reset_round":7, "reopen_count":0, "last_session_ref":"sess-1",
+        assert result.startswith("CONCEDE: The finding used the wrong path.")
+        assert reloaded.review_state["phase"] == "final"
+        assert reloaded.review_state["last_round"] == 7
+        assert reloaded.review_state["debt"][0]["status"] == "closed"
+        assert reloaded.review_state["debt"][0]["evidence"] == ["repository/app.py:1"]
+        assert "reason" not in reloaded.review_state["debt"][0]
+        assert reloaded.classes["class-a"].status == cc.CLOSED
+        assert reloaded.review_state["correction_control"]["classes"]["class-a"] == {
+            "reset_round":None, "reopen_count":0, "last_session_ref":None,
         }
-        assert reloaded.classes["class-a"].status == cc.OPEN
 
-        with pytest.raises(ValueError, match="current durable session"):
+        with pytest.raises(ValueError, match="not currently blocking"):
             handlers.rebut({
                 "repo_path":str(repo), "session_ref":"stale",
                 "rebuttal":"again", "lineage":"bound-rebut",
-                "class_id":"class-a", "lineage_mode":"plan",
+                "class_id":"class-a", "debt_id":"D1", "lineage_mode":"plan",
             }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
         assert len(eng.calls) == 1
         audits = [json.loads(path.read_text()) for path in (tmp_path / "logs").glob("*.json")]
         rejected = [row for row in audits if row.get("error")]
         assert len(rejected) == 1
         assert rejected[0]["lineage_binding"] == {
-            "lineage":"bound-rebut", "class_id":"class-a", "lineage_mode":"plan",
+            "lineage":"bound-rebut", "class_id":"class-a", "debt_id":"D1",
+            "lineage_mode":"plan",
         }
-        assert rejected[0]["correction_control_reset"] is False
-        reloaded.classes["class-a"] = replace(
-            reloaded.classes["class-a"], status=cc.CLOSED,
-        )
-        cc.save_lineage(cc.default_state_root(), reloaded)
-        with pytest.raises(ValueError, match="not currently blocking"):
-            handlers.rebut({
-                "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"closed",
-                "lineage":"bound-rebut", "class_id":"class-a",
-                "lineage_mode":"plan",
-            }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
-        assert len(eng.calls) == 1
+        successful = [row for row in audits if not row.get("error")][0]
+        assert successful["disposition"] == "CONCEDE"
+        assert successful["prior_target_debt"] == debt
+        assert successful["rebut_evidence"] == ["repository/app.py:1"]
+        assert successful["debt_settled"] is True
+        assert successful["class_closed"] is True
 
     def test_bound_rebut_identity_is_all_or_none(self, repo: Path, tmp_path: Path) -> None:
-        with pytest.raises(ValueError, match="requires lineage, class_id, and lineage_mode"):
+        with pytest.raises(ValueError, match="requires lineage, class_id, debt_id, and lineage_mode"):
             handlers.rebut({
                 "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"x",
                 "lineage":"only-lineage",
             }, engine=FakeEngine(), log_dir=tmp_path, now=fixed_clock)
+
+    def test_bound_rebut_hold_is_audit_only(
+        self, repo: Path, tmp_path: Path, monkeypatch,
+    ) -> None:
+        monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
+        debt = {
+            "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
+            "summary":"finding", "evidence":["plan:1"], "remedy":"repair",
+            "source_ids":[], "class_ids":["class-a"], "first_round":1,
+            "last_round":7, "reason":"still present",
+        }
+        state = rc.normalize_state(None, stakes="s", snapshot="p")
+        state.update(phase="correction", last_round=7, debt=[debt])
+        state["correction_control"] = {"version":1, "classes":{"class-a":{
+            "reset_round":None, "reopen_count":3, "last_session_ref":"sess-1",
+        }}}
+        lineage = cc.Lineage(
+            "hold-rebut", mode=cc.PLAN_MODE,
+            classes={"class-a":cc.TrackedClass(
+                "class-a", "invariant", cc.MAJOR, 1, cc.OPEN, procedure="inspect",
+            )}, review_state=state,
+        )
+        cc.save_lineage(cc.default_state_root(), lineage)
+        before = json.loads(json.dumps((tmp_path / "state" / "lineages" / "hold-rebut.json").read_text()))
+        eng = FakeEngine(json.dumps({
+            "disposition":"HOLD", "reason":"The counter-evidence misses the path.",
+            "evidence":["repository/app.py:1"],
+        }))
+        result = handlers.rebut({
+            "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"counter",
+            "lineage":"hold-rebut", "class_id":"class-a", "debt_id":"D1",
+            "lineage_mode":"plan",
+        }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
+        after = json.loads(json.dumps((tmp_path / "state" / "lineages" / "hold-rebut.json").read_text()))
+        assert result.startswith("HOLD: The counter-evidence misses the path.")
+        assert after == before
+        audit = json.loads(next((tmp_path / "logs").glob("*.json")).read_text())
+        assert audit["disposition"] == "HOLD"
+        assert audit["debt_settled"] is False
+        assert audit["class_closed"] is False
 
     def test_bound_rebut_ambiguous_save_is_audited_and_retains_latch(
         self, repo: Path, tmp_path: Path, monkeypatch,
     ) -> None:
         monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
         state = rc.normalize_state(None, stakes="s", snapshot="p")
-        state.update(phase="correction", last_round=7, debt=[])
+        state.update(phase="correction", last_round=7, debt=[{
+            "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
+            "summary":"wrong finding", "evidence":["plan:1"], "remedy":"withdraw",
+            "source_ids":[], "class_ids":["class-a"], "first_round":1,
+            "last_round":7, "reason":"still present",
+        }])
         tracked = cc.TrackedClass(
             "class-a", "invariant", cc.MAJOR, 1, cc.OPEN, procedure="inspect",
         )
@@ -356,12 +415,14 @@ class TestRebut:
         with pytest.raises(cc.StateUnavailable, match="ambiguous rebut write"):
             handlers.rebut({
                 "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"scope",
-                "lineage":"ambiguous-rebut", "class_id":"class-a",
+                "lineage":"ambiguous-rebut", "class_id":"class-a", "debt_id":"D1",
                 "lineage_mode":"plan",
-            }, engine=FakeEngine(), log_dir=tmp_path / "logs", now=fixed_clock)
+            }, engine=FakeEngine(json.dumps({
+                "disposition":"CONCEDE", "reason":"wrong", "evidence":["app.py:1"],
+            })), log_dir=tmp_path / "logs", now=fixed_clock)
         pending = cc.lineage_dir(cc.default_state_root()) / "ambiguous-rebut.pending"
         assert pending.exists()
         audit = json.loads(next((tmp_path / "logs").glob("*.json")).read_text())
         assert audit["error"] is True
-        assert audit["correction_control_reset"] is False
+        assert audit["debt_settled"] is False
         cc.clear_latch(cc.default_state_root(), "ambiguous-rebut")

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -386,6 +386,50 @@ class TestRebut:
         assert audit["debt_settled"] is False
         assert audit["class_closed"] is False
 
+    def test_bound_branch_rebut_uses_authoritative_terminal_lf_line_count(
+        self, repo: Path, tmp_path: Path, monkeypatch,
+    ) -> None:
+        monkeypatch.setenv(cc.STATE_ROOT_ENV, str(tmp_path / "state"))
+        state = rc.normalize_state(None, stakes="s", snapshot="p")
+        state.update(phase="correction", last_round=2, debt=[{
+            "id":"D1", "finding_id":"F1", "status":"open", "severity":cc.MAJOR,
+            "summary":"wrong contract finding", "evidence":["plan:2"],
+            "remedy":"withdraw", "source_ids":[], "class_ids":["class-a"],
+            "first_round":1, "last_round":2, "reason":"open",
+        }])
+        state["correction_control"] = {"version":1, "classes":{"class-a":{
+            "reset_round":None, "reopen_count":0, "last_session_ref":"sess-1",
+        }}}
+        tracked = cc.TrackedClass(
+            "class-a", "invariant", cc.MAJOR, 1, cc.OPEN, procedure="inspect",
+        )
+        cc.save_lineage(cc.default_state_root(), cc.Lineage(
+            "branch-lf-rebut", mode=cc.BRANCH_MODE,
+            classes={"class-a":tracked}, review_state=state,
+            branch_contract={
+                "version":handlers.BRANCH_CONTRACT_VERSION, "present":True,
+                "digest":handlers._branch_contract_view("one\n").digest,
+                "text":"one\n",
+            },
+        ))
+        eng = FakeEngine(json.dumps({
+            "disposition":"CONCEDE", "reason":"The second contract line is valid.",
+            "evidence":[{"anchor":"plan:2", "rationale":"terminal LF line"}],
+        }))
+
+        result = handlers.rebut({
+            "repo_path":str(repo), "session_ref":"sess-1", "rebuttal":"line two",
+            "lineage":"branch-lf-rebut", "class_id":"class-a", "debt_id":"D1",
+            "lineage_mode":"branch",
+        }, engine=eng, log_dir=tmp_path / "logs", now=fixed_clock)
+
+        assert result.startswith("CONCEDE:")
+        durable = cc.load_lineage(
+            cc.default_state_root(), "branch-lf-rebut", stamp="T", mode=cc.BRANCH_MODE,
+        )
+        assert durable.review_state["debt"][0]["evidence"] == ["plan:2"]
+        assert durable.classes["class-a"].status == cc.CLOSED
+
     @pytest.mark.parametrize(("mechanized", "prior_evidence", "evidence", "error"), [
         (True, ["repository/app.py:1"], [{"anchor":"repository/app.py:1", "rationale":"current"}], "mechanized"),
         (False, ["repository/app.py:1"], [{"anchor":"repository/missing.py:1", "rationale":"current"}], "unresolvable"),

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -307,6 +307,7 @@ class TestRebut:
             cc.default_state_root(), "bound-rebut", stamp="T", mode=cc.PLAN_MODE,
         )
         assert result.startswith("CONCEDE: The finding used the wrong path.")
+        assert "literal `repository/` prefix" in eng.calls[0]["prompt"]
         assert reloaded.review_state["phase"] == "final"
         assert reloaded.review_state["last_round"] == 7
         assert reloaded.review_state["debt"][0]["status"] == "closed"

--- a/tests/test_plan_claims.py
+++ b/tests/test_plan_claims.py
@@ -1,8 +1,10 @@
 from __future__ import annotations
 
 import hashlib
+import importlib.util
 import json
 import os
+import shutil
 import subprocess
 import sys
 from collections.abc import Callable
@@ -46,6 +48,35 @@ def test_plan_review_reliability_acceptance_is_source_and_route_bound(
         capture_output=True,
         text=True,
     )
+
+
+def test_plan_review_reliability_rejects_changed_validation_source(
+    tmp_path: Path,
+) -> None:
+    root = Path(__file__).resolve().parents[1]
+    spec = importlib.util.spec_from_file_location(
+        "plan_review_reliability_acceptance",
+        root / "scripts/run_plan_review_reliability_acceptance.py",
+    )
+    assert spec and spec.loader
+    acceptance = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(acceptance)
+    clone = tmp_path / "validation-replay"
+    subprocess.run(
+        ["git", "clone", "-q", "--no-hardlinks", str(root), str(clone)],
+        check=True,
+    )
+    for relative in acceptance.SOURCES:
+        destination = clone / relative
+        destination.parent.mkdir(parents=True, exist_ok=True)
+        shutil.copy2(root / relative, destination)
+    target = clone / "src/paranoia_local/handlers.py"
+    target.write_text(target.read_text(encoding="utf-8") + "\n", encoding="utf-8")
+    artifact = json.loads(
+        (root / "docs/plan_review_reliability_acceptance_2026-08-30.json").read_text()
+    )
+    with pytest.raises(ValueError, match="later-source allowance mismatch"):
+        acceptance.validate_artifact(artifact, clone)
 
 
 def test_large_page_capture_acceptance_record() -> None:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -2736,10 +2736,17 @@ def test_primary_staged_failure_surface_preserves_failure_kind(kind, headline, b
 def test_trailer_surfaces_persistent_class_and_rebut_session() -> None:
     state = {
         "phase": "correction", "last_round": 57,
-        "debt": [{
-            "id": "debt-a", "status": "open", "severity": cc.MAJOR,
-            "first_round": 34, "class_ids": ["6cf3f68b"],
-        }],
+        "debt": [
+            {
+                "id": "closed-predecessor", "status": "closed",
+                "severity": cc.MAJOR, "first_round": 3,
+                "class_ids": ["6cf3f68b"],
+            },
+            {
+                "id": "debt-a", "status": "open", "severity": cc.MAJOR,
+                "first_round": 34, "class_ids": ["6cf3f68b"],
+            },
+        ],
     }
 
     rendered = rc.trailer(
@@ -2752,6 +2759,7 @@ def test_trailer_surfaces_persistent_class_and_rebut_session() -> None:
         "(first raised 1, now 57), current debt open since 34"
     ) in rendered
     assert "rebut with session_ref=session-57 debt_id=debt-a" in rendered
+    assert "debt_id=closed-predecessor" not in rendered
 
 
 def test_trailer_omits_persistence_until_third_tracked_round() -> None:

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -436,9 +436,9 @@ def test_three_blocking_classes_keep_plan_correction_targeted(tmp_path, monkeypa
 
 
 @pytest.mark.parametrize(("mode", "phase", "prompt_sha256", "schema_sha256", "next_phase"), [
-    (
-        cc.PLAN_MODE, "final",
-        "7051432dcbc9a3f5f2677056c48037b559a65e2f1f424327a9831ebebb496a3d",
+        (
+            cc.PLAN_MODE, "final",
+            "e0f6e28736a5bbe7aa1cbb43edfd8a00e4415ce81a0e84e70fe899a28e83f9bf",
         "1d4a43d7b46b4447884168b935ec249d8e1579623dff1da1a6df5528f1c5a54a",
         "clear",
     ),
@@ -4218,6 +4218,73 @@ def test_public_correction_retries_non_debt_assessment_evidence_omission(
         if row["status"] == "open" and row["class_ids"] == ["fresh-class"]
     )
     assert fresh["evidence"] == anchors
+
+
+def test_plan_active_class_view_is_phase_correct_and_branch_view_is_unchanged():
+    tracked = cc.TrackedClass(
+        "class-a", "runtime output is correct", cc.MAJOR, 1, cc.CLOSED,
+        procedure="execute the future verifier",
+    )
+    lineage = cc.Lineage(
+        "phase-view", mode=cc.PLAN_MODE, classes={"class-a":tracked},
+    )
+    plan_rows = handlers._active_class_rows(lineage, cc.PLAN_MODE)
+    assert plan_rows == handlers._active_class_rows(lineage, cc.PLAN_MODE)
+    assert "PLAN-PHASE INTERPRETATION" in plan_rows[0]["invariant"]
+    assert "runtime output is correct" in plan_rows[0]["invariant"]
+    procedure = plan_rows[0]["procedure"]
+    for required in (
+        "exact implementation scope", "executable acceptance evidence",
+        "fail-closed behavior", "named durable residual", "owner",
+        "acceptance boundary", "MINOR", "OUT-OF-SCOPE",
+        "expected pre-implementation code",
+    ):
+        assert required in procedure
+    branch_rows = handlers._active_class_rows(lineage, cc.BRANCH_MODE)
+    assert branch_rows[0]["invariant"] == "runtime output is correct"
+    assert branch_rows[0]["procedure"] == "execute the future verifier"
+
+
+def test_rebut_concession_settlement_is_targeted_and_refuses_ambiguous_state():
+    target = {
+        "id":"D1", "finding_id":"F1", "status":"open", "severity":"MAJOR",
+        "summary":"target", "evidence":["plan:1"], "remedy":"withdraw",
+        "source_ids":[], "class_ids":["class-a"], "first_round":1,
+        "last_round":4, "reason":"open",
+    }
+    sibling = {
+        "id":"D2", "finding_id":"F2", "status":"open", "severity":"MAJOR",
+        "summary":"sibling", "evidence":["plan:2"], "remedy":"repair",
+        "source_ids":[], "class_ids":["class-b"], "first_round":2,
+        "last_round":4, "reason":"open",
+    }
+    state = rc.normalize_state(None, stakes="s", snapshot="p")
+    state.update(phase="correction", last_round=4, debt=[target, sibling])
+    before = json.loads(json.dumps(state))
+    settled = rc.settle_rebut_concession(
+        state, debt_id="D1", class_id="class-a", evidence=["plan:3"],
+        blocking_class_ids=["class-a", "class-b"],
+    )
+    assert state == before
+    assert settled["phase"] == "correction"
+    assert settled["debt"][0]["status"] == "closed"
+    assert settled["debt"][0]["evidence"] == ["plan:3"]
+    assert "reason" not in settled["debt"][0]
+    assert settled["debt"][1] == sibling
+
+    for key in rc.REBUT_FAILURE_FIELDS:
+        invalid = json.loads(json.dumps(state))
+        invalid[key] = ["blocked"] if key.endswith("classes") else {"blocked":True}
+        with pytest.raises(rc.CensusError, match="unresolved structural state"):
+            rc.settle_rebut_concession(
+                invalid, debt_id="D1", class_id="class-a", evidence=["plan:3"],
+                blocking_class_ids=["class-a", "class-b"],
+            )
+    with pytest.raises(rc.CensusError, match="unbound blocking classes"):
+        rc.settle_rebut_concession(
+            state, debt_id="D1", class_id="class-a", evidence=["plan:3"],
+            blocking_class_ids=["class-a", "class-b", "class-c"],
+        )
 
 
 def test_plan_handler_replaces_artifact_demand_with_phase_bound_class(

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -201,6 +201,9 @@ def test_closed_persisted_state_validator_accepts_every_supported_envelope():
     current_unbound = deepcopy(base)
     current_unbound["unbound_class_ids"] = ["class-a"]
     accepted.append(current_unbound)
+    plan_bounded = deepcopy(base)
+    plan_bounded["plan_line_count"] = 7
+    accepted.append(plan_bounded)
 
     for state in accepted:
         validated = rc.validate_persisted_state(state, [tracked])
@@ -221,6 +224,8 @@ def test_closed_persisted_state_validator_accepts_every_supported_envelope():
     (("snapshot_digest",), {}, "snapshot_digest"),
     (("debt",), {}, "review_state debt"),
     (("last_round",), False, "last_round"),
+    (("plan_line_count",), False, "plan line count"),
+    (("plan_line_count",), 0, "plan line count"),
     (("debt", 0, "id"), [], "debt id"),
     (("debt", 0, "finding_id"), None, "finding_id"),
     (("debt", 0, "status"), [], "debt status"),
@@ -4218,6 +4223,10 @@ def test_public_correction_retries_non_debt_assessment_evidence_omission(
         if row["status"] == "open" and row["class_ids"] == ["fresh-class"]
     )
     assert fresh["evidence"] == anchors
+    if mode == cc.PLAN_MODE:
+        assert durable.review_state["plan_line_count"] == 3
+    else:
+        assert "plan_line_count" not in durable.review_state
 
 
 def test_plan_active_class_view_is_phase_correct_and_branch_view_is_unchanged():

--- a/tests/test_review_census.py
+++ b/tests/test_review_census.py
@@ -2732,7 +2732,7 @@ def test_trailer_surfaces_persistent_class_and_rebut_session() -> None:
     state = {
         "phase": "correction", "last_round": 57,
         "debt": [{
-            "id": "debt-a", "status": "open", "severity": cc.MINOR,
+            "id": "debt-a", "status": "open", "severity": cc.MAJOR,
             "first_round": 34, "class_ids": ["6cf3f68b"],
         }],
     }
@@ -2746,7 +2746,7 @@ def test_trailer_surfaces_persistent_class_and_rebut_session() -> None:
         "PERSISTENCE: 6cf3f68b currently open; round-label span 57 "
         "(first raised 1, now 57), current debt open since 34"
     ) in rendered
-    assert "rebut with session_ref=session-57" in rendered
+    assert "rebut with session_ref=session-57 debt_id=debt-a" in rendered
 
 
 def test_trailer_omits_persistence_until_third_tracked_round() -> None:

--- a/tests/test_server.py
+++ b/tests/test_server.py
@@ -82,8 +82,10 @@ class TestToolListing:
         req = tool.inputSchema["required"]
         assert "session_ref" in req and "rebuttal" in req
         deps = tool.inputSchema["dependentRequired"]
-        assert deps["lineage"] == ["class_id", "lineage_mode"]
-        assert deps["class_id"] == ["lineage", "lineage_mode"]
+        assert deps["lineage"] == ["class_id", "debt_id", "lineage_mode"]
+        assert deps["class_id"] == ["lineage", "debt_id", "lineage_mode"]
+        assert deps["debt_id"] == ["lineage", "class_id", "lineage_mode"]
+        assert deps["lineage_mode"] == ["lineage", "class_id", "debt_id"]
 
 
 class TestDispatch:


### PR DESCRIPTION
## Summary
- make debt-bound rebut concessions durably close the exact eligible debt and class while keeping HOLD audit-only
- phase plan-review classes so cold review does not demand implementation artifacts that belong to branch review
- bind rebut citations, branch-contract line semantics, persistence checks, and current debt selection to authoritative state
- strengthen deterministic acceptance replay and synchronize public documentation

## Verification
- 1657 tests passed
- real Codex debt-bound rebut acceptance exercised CONCEDE settlement and repository citations
- CODE convergence reached zero open classes and zero blocking debt after targeted correction
- operator waived an additional cold final because the last correction was documentation-only